### PR TITLE
Expose Prometheus /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ the only modification to the original B3 schema.
 | Document | What's inside |
 |----------|---------------|
 | [docs/OPERATIONS.md](docs/OPERATIONS.md) | Running locally and in Docker, web viewer screenshots, health endpoints, metrics, backpressure summary, graceful shutdown, TLS, profiling |
+| [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) | Prometheus `/metrics` endpoint, full metric catalogue (WebSocket / feed / transport / book / per-symbol), labels and cardinality rules, hot-path impact |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | CLI options, full `UMDF_*` environment variable reference, multicast JSON config, host kernel tuning, replay-speed range |
 | [docs/WEBSOCKET_API.md](docs/WEBSOCKET_API.md) | **Consumer-facing landing for the WebSocket distribution layer**: stability label, breaking-change policy, "reference price" quickstart for downstream apps (e.g. risk modules) |
 | [docs/WEBSOCKET-PROTOCOL.md](docs/WEBSOCKET-PROTOCOL.md) | Wire framing, message catalog, hex examples, subscription / reconnect / slow-consumer flows, candle chunking |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,155 @@
+# Observability — `/metrics` (Prometheus) reference
+
+`B3MarketDataPlatform` exposes a Prometheus scrape endpoint on the same
+HTTP port as the health probes (`/health`, `/ready`, `/live`, default
+port `8080`):
+
+```
+GET /metrics
+```
+
+Content type: `text/plain; version=0.0.4` (OpenMetrics exposition).
+
+This is the canonical observability surface for the family stack
+(otel-collector → prometheus → grafana). There is no OTLP push exporter
+yet — pull is what the family converged on (B3TradingPlatform issue #9 /
+PR 7-2c). An OTLP exporter can be added behind a config flag without
+breaking the pull endpoint.
+
+## Pipeline
+
+The host registers an OpenTelemetry `MeterProvider` with the Prometheus
+ASP.NET Core exporter and exposes:
+
+- The **`B3.Umdf`** meter (defined by
+  [`MetricsRegistry`](../src/B3.Umdf.Server/MetricsRegistry.cs)) — WebSocket
+  / broadcast-pool counters and gauges that live inside the `B3.Umdf.Server`
+  library itself.
+- The **`B3.Umdf.Consumer`** meter (defined by
+  [`MetricsBinder`](../src/B3.Umdf.ConsoleApp/MetricsBinder.cs)) — feed,
+  book, transport, and per-symbol observability registered by the
+  ConsoleApp at startup.
+
+Both names are wired in `Program.cs` via
+`WebSocketHost.AdditionalMeterNames`. Anything created on those two
+`Meter`s is automatically scraped — no per-metric registration on the
+host side.
+
+> Names are emitted in Prometheus form: dots become underscores
+> (`umdf.ws.messages.sent` → `umdf_ws_messages_sent`).
+
+## Metric catalogue
+
+The mapping below is non-exhaustive; the source files above are the
+ground truth. Every metric here is currently emitted on `/metrics`.
+
+### WebSocket / broadcast pool (`B3.Umdf` meter)
+
+| Prometheus name | Type | Labels | Semantics |
+|---|---|---|---|
+| `umdf_ws_connections_active` | UpDownCounter | — | Live WebSocket subscribers (incremented on connect, decremented on disconnect). |
+| `umdf_ws_subscribed_symbols` | Gauge | — | Distinct securities with at least one active subscriber (`SubscriptionManager.ActiveSymbolCount`). |
+| `umdf_ws_subscriptions_total` | Counter | — | Cumulative `Subscribe` accepts (negative deltas applied on bulk disconnect; treat as activity not a level). |
+| `umdf_ws_messages_sent_total` | Counter | — | Total frames pushed to clients across all sessions. |
+| `umdf_ws_messages_conflated_total` | Counter | — | Frames collapsed by per-symbol conflation before send. |
+| `umdf_ws_slow_disconnects_total` | Counter | — | Sessions terminated for back-pressure violation (1008 close, slow-consumer policy). |
+| `umdf_packets_received_total` | Counter | — | Raw UMDF packets observed by the server-side counters. |
+| `umdf_gaps_detected_total` | Counter | — | Sequence gaps observed (server-local view). |
+| `umdf_parse_errors_total` | Counter | — | SBE decode failures. |
+| `umdf_orders_processed_total` | Counter | — | OrderAdded/Updated applied. |
+| `umdf_trades_processed_total` | Counter | — | Trades applied. |
+| `umdf_deletes_processed_total` | Counter | — | OrderDeleted applied. |
+| `umdf_broadcast_pool_rent_hits_total` | Counter | — | `BroadcastBufferPool` rents that hit the pool. |
+| `umdf_broadcast_pool_rent_misses_total` | Counter | — | Rents that fell through to a fresh allocation. |
+| `umdf_broadcast_pool_return_drops_total` | Counter | — | Returned buffers dropped (pool full / wrong size). |
+| `umdf_broadcast_pool_oversize_rents_total` | Counter | — | Rents above the pool's max bucket size. |
+
+### Feed (`B3.Umdf.Consumer` meter)
+
+| Prometheus name | Type | Labels | Semantics |
+|---|---|---|---|
+| `b3_umdf_feed_state` | Gauge | `group` | `0`=`WaitInstrumentDefinition`, `1`=`Streaming`. |
+| `b3_umdf_feed_packets_total` | Counter | `group` | Packets fed into the channel handler. |
+| `b3_umdf_feed_duplicates_total` | Counter | `group` | Duplicate packets skipped. |
+| `b3_umdf_feed_gaps_total` | Counter | `group` | Channel-level sequence gaps detected. |
+| `b3_umdf_feed_instrument_definitions_total` | Counter | `group` | Instrument definitions received. |
+| `b3_umdf_feed_reorder_hits_total` | Counter | `group` | Out-of-order packets later drained from the A/B reorder buffer (avoided spurious recovery). |
+| `b3_umdf_feed_reorder_buffer_depth` | Gauge | `group` | Current depth of the A/B reorder buffer. |
+| `b3_umdf_feed_channel_gaps_absorbed_total` | Counter | `group` | Channel-level gaps absorbed without exiting `Streaming`. |
+| `b3_umdf_feed_last_packet_age` | Gauge (ms) | `group` | Milliseconds since the last packet was dispatched (`-1` if none yet). Operational liveness signal. |
+| `b3_umdf_feed_ring_depth` | Gauge | `group` | Pending packets in the per-group MPSC dispatch ring. |
+| `b3_umdf_feed_ring_dropped_total` | Counter | `group` | Packets dropped on per-group ring overflow. |
+| `b3_umdf_feed_ring_dropped_by_channel_total` | Counter | `group`, `channel` | Per-channel breakdown of the drops above. |
+
+### Transport (multicast)
+
+| Prometheus name | Type | Labels | Semantics |
+|---|---|---|---|
+| `b3_umdf_transport_recvmmsg_syscalls_total` | Counter | `group`, `channel` | `recvmmsg(2)` syscalls returning ≥ 1 datagram. |
+| `b3_umdf_transport_recvmmsg_datagrams_total` | Counter | `group`, `channel` | Datagrams received in batched receive. Average batch = datagrams / syscalls. |
+| `b3_umdf_transport_membership_joins_total` | Counter | `group`, `channel` | IGMP joins (initial + recovery rejoins). |
+| `b3_umdf_transport_membership_leaves_total` | Counter | `group`, `channel` | IGMP leaves (issued when group enters RealTime). |
+| `b3_umdf_transport_membership_joined` | Gauge | `group`, `channel` | `1` if currently joined, else `0`. |
+
+### Book
+
+| Prometheus name | Type | Labels | Semantics |
+|---|---|---|---|
+| `b3_umdf_book_orders_added_total` | Counter | `group` | Orders added to books. |
+| `b3_umdf_book_orders_updated_total` | Counter | `group` | Order updates applied. |
+| `b3_umdf_book_orders_deleted_total` | Counter | `group` | Orders deleted from books. |
+| `b3_umdf_book_trades_total` | Counter | `group` | Trades applied to books. |
+| `b3_umdf_book_parse_errors_total` | Counter | `group` | SBE parse errors during book maintenance. |
+| `b3_umdf_book_crossings_total` | Counter | `group` | Cross detections raised. |
+| `b3_umdf_book_currently_crossed` | Gauge | `group` | Symbols currently crossed (continuous trading). |
+| `b3_umdf_book_currently_crossed_auction` | Gauge | `group` | Symbols currently crossed in auction (expected). |
+| `b3_umdf_book_currently_locked` | Gauge | `group` | Symbols currently locked (bid==ask). |
+| `b3_umdf_book_delete_not_found_total` | Counter | `group` | Deletes for unknown orders (after gap healing). |
+| `b3_umdf_book_instruments_replaced_total` | Counter | `group` | InstrumentDefinition replacements applied. |
+| `b3_umdf_book_null_price_skips_total` | Counter | `group` | Null-price events skipped. |
+| `b3_umdf_book_market_order_*` | Counter | `group` | Market-order lifecycle counters (adds/updates/deletes/transitions). |
+
+### Per-symbol bootstrap / recovery
+
+| Prometheus name | Type | Labels | Semantics |
+|---|---|---|---|
+| `b3_umdf_persymbol_stale_symbols` | Gauge | `group` | Symbols currently in `Stale` (waiting for a heal snapshot). |
+| `b3_umdf_persymbol_tracked_symbols` | Gauge | `group` | Symbols tracked by the per-symbol registry. |
+| `b3_umdf_persymbol_lagging_snapshots_total` | Counter | `group` | Snapshot frames behind the highest-seen incremental. |
+| `b3_umdf_persymbol_snapshots_healed_total` | Counter | `group` | Snapshots that healed a `Stale` symbol. |
+| `b3_umdf_persymbol_snapshots_authoritative_reset_total` | Counter | `group` | Forced healing despite missing intermediate sequences. |
+| `b3_umdf_persymbol_authoritative_reset_unsafe_delta_*` | Gauge / Counter | `group` | Severity gauges / sums of forced-heal `(MinHeal − snap)` deltas. Use **max/sum** for alerting; **last** hides spikes between scrapes. |
+| `b3_umdf_persymbol_authoritative_reset_discarded_tail_delta_*` | Gauge / Counter | `group` | Same shape, for the discarded-tail delta `(highWater − snap)`. |
+| `b3_umdf_symbol_gap_*` | Counter / Gauge | `group`, `kind` | Per-symbol gap detection (count, total size, currently-affected). |
+
+## Hot-path impact
+
+Every counter incremented inside the receive / dispatch / broadcast loops
+is a `System.Diagnostics.Metrics.Counter<T>.Add(...)` — an interlocked
+update. Gauges are uniformly `ObservableGauge`, evaluated only on scrape.
+There is no string formatting, no allocation, and no `IsEnabled` check
+on the hot path; the OpenTelemetry SDK collects from the Meter listener
+side, separate from the producer.
+
+## Cardinality
+
+- `group` is bounded by the configured channel-group set (typically
+  single digits).
+- `channel` is the `ChannelType` enum (Inc A, Inc B, Snap A, Snap B,
+  InstrDef) — fixed.
+- **No `symbol` label is emitted on counters or gauges.** Per-symbol
+  detail belongs in the recovery audit endpoint
+  (`GET /api/recovery/recent`) and in logs, not in Prometheus.
+
+## Adding a meter
+
+If a new module wants to publish via `/metrics`, either:
+
+1. Reuse the `B3.Umdf` meter
+   (`MetricsRegistry.Meter.CreateCounter<long>(...)`) — picked up
+   automatically by the host.
+2. Or add the meter name to `wsHost.AdditionalMeterNames` before
+   `StartAsync` (see `Program.cs` for the pattern).
+
+Mutating `AdditionalMeterNames` after `StartAsync` has no effect — the
+`MeterProvider` is built once at host start.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -194,9 +194,25 @@ curl http://localhost:8080/health | jq
 ## Metrics
 
 OTEL-compatible metrics via `System.Diagnostics.Metrics` (zero NuGet
-dependencies, fully AOT-safe).
+dependencies on the producer side, fully AOT-safe).
 
-**Meter name:** `B3.Umdf.Consumer`
+**Meter names:** `B3.Umdf.Consumer` (ConsoleApp / `MetricsBinder`) and
+`B3.Umdf` (Server / `MetricsRegistry`).
+
+### Prometheus `/metrics`
+
+The host exposes a Prometheus scrape endpoint on the same port as
+`/health` (default `8080`):
+
+```bash
+curl -s http://localhost:8080/metrics | head
+```
+
+Both meters above are wired into the scrape automatically. See
+[OBSERVABILITY.md](OBSERVABILITY.md) for the full metric catalogue,
+labels, and cardinality rules.
+
+### Local development with `dotnet-counters`
 
 ```bash
 # one time
@@ -276,8 +292,9 @@ automatically.
 | `b3.umdf.server.events_received` | Counter | `group` | Events received into conflation |
 | `b3.umdf.server.events_flushed` | Counter | `group` | Events flushed from conflation to clients |
 
-Adding a Prometheus `/metrics` endpoint or an OTLP exporter requires only
-the corresponding NuGet package — no instrumentation changes.
+Adding an OTLP push exporter requires only the corresponding NuGet
+package — no instrumentation changes; the pull `/metrics` endpoint
+remains available in parallel.
 
 ## Backpressure & slow clients
 

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -549,6 +549,15 @@ if (subscriptionManager is not null)
     wsHost.RecoveryEventProvider = max => recoveryEventLog.Snapshot(max);
     wsHost.RecoveryEventTotalProvider = () => recoveryEventLog.TotalRecorded;
 
+    // Expose the ConsoleApp's MetricsBinder meter through the host's
+    // /metrics endpoint alongside the Server's own "B3.Umdf" meter.
+    wsHost.AdditionalMeterNames = new[] { MetricsBinder.Meter.Name };
+
+    // Wire the active-symbol gauge to SubscriptionManager. Captured once;
+    // SubscriptionManager outlives the host.
+    var sm = subscriptionManager;
+    MetricsRegistry.ActiveSubscribedSymbolsProvider = () => sm.ActiveSymbolCount;
+
     await wsHost.StartAsync(wsPort!.Value, cts.Token);
 }
 

--- a/src/B3.Umdf.Server/B3.Umdf.Server.csproj
+++ b/src/B3.Umdf.Server/B3.Umdf.Server.csproj
@@ -20,4 +20,9 @@
     <InternalsVisibleTo Include="B3.Umdf.Server.Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/B3.Umdf.Server/MetricsRegistry.cs
+++ b/src/B3.Umdf.Server/MetricsRegistry.cs
@@ -35,4 +35,24 @@ public sealed class MetricsRegistry
     public static readonly Counter<long> BroadcastBufferRentMisses = Meter.CreateCounter<long>("umdf.broadcast_pool.rent_misses");
     public static readonly Counter<long> BroadcastBufferReturnDrops = Meter.CreateCounter<long>("umdf.broadcast_pool.return_drops");
     public static readonly Counter<long> BroadcastBufferOversizeRents = Meter.CreateCounter<long>("umdf.broadcast_pool.oversize_rents");
+
+    // ── Observable gauges (read at scrape time only — zero hot-path cost) ──
+    //
+    // These are lazily wired from a callback so the Server library has no
+    // direct dependency on SubscriptionManager construction order. Set the
+    // provider before starting the host; null (default) disables emission.
+
+    /// <summary>
+    /// Provider for <c>umdf.ws.subscribed_symbols</c> — distinct securities with
+    /// at least one active subscriber. Set once at startup.
+    /// </summary>
+    public static Func<int>? ActiveSubscribedSymbolsProvider { get; set; }
+
+    static MetricsRegistry()
+    {
+        Meter.CreateObservableGauge(
+            "umdf.ws.subscribed_symbols",
+            static () => ActiveSubscribedSymbolsProvider?.Invoke() ?? 0,
+            description: "Distinct securities with at least one active WebSocket subscriber.");
+    }
 }

--- a/src/B3.Umdf.Server/SubscriptionManager.cs
+++ b/src/B3.Umdf.Server/SubscriptionManager.cs
@@ -236,6 +236,12 @@ public sealed class SubscriptionManager : IDisposable
     /// <summary>Lock-free check whether any client is subscribed to a security.</summary>
     internal bool IsSubscribed(ulong securityId) => _subscriptions.ContainsKey(securityId);
 
+    /// <summary>
+    /// Count of distinct securities with at least one active subscriber.
+    /// Lock-free; intended for observability gauges (low-cardinality, scrape-time only).
+    /// </summary>
+    public int ActiveSymbolCount => _subscriptions.Count;
+
     /// <summary>Broadcast pre-serialized bytes to all Book subscribers for a security.</summary>
     internal void BroadcastToSubscribers(ulong securityId, ReadOnlyMemory<byte> payload)
     {

--- a/src/B3.Umdf.Server/WebSocketHost.cs
+++ b/src/B3.Umdf.Server/WebSocketHost.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Metrics;
 
 namespace B3.Umdf.Server;
 
@@ -44,6 +45,17 @@ public sealed class WebSocketHost : IAsyncDisposable
 
     /// <summary>Optional accessor for total events recorded since process start (for the audit-trail endpoint).</summary>
     public Func<long>? RecoveryEventTotalProvider { get; set; }
+
+    /// <summary>
+    /// Additional <c>System.Diagnostics.Metrics.Meter</c> names to expose via
+    /// the Prometheus <c>/metrics</c> endpoint. The host always exposes the
+    /// <c>"B3.Umdf"</c> meter (defined by <see cref="MetricsRegistry"/>);
+    /// callers may add others (e.g. <c>"B3.Umdf.Consumer"</c> registered by
+    /// the ConsoleApp's <c>MetricsBinder</c>) to surface them on the same
+    /// scrape endpoint. Set before <see cref="StartAsync"/>; mutations after
+    /// the host has started are ignored.
+    /// </summary>
+    public IReadOnlyList<string> AdditionalMeterNames { get; set; } = Array.Empty<string>();
 
     public WebSocketHost(
         SubscriptionManager subscriptionManager,
@@ -84,6 +96,19 @@ public sealed class WebSocketHost : IAsyncDisposable
         builder.Services.ConfigureHttpJsonOptions(options =>
             options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default));
 
+        builder.Services
+            .AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddMeter(MetricsRegistry.Meter.Name);
+                foreach (var name in AdditionalMeterNames)
+                {
+                    if (!string.IsNullOrWhiteSpace(name))
+                        metrics.AddMeter(name);
+                }
+                metrics.AddPrometheusExporter();
+            });
+
         _app = builder.Build();
         _app.UseWebSockets(new WebSocketOptions
         {
@@ -92,6 +117,7 @@ public sealed class WebSocketHost : IAsyncDisposable
 
         UseCorsHeaders(_app);
         MapHealthEndpoints(_app);
+        MapMetricsEndpoint(_app);
         MapSymbolEndpoints(_app);
         MapInstrumentEndpoint(_app);
         MapRecoveryEndpoint(_app);
@@ -147,6 +173,14 @@ public sealed class WebSocketHost : IAsyncDisposable
             _subscriptionManager.IsReady ? Results.Ok("ready") : Results.StatusCode(503));
 
         app.MapGet("/live", () => Results.Ok("alive"));
+    }
+
+    private static void MapMetricsEndpoint(WebApplication app)
+    {
+        // Prometheus scrape endpoint. Exposes every meter registered in the
+        // OpenTelemetry pipeline (always B3.Umdf, plus AdditionalMeterNames).
+        // Lives on the same port as /health for ops-stack convenience.
+        app.MapPrometheusScrapingEndpoint();
     }
 
     private void MapSymbolEndpoints(WebApplication app)

--- a/tests/B3.Umdf.Server.Tests/PrometheusMetricsEndpointTests.cs
+++ b/tests/B3.Umdf.Server.Tests/PrometheusMetricsEndpointTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using B3.Umdf.Server;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Verifies that <see cref="WebSocketHost"/> exposes a Prometheus-format
+/// <c>/metrics</c> endpoint on the same port as the health endpoints, and
+/// that it surfaces the meters registered via the OTel pipeline (the
+/// always-on <c>"B3.Umdf"</c> meter plus any meter named in
+/// <see cref="WebSocketHost.AdditionalMeterNames"/>).
+/// </summary>
+public class PrometheusMetricsEndpointTests
+{
+    private static int FindFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    [Fact]
+    public async Task Metrics_Endpoint_ServesPrometheusExposition()
+    {
+        var sm = new SubscriptionManager();
+        var host = new WebSocketHost(sm);
+        var port = FindFreePort();
+        var cts = new CancellationTokenSource();
+
+        await host.StartAsync(port, cts.Token);
+        try
+        {
+            // Increment AFTER the OTel MeterProvider is built so the SDK
+            // observes a non-zero delta on the first scrape.
+            MetricsRegistry.WsMessagesSent.Add(1);
+
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var resp = await http.GetAsync($"http://127.0.0.1:{port}/metrics");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var contentType = resp.Content.Headers.ContentType?.MediaType;
+            // Prometheus exposition format is text/plain (the version
+            // suffix lives in the parameters and is allowed to vary).
+            Assert.Equal("text/plain", contentType);
+
+            var body = await resp.Content.ReadAsStringAsync();
+
+            // Prometheus exposition uses '_' separators, so dotted meter
+            // names like "umdf.ws.messages.sent" become "umdf_ws_messages_sent".
+            Assert.Contains("umdf_ws_messages_sent", body);
+            // The active-symbols ObservableGauge wired in MetricsRegistry's
+            // static ctor should always emit (returns 0 when the provider
+            // is null, which is the case in this isolated test).
+            Assert.Contains("umdf_ws_subscribed_symbols", body);
+        }
+        finally
+        {
+            cts.Cancel();
+            await host.StopAsync();
+            await host.DisposeAsync();
+            sm.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Metrics_Endpoint_IncludesAdditionalMeterNames()
+    {
+        var sm = new SubscriptionManager();
+        var host = new WebSocketHost(sm)
+        {
+            AdditionalMeterNames = new[] { "B3.Umdf.Server.Tests.Extra" },
+        };
+
+        // Create a counter on the additional meter BEFORE StartAsync so
+        // the OTel SDK picks it up when the MeterProvider is built.
+        using var extraMeter = new System.Diagnostics.Metrics.Meter("B3.Umdf.Server.Tests.Extra", "1.0.0");
+        var extraCounter = extraMeter.CreateCounter<long>("test.extra.counter");
+
+        var port = FindFreePort();
+        var cts = new CancellationTokenSource();
+        await host.StartAsync(port, cts.Token);
+        try
+        {
+            extraCounter.Add(42);
+
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+            var resp = await http.GetAsync($"http://127.0.0.1:{port}/metrics");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("test_extra_counter", body);
+        }
+        finally
+        {
+            cts.Cancel();
+            await host.StopAsync();
+            await host.DisposeAsync();
+            sm.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4.

Wires OpenTelemetry's MeterProvider + Prometheus AspNetCore exporter into `WebSocketHost`, exposing `GET /metrics` on the same port as `/health` (default 8080). Both meters used in the codebase (`B3.Umdf` from `MetricsRegistry`, `B3.Umdf.Consumer` from `MetricsBinder`) are surfaced — the latter via a new opt-in `WebSocketHost.AdditionalMeterNames` property set by `Program.cs`.

### What's exposed

Everything already created on those two meters — feed counters / gauges, transport, book, per-symbol bootstrap, WebSocket connection / subscription / messages-sent / slow-disconnect, broadcast-pool retention, etc. The full catalogue is documented in [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md), with labels and the cardinality contract (**no per-symbol labels** anywhere — per the issue).

One new instrument: `umdf.ws.subscribed_symbols` (`ObservableGauge`) — distinct securities with ≥ 1 active subscriber, sourced from a new `SubscriptionManager.ActiveSymbolCount` accessor. Pairs with the existing `umdf.ws.subscriptions` delta counter so operators have both rate and level.

### Mapping vs. issue's suggested table

| Issue name | Emitted as |
|---|---|
| `b3md_ws_connections` | `umdf_ws_connections_active` |
| `b3md_ws_subscriptions` | `umdf_ws_subscribed_symbols` (gauge, new) + `umdf_ws_subscriptions_total` (existing counter) |
| `b3md_ws_frames_sent_total` | `umdf_ws_messages_sent_total` |
| `b3md_ws_slow_consumer_drops_total` | `umdf_ws_slow_disconnects_total` |
| `b3md_feed_state` | `b3_umdf_feed_state` (label `group`) |
| `b3md_feed_packets_in_total` | `b3_umdf_feed_packets_total` |
| `b3md_feed_gap_total` | `b3_umdf_feed_gaps_total` |
| `b3md_feed_recovery_in_progress` | derivable from `b3_umdf_persymbol_stale_symbols` (per-symbol bootstrap is the actual recovery surface; channel-level no longer has a Recovery state — see RESILIENCE.md) |
| `b3md_book_symbols` | `b3_umdf_persymbol_tracked_symbols` |
| `b3md_trades_total` | `b3_umdf_book_trades_total` |

### Hot path

Untouched. All counters were already `System.Diagnostics.Metrics` primitives; the new gauge is `ObservableGauge`, evaluated only at scrape time. The OTel SDK collects from the meter listener side, fully off the dispatch threads.

### Tests

Two new integration tests in `B3.Umdf.Server.Tests/PrometheusMetricsEndpointTests.cs`:
- the always-on `B3.Umdf` meter shows up on `/metrics` (incl. `umdf_ws_subscribed_symbols` gauge);
- meters opted in via `AdditionalMeterNames` are scraped too.

Full suite green: 449 / 449 passing.

### Out of scope (per issue)

- Tracing (`ActivitySource`s) — separable, not in this PR.
- OTLP push — pull is what the family stack scrapes; the doc notes how to add an OTLP exporter on top without breaking the pull endpoint.
- Grafana dashboard JSON — issue marks it "optional but nice"; can ship as a follow-up once the family stack is up and we've confirmed the panel set we want.