### PR TITLE
Ship typed WebSocketClient SDK (closes #5)

### DIFF
--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -4,6 +4,7 @@
     <Project Path="benchmarks/B3.Umdf.Feed.Benchmarks/B3.Umdf.Feed.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj" />
     <Project Path="src/B3.Umdf.Book/B3.Umdf.Book.csproj" />
     <Project Path="src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj" />
     <Project Path="src/B3.Umdf.Feed/B3.Umdf.Feed.csproj" />
@@ -18,6 +19,7 @@
     <Project Path="tools/InboundLatencyProbe/InboundLatencyProbe.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/B3.MarketData.WebSocketClient.Tests/B3.MarketData.WebSocketClient.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Book.Tests/B3.Umdf.Book.Tests.csproj" />
     <Project Path="tests/B3.Umdf.ConsoleApp.Tests/B3.Umdf.ConsoleApp.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Feed.Tests/B3.Umdf.Feed.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ the only modification to the original B3 schema.
 | [docs/OPERATIONS.md](docs/OPERATIONS.md) | Running locally and in Docker, web viewer screenshots, health endpoints, metrics, backpressure summary, graceful shutdown, TLS, profiling |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | CLI options, full `UMDF_*` environment variable reference, multicast JSON config, host kernel tuning, replay-speed range |
 | [docs/WEBSOCKET_API.md](docs/WEBSOCKET_API.md) | **Consumer-facing landing for the WebSocket distribution layer**: stability label, breaking-change policy, "reference price" quickstart for downstream apps (e.g. risk modules) |
+| [docs/CLIENT-SDK.md](docs/CLIENT-SDK.md) | **Typed C# SDK** (`B3.MarketData.WebSocketClient` NuGet): API, DI extension, reconnect+replay, back-pressure policies |
 | [docs/WEBSOCKET-PROTOCOL.md](docs/WEBSOCKET-PROTOCOL.md) | Wire framing, message catalog, hex examples, subscription / reconnect / slow-consumer flows, candle chunking |
 | [docs/PERFORMANCE.md](docs/PERFORMANCE.md) | Hot-path design, zero-copy decoding, MPSC ring, broadcaster decoupling, coalescing, benchmarks |
 | [docs/RESILIENCE.md](docs/RESILIENCE.md) | Failure modes, gap recovery, fanout suppression, slow-consumer layered defenses, memory bounds, operational playbook |

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -1,0 +1,88 @@
+# Client SDK — `B3.MarketData.WebSocketClient`
+
+A typed, allocation-aware C# SDK for consuming the
+B3MarketDataPlatform WebSocket distribution layer. The package wraps
+the binary wire protocol described in
+[`docs/WEBSOCKET-PROTOCOL.md`](WEBSOCKET-PROTOCOL.md), exposes the
+"reference-price" surface from
+[`docs/WEBSOCKET_API.md`](WEBSOCKET_API.md) as .NET events, and handles
+reconnect + replay transparently.
+
+| Item | Value |
+|------|-------|
+| Package id | `B3.MarketData.WebSocketClient` |
+| Target | `net10.0` |
+| License | MIT |
+| Public surface | `MarketDataClient`, `MarketDataClientOptions`, event records, `SubscribeFlags` |
+| Source | `src/B3.MarketData.WebSocketClient/` |
+
+## Quickstart
+
+```csharp
+await using var client = new MarketDataClient(new MarketDataClientOptions
+{
+    Endpoint = new Uri("ws://localhost:8080/ws"),
+});
+
+client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}");
+client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice}");
+client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
+client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");
+
+await client.ConnectAsync();
+await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info);
+```
+
+`Price` is delivered as `decimal` already scaled by the SBE exponent
+(`-4` for trades and info fields) — no manual divide is needed.
+
+## Dependency injection
+
+```csharp
+services.AddMarketDataClient(opt =>
+{
+    opt.Endpoint = new Uri(builder.Configuration["MarketData:Endpoint"]!);
+    opt.BackPressure = BackPressurePolicy.DropOldest;
+});
+```
+
+The client is registered as a singleton; resolve `MarketDataClient`
+from your `IServiceProvider` and call `ConnectAsync` once during
+startup.
+
+## Reconnect & replay
+
+- Background loop reconnects with exponential backoff
+  (`ReconnectInitialDelay` → `ReconnectMaxDelay`, default 250 ms → 30 s),
+  with up to ~25 % additive jitter.
+- When the socket re-opens, every active subscription is re-issued
+  automatically (`AutoResubscribeOnReconnect = true`). Consumers do
+  **not** need to re-subscribe on `ConnectionStateChanged`.
+- The cached `symbol → securityId` mapping is preserved across
+  reconnects and refreshed by the new `SubscribeOk` frames.
+
+## Back-pressure
+
+Decoded events are queued through a bounded `Channel<T>`
+(`EventChannelCapacity`, default 4096). When full, behaviour follows
+`BackPressurePolicy`:
+
+| Policy | Effect | When to use |
+|--------|--------|-------------|
+| `DropOldest` *(default)* | Discards the oldest queued event; increments `DroppedEventCount`. | Reference-price consumers that only need the latest tick. |
+| `Block` | The receive loop awaits channel capacity. | Audit/persistence consumers that must not lose events but accept latency. |
+| `Throw` | Drops the new event and raises `DroppedEventCount`. | Tests / strict consumers that want explicit detection. |
+
+Monitor `client.DroppedEventCount` to detect slow handlers; the server
+also enforces its own queue limits described in
+[`docs/RESILIENCE.md`](RESILIENCE.md).
+
+## Scope of v1
+
+In: `Trade`, `TradeBust`, `InfoSnapshot`, `ServerStatus`,
+`SubscribeError`, `ConnectionStateChanged`, reconnect+replay, DI
+extension, bounded back-pressure.
+
+Out (intentional): MBO/MBP order-book streams, recovery REST, auth
+tokens. These remain accessible via the raw protocol described in
+[`docs/WEBSOCKET-PROTOCOL.md`](WEBSOCKET-PROTOCOL.md).

--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.MarketData.WebSocketClient</RootNamespace>
+    <AssemblyName>B3.MarketData.WebSocketClient</AssemblyName>
+
+    <!-- Packaging -->
+    <IsPackable>true</IsPackable>
+    <PackageId>B3.MarketData.WebSocketClient</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>pedrosakuma</Authors>
+    <Description>Typed C# subscriber SDK for the B3MarketDataPlatform WebSocket distribution layer (v1: trades, info snapshots, server status). Built-in reconnect with transparent re-subscribe and bounded back-pressure.</Description>
+    <PackageTags>b3;marketdata;websocket;sdk;trades;reference-price</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pedrosakuma/B3MarketDataPlatform</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pedrosakuma/B3MarketDataPlatform</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!-- SourceLink + deterministic build (matches the rest of the family's NuGets) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <DebugType>portable</DebugType>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.MarketData.WebSocketClient.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -1,0 +1,101 @@
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>Connection state surfaced via <see cref="MarketDataClient.ConnectionStateChanged"/>.</summary>
+public enum ConnectionState
+{
+    Disconnected = 0,
+    Connecting = 1,
+    Connected = 2,
+    Reconnecting = 3,
+    Faulted = 4,
+}
+
+/// <summary>
+/// A live trade print. Price has the SBE 4-decimal exponent already
+/// applied (the raw wire value is <c>price × 10_000</c>).
+/// </summary>
+/// <param name="SecurityId">B3 security id.</param>
+/// <param name="Symbol">Resolved symbol (from the client-side
+/// <c>SubscribeOk</c> cache).</param>
+/// <param name="Price">Trade price, scaled. <c>raw / 10_000m</c>.</param>
+/// <param name="Qty">Trade quantity (raw, unscaled).</param>
+/// <param name="TradeId">Server-assigned trade id (for correlation with
+/// a future <see cref="TradeBustEvent"/>).</param>
+/// <param name="ReceivedUtc">UTC timestamp at which the SDK received
+/// the frame from the WebSocket. Not the exchange match time.</param>
+public readonly record struct TradeEvent(
+    ulong SecurityId,
+    string Symbol,
+    decimal Price,
+    long Qty,
+    long TradeId,
+    DateTime ReceivedUtc);
+
+/// <summary>
+/// Cancellation of a previously-broadcast trade. Risk consumers usually
+/// ignore this (the live tape has already moved on); audit consumers
+/// should remove the print from their trade history by
+/// <see cref="TradeId"/>.
+/// </summary>
+public readonly record struct TradeBustEvent(
+    ulong SecurityId,
+    string Symbol,
+    long TradeId,
+    DateTime ReceivedUtc);
+
+/// <summary>
+/// Per-symbol info snapshot. Only fields actually present in the frame
+/// are populated; absent fields are <c>null</c>. Prices are scaled with
+/// the SBE 4-decimal exponent.
+/// </summary>
+public sealed class InfoSnapshotEvent
+{
+    public ulong SecurityId { get; init; }
+    public string Symbol { get; init; } = "";
+    public DateTime ReceivedUtc { get; init; }
+
+    public decimal? OpeningPrice { get; init; }
+    public decimal? ClosingPrice { get; init; }
+    public decimal? HighPrice { get; init; }
+    public decimal? LowPrice { get; init; }
+    public decimal? LastTradePrice { get; init; }
+    public long? LastTradeSize { get; init; }
+    public decimal? SettlementPrice { get; init; }
+    public decimal? VwapPrice { get; init; }
+    public long? NumberOfTrades { get; init; }
+    public long? OpenInterest { get; init; }
+    public decimal? PriceBandLow { get; init; }
+    public decimal? PriceBandHigh { get; init; }
+    public decimal? TradingReferencePrice { get; init; }
+    public long? TradeVolume { get; init; }
+    public long? TradingStatus { get; init; }
+    public long? TradingEvent { get; init; }
+}
+
+/// <summary>
+/// Server feed status. <see cref="Ready"/> = <c>true</c> once every
+/// upstream feed group is in <c>RealTime</c>. The server emits one on
+/// connect and one on each transition; treat <c>Ready=false</c> as
+/// "do not subscribe yet".
+/// </summary>
+public readonly record struct ServerStatusEvent(bool Ready, DateTime ReceivedUtc);
+
+/// <summary>
+/// Returned by the server when a <c>Subscribe</c> can't be satisfied.
+/// </summary>
+public enum SubscribeErrorCode : byte
+{
+    Unknown = 0,
+    UnknownSymbol = 0x01,
+    NotReady = 0x02,
+}
+
+public readonly record struct SubscribeErrorEvent(
+    string Symbol,
+    SubscribeErrorCode ErrorCode,
+    DateTime ReceivedUtc);
+
+public readonly record struct ConnectionStateChangedEvent(
+    ConnectionState State,
+    Exception? Error,
+    DateTime ChangedUtc);

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -1,0 +1,487 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>
+/// Typed C# subscriber for the B3MarketDataPlatform WebSocket
+/// distribution layer (v1: trades, info snapshots, server status).
+///
+/// Lifecycle: <see cref="ConnectAsync"/> opens the WebSocket and starts
+/// two background loops — one drains the socket and pushes decoded
+/// events into a bounded internal channel; the other dispatches events
+/// to the typed handlers. Reconnects are transparent: the SDK retries
+/// with exponential back-off and re-issues every active subscription
+/// when <see cref="MarketDataClientOptions.AutoResubscribeOnReconnect"/>
+/// is set (default).
+///
+/// All event handlers are invoked sequentially on the dispatch loop
+/// thread; do not block them. Handler exceptions are logged and
+/// swallowed — they do not interrupt the stream.
+/// </summary>
+public sealed class MarketDataClient : IAsyncDisposable
+{
+    private readonly MarketDataClientOptions _options;
+    private readonly ILogger<MarketDataClient> _logger;
+    private readonly ConcurrentDictionary<string, SubscriptionRecord> _subscriptions = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<ulong, string> _securityIdToSymbol = new();
+    private readonly Channel<Action> _eventChannel;
+    private readonly object _stateLock = new();
+
+    private CancellationTokenSource? _runCts;
+    private Task? _runTask;
+    private Task? _dispatchTask;
+    private ClientWebSocket? _socket;
+    private long _droppedEventCount;
+    private ConnectionState _connectionState = ConnectionState.Disconnected;
+    private bool _disposed;
+
+    public MarketDataClient(MarketDataClientOptions options, ILogger<MarketDataClient>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (options.Endpoint is null) throw new ArgumentException("Endpoint is required", nameof(options));
+        if (options.EventChannelCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(options), "EventChannelCapacity must be > 0");
+
+        _options = options;
+        _logger = logger ?? NullLogger<MarketDataClient>.Instance;
+
+        var channelOptions = new BoundedChannelOptions(options.EventChannelCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = true,
+            FullMode = options.BackPressure switch
+            {
+                BackPressurePolicy.DropOldest => BoundedChannelFullMode.DropOldest,
+                BackPressurePolicy.Block => BoundedChannelFullMode.Wait,
+                BackPressurePolicy.Throw => BoundedChannelFullMode.DropWrite,
+                _ => BoundedChannelFullMode.DropOldest,
+            },
+        };
+        _eventChannel = Channel.CreateBounded<Action>(channelOptions);
+    }
+
+    // ── Public events ────────────────────────────────────────────────
+
+    public event Action<TradeEvent>? Trade;
+    public event Action<TradeBustEvent>? TradeBust;
+    public event Action<InfoSnapshotEvent>? InfoSnapshot;
+    public event Action<ServerStatusEvent>? ServerStatus;
+    public event Action<SubscribeErrorEvent>? SubscribeError;
+    public event Action<ConnectionStateChangedEvent>? ConnectionStateChanged;
+
+    /// <summary>Current connection state. Updated by the run loop.</summary>
+    public ConnectionState State
+    {
+        get { lock (_stateLock) return _connectionState; }
+    }
+
+    /// <summary>
+    /// Cumulative number of decoded events dropped due to back-pressure
+    /// (only applicable when <see cref="BackPressurePolicy.DropOldest"/>
+    /// or <see cref="BackPressurePolicy.Throw"/> is in effect).
+    /// </summary>
+    public long DroppedEventCount => Interlocked.Read(ref _droppedEventCount);
+
+    /// <summary>
+    /// Symbols currently subscribed (snapshot — safe to enumerate).
+    /// </summary>
+    public IReadOnlyCollection<string> ActiveSubscriptions => _subscriptions.Keys.ToArray();
+
+    // ── Public API ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Open the WebSocket and start the receive + dispatch loops.
+    /// Returns once the underlying connection has either succeeded or
+    /// the run loop has begun retrying. Subsequent calls are no-ops.
+    /// </summary>
+    public Task ConnectAsync(CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        lock (_stateLock)
+        {
+            if (_runTask is not null) return Task.CompletedTask;
+            _runCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _dispatchTask = Task.Run(() => DispatchLoopAsync(_runCts.Token));
+            _runTask = Task.Run(() => RunLoopAsync(_runCts.Token));
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Subscribe to a symbol with the given flags (default
+    /// <see cref="SubscribeFlags.Trades"/>). The Subscribe frame is
+    /// queued for transmission on the current socket; the SDK also
+    /// records the symbol so reconnects re-issue the subscription
+    /// transparently.
+    /// </summary>
+    public ValueTask SubscribeAsync(string symbol, SubscribeFlags flags = SubscribeFlags.Trades, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrEmpty(symbol);
+        var record = new SubscriptionRecord(symbol, flags);
+        _subscriptions[symbol] = record;
+        return SendSubscribeAsync(record, ct);
+    }
+
+    /// <summary>
+    /// Unsubscribe by symbol. The SDK looks up the cached securityId
+    /// (populated by <c>SubscribeOk</c>) and sends an <c>Unsubscribe</c>
+    /// frame; if the securityId is not yet known, the entry is just
+    /// removed from the active set and no frame is sent.
+    /// </summary>
+    public ValueTask UnsubscribeAsync(string symbol, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+        ArgumentException.ThrowIfNullOrEmpty(symbol);
+        if (!_subscriptions.TryRemove(symbol, out var record)) return default;
+
+        ulong secId = record.SecurityId;
+        if (secId == 0) return default;
+        return SendUnsubscribeAsync(secId, ct);
+    }
+
+    /// <summary>Resolve a previously-subscribed symbol to its securityId.</summary>
+    public bool TryGetSecurityId(string symbol, out ulong securityId)
+    {
+        if (_subscriptions.TryGetValue(symbol, out var rec) && rec.SecurityId != 0)
+        {
+            securityId = rec.SecurityId;
+            return true;
+        }
+        securityId = 0;
+        return false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _runCts?.Cancel();
+        try
+        {
+            if (_runTask is not null) await _runTask.ConfigureAwait(false);
+        }
+        catch { /* expected on cancellation */ }
+
+        try
+        {
+            _eventChannel.Writer.TryComplete();
+            if (_dispatchTask is not null) await _dispatchTask.ConfigureAwait(false);
+        }
+        catch { /* expected on cancellation */ }
+
+        _socket?.Dispose();
+        _runCts?.Dispose();
+    }
+
+    // ── Internals ────────────────────────────────────────────────────
+
+    private async Task RunLoopAsync(CancellationToken ct)
+    {
+        var delay = _options.ReconnectInitialDelay;
+        var rng = new Random();
+
+        while (!ct.IsCancellationRequested)
+        {
+            ClientWebSocket? socket = null;
+            try
+            {
+                ChangeState(ConnectionState.Connecting, error: null);
+                socket = new ClientWebSocket();
+                await socket.ConnectAsync(_options.Endpoint, ct).ConfigureAwait(false);
+                _socket = socket;
+                ChangeState(ConnectionState.Connected, error: null);
+                delay = _options.ReconnectInitialDelay;
+
+                if (_options.AutoResubscribeOnReconnect)
+                    await ResubscribeAllAsync(ct).ConfigureAwait(false);
+
+                await ReceiveLoopAsync(socket, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                ChangeState(ConnectionState.Reconnecting, ex);
+                _logger.LogWarning(ex, "MarketDataClient connection lost; reconnecting in {DelayMs}ms", (int)delay.TotalMilliseconds);
+            }
+            finally
+            {
+                try { socket?.Dispose(); } catch { }
+                if (ReferenceEquals(_socket, socket)) _socket = null;
+            }
+
+            if (ct.IsCancellationRequested) break;
+
+            // Exponential back-off with up to 25% additive jitter.
+            int jitterMs = rng.Next((int)(delay.TotalMilliseconds * 0.25) + 1);
+            try
+            {
+                await Task.Delay(delay + TimeSpan.FromMilliseconds(jitterMs), ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+
+            var nextMs = Math.Min(delay.TotalMilliseconds * 2, _options.ReconnectMaxDelay.TotalMilliseconds);
+            delay = TimeSpan.FromMilliseconds(nextMs);
+        }
+
+        ChangeState(ConnectionState.Disconnected, error: null);
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        // 64 KiB matches the protocol's u16-length cap; anything larger
+        // would be a server-side bug (and we'd close on it anyway).
+        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+            {
+                int filled = 0;
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer, filled, buffer.Length - filled), ct).ConfigureAwait(false);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "client closing", ct).ConfigureAwait(false);
+                        return;
+                    }
+                    filled += result.Count;
+                    if (filled == buffer.Length && !result.EndOfMessage)
+                        throw new InvalidOperationException("WebSocket frame exceeded 64 KiB buffer (protocol violation).");
+                }
+                while (!result.EndOfMessage);
+
+                if (result.MessageType != WebSocketMessageType.Binary)
+                    continue; // ignore unexpected text frames
+
+                DispatchFrames(new ReadOnlyMemory<byte>(buffer, 0, filled));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    /// <summary>
+    /// Decode all wire messages packed into <paramref name="data"/> and
+    /// enqueue typed callbacks onto the event channel. The server may
+    /// coalesce many wire messages into a single WebSocket frame
+    /// (<c>UMDF_CLIENT_COALESCE_WINDOW_MS</c>) — so iterate.
+    /// </summary>
+    private void DispatchFrames(ReadOnlyMemory<byte> data)
+    {
+        var receivedUtc = DateTime.UtcNow;
+        var span = data.Span;
+        int offset = 0;
+
+        while (offset < span.Length)
+        {
+            if (!WireFormat.TryReadHeader(span[offset..], out ushort len, out var type) || len < WireFormat.FramingHeaderSize)
+            {
+                _logger.LogWarning("Truncated frame header at offset {Offset}; dropping rest of packet.", offset);
+                return;
+            }
+            if (offset + len > span.Length)
+            {
+                _logger.LogWarning("Truncated frame body (declared {Len}, available {Avail}); dropping rest.", len, span.Length - offset);
+                return;
+            }
+
+            var payload = span.Slice(offset + WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize);
+            DecodeAndEnqueue(type, payload, receivedUtc);
+            offset += len;
+        }
+    }
+
+    private void DecodeAndEnqueue(WireFormat.MessageType type, ReadOnlySpan<byte> payload, DateTime receivedUtc)
+    {
+        switch (type)
+        {
+            case WireFormat.MessageType.ServerStatus:
+            {
+                bool ready = WireFormat.ReadServerStatus(payload);
+                Enqueue(() => ServerStatus?.Invoke(new ServerStatusEvent(ready, receivedUtc)));
+                break;
+            }
+            case WireFormat.MessageType.SubscribeOk:
+            {
+                var (secId, _, sym) = WireFormat.ReadSubscribeOk(payload);
+                _securityIdToSymbol[secId] = sym;
+                if (_subscriptions.TryGetValue(sym, out var rec))
+                    rec.SecurityId = secId;
+                break;
+            }
+            case WireFormat.MessageType.SubscribeError:
+            {
+                var (sym, code) = WireFormat.ReadSubscribeError(payload);
+                Enqueue(() => SubscribeError?.Invoke(new SubscribeErrorEvent(
+                    sym,
+                    Enum.IsDefined(typeof(SubscribeErrorCode), code) ? (SubscribeErrorCode)code : SubscribeErrorCode.Unknown,
+                    receivedUtc)));
+                break;
+            }
+            case WireFormat.MessageType.Trade:
+            {
+                var (secId, price, qty, tradeId) = WireFormat.ReadTrade(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new TradeEvent(secId, symbol, price / WireFormat.PriceScale, qty, tradeId, receivedUtc);
+                Enqueue(() => Trade?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.TradeBust:
+            {
+                var (secId, tradeId) = WireFormat.ReadTradeBust(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                Enqueue(() => TradeBust?.Invoke(new TradeBustEvent(secId, symbol, tradeId, receivedUtc)));
+                break;
+            }
+            case WireFormat.MessageType.InfoSnapshot:
+            {
+                ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                // InfoSnapshot decoding allocates the event object — keep it on the
+                // dispatch enqueue path; do the decode now while we still own the
+                // payload buffer (the receive loop owns the rented array).
+                var ev = WireFormat.ReadInfoSnapshot(payload, symbol, receivedUtc);
+                Enqueue(() => InfoSnapshot?.Invoke(ev));
+                break;
+            }
+            // Unsubscribed (0x0012) is currently silent — the application
+            // already knows it called UnsubscribeAsync. Other message
+            // types (Book, Mbp, News, …) are out of scope for v1 and
+            // simply ignored.
+            default:
+                break;
+        }
+    }
+
+    private void Enqueue(Action callback)
+    {
+        if (_eventChannel.Writer.TryWrite(callback))
+            return;
+
+        switch (_options.BackPressure)
+        {
+            case BackPressurePolicy.Block:
+                // BoundedChannelFullMode.Wait is async; for the binary
+                // flush path we synchronously spin via WaitToWriteAsync.
+                _eventChannel.Writer.WriteAsync(callback).AsTask().GetAwaiter().GetResult();
+                break;
+            case BackPressurePolicy.Throw:
+                Interlocked.Increment(ref _droppedEventCount);
+                throw new InvalidOperationException("MarketDataClient event channel is full (BackPressurePolicy.Throw).");
+            case BackPressurePolicy.DropOldest:
+            default:
+                Interlocked.Increment(ref _droppedEventCount);
+                break;
+        }
+    }
+
+    private async Task DispatchLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (await _eventChannel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+            {
+                while (_eventChannel.Reader.TryRead(out var callback))
+                {
+                    try { callback(); }
+                    catch (Exception ex) { _logger.LogError(ex, "MarketDataClient event handler threw"); }
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* expected */ }
+    }
+
+    private async ValueTask SendSubscribeAsync(SubscriptionRecord record, CancellationToken ct)
+    {
+        var socket = _socket;
+        if (socket is null || socket.State != WebSocketState.Open)
+            return; // will be replayed by ResubscribeAllAsync after reconnect
+        var buffer = ArrayPool<byte>.Shared.Rent(4 + 1 + 1 + 256);
+        try
+        {
+            int len = WireFormat.WriteSubscribe(buffer, record.Flags, record.Symbol);
+            await socket.SendAsync(new ArraySegment<byte>(buffer, 0, len), WebSocketMessageType.Binary, endOfMessage: true, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Subscribe send for {Symbol} failed; will be retried on reconnect.", record.Symbol);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async ValueTask SendUnsubscribeAsync(ulong securityId, CancellationToken ct)
+    {
+        var socket = _socket;
+        if (socket is null || socket.State != WebSocketState.Open) return;
+        var buffer = ArrayPool<byte>.Shared.Rent(12);
+        try
+        {
+            int len = WireFormat.WriteUnsubscribe(buffer, securityId);
+            await socket.SendAsync(new ArraySegment<byte>(buffer, 0, len), WebSocketMessageType.Binary, endOfMessage: true, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Unsubscribe send for {SecurityId} failed.", securityId);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task ResubscribeAllAsync(CancellationToken ct)
+    {
+        // Snapshot the current set; new subscriptions added concurrently
+        // will go through SendSubscribeAsync directly.
+        foreach (var record in _subscriptions.Values)
+        {
+            await SendSubscribeAsync(record, ct).ConfigureAwait(false);
+        }
+    }
+
+    private void ChangeState(ConnectionState newState, Exception? error)
+    {
+        ConnectionState old;
+        lock (_stateLock)
+        {
+            old = _connectionState;
+            _connectionState = newState;
+        }
+        if (old == newState) return;
+        try { ConnectionStateChanged?.Invoke(new ConnectionStateChangedEvent(newState, error, DateTime.UtcNow)); }
+        catch (Exception ex) { _logger.LogError(ex, "ConnectionStateChanged handler threw"); }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(MarketDataClient));
+    }
+
+    private sealed class SubscriptionRecord
+    {
+        public string Symbol { get; }
+        public SubscribeFlags Flags { get; }
+        public ulong SecurityId; // populated on SubscribeOk; 0 until then
+
+        public SubscriptionRecord(string symbol, SubscribeFlags flags)
+        {
+            Symbol = symbol;
+            Flags = flags;
+        }
+    }
+}

--- a/src/B3.MarketData.WebSocketClient/MarketDataClientOptions.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClientOptions.cs
@@ -1,0 +1,76 @@
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>
+/// Strategy for handling a slow consumer when the SDK's internal event
+/// channel can't be drained fast enough by the application.
+/// </summary>
+public enum BackPressurePolicy
+{
+    /// <summary>
+    /// Drop the oldest pending event to make room for the new one.
+    /// Increments <see cref="MarketDataClient.DroppedEventCount"/>.
+    /// Default — safest for "live last-value" consumers (e.g. reference
+    /// price), where stale events behind the head are useless anyway.
+    /// </summary>
+    DropOldest = 0,
+
+    /// <summary>
+    /// Block the receive loop until there is room. Will eventually
+    /// trigger server-side slow-consumer disconnect (1008) if the
+    /// application stays stalled, since the receive loop also drains
+    /// the underlying TCP buffers.
+    /// </summary>
+    Block = 1,
+
+    /// <summary>
+    /// Throw an <see cref="InvalidOperationException"/> from the receive
+    /// loop, surfaced via <see cref="MarketDataClient.ConnectionStateChanged"/>
+    /// and forcing reconnect. Useful for fail-fast deployments.
+    /// </summary>
+    Throw = 2,
+}
+
+/// <summary>
+/// Configuration for <see cref="MarketDataClient"/>. All values have
+/// defaults tuned for the reference-price use case.
+/// </summary>
+public sealed class MarketDataClientOptions
+{
+    /// <summary>
+    /// WebSocket endpoint. Required. Use <c>ws://</c> for plaintext or
+    /// <c>wss://</c> when terminating TLS at an ingress.
+    /// </summary>
+    public Uri Endpoint { get; set; } = new("ws://localhost:8080/ws");
+
+    /// <summary>
+    /// Bound for the internal event channel. Default 4096 — sized for
+    /// burst tolerance of one second at peak trade rate.
+    /// </summary>
+    public int EventChannelCapacity { get; set; } = 4096;
+
+    /// <summary>
+    /// Policy applied when <see cref="EventChannelCapacity"/> is full.
+    /// Default <see cref="BackPressurePolicy.DropOldest"/>.
+    /// </summary>
+    public BackPressurePolicy BackPressure { get; set; } = BackPressurePolicy.DropOldest;
+
+    /// <summary>
+    /// Initial delay before the first reconnect attempt. Doubles each
+    /// failed attempt up to <see cref="ReconnectMaxDelay"/>, with up to
+    /// 25% additive jitter. Default 250 ms.
+    /// </summary>
+    public TimeSpan ReconnectInitialDelay { get; set; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Cap on the exponential reconnect back-off. Default 30 s.
+    /// </summary>
+    public TimeSpan ReconnectMaxDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// When <c>true</c> (default), the SDK transparently re-issues every
+    /// active subscription after a reconnect — the application observes
+    /// only a <c>ConnectionStateChanged</c> event, no resubscribe loop
+    /// of its own.
+    /// </summary>
+    public bool AutoResubscribeOnReconnect { get; set; } = true;
+}

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -1,0 +1,38 @@
+# B3.MarketData.WebSocketClient
+
+Typed C# subscriber SDK for the
+[B3MarketDataPlatform](https://github.com/pedrosakuma/B3MarketDataPlatform)
+WebSocket distribution layer.
+
+This v1 release covers the **reference-price use case** (trade prints,
+info snapshots, server status) — the same surface documented in
+[`docs/WEBSOCKET_API.md`](https://github.com/pedrosakuma/B3MarketDataPlatform/blob/main/docs/WEBSOCKET_API.md),
+exposed as typed events with the SBE 4-decimal price exponent already
+applied so consumers never see the raw `i64` mantissa.
+
+```csharp
+using B3.MarketData.WebSocketClient;
+
+await using var client = new MarketDataClient(new MarketDataClientOptions
+{
+    Endpoint = new Uri("ws://localhost:8080/ws"),
+});
+
+client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
+
+await client.ConnectAsync();
+await client.SubscribeAsync("PETR4");
+```
+
+Includes:
+
+- Transparent reconnect with exponential back-off + automatic
+  re-subscribe of every active subscription.
+- Bounded back-pressure (`Channel<T>` with a configurable policy:
+  `DropOldest` / `Block` / `Throw`).
+- DI extension: `services.AddMarketDataClient(...)`.
+
+Out of scope for v1: full L2/MBO subscription, recovery REST endpoints.
+
+See [`docs/CLIENT-SDK.md`](https://github.com/pedrosakuma/B3MarketDataPlatform/blob/main/docs/CLIENT-SDK.md)
+for the full guide.

--- a/src/B3.MarketData.WebSocketClient/ServiceCollectionExtensions.cs
+++ b/src/B3.MarketData.WebSocketClient/ServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>
+/// DI integration for <see cref="MarketDataClient"/>.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register a singleton <see cref="MarketDataClient"/> configured by
+    /// <paramref name="configureOptions"/>. The application is
+    /// responsible for calling <c>ConnectAsync</c> at startup (e.g.
+    /// from an <c>IHostedService</c>) and for disposing the client at
+    /// shutdown — DI handles disposal automatically when the singleton
+    /// scope is torn down.
+    /// </summary>
+    public static IServiceCollection AddMarketDataClient(
+        this IServiceCollection services,
+        Action<MarketDataClientOptions> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        services.AddOptions<MarketDataClientOptions>().Configure(configureOptions);
+        services.TryAddSingleton(sp =>
+        {
+            var options = sp.GetRequiredService<IOptions<MarketDataClientOptions>>().Value;
+            var loggerFactory = sp.GetService<ILoggerFactory>();
+            var logger = loggerFactory?.CreateLogger<MarketDataClient>();
+            return new MarketDataClient(options, logger);
+        });
+        return services;
+    }
+}

--- a/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
+++ b/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
@@ -1,0 +1,22 @@
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>
+/// Bitmask matching the server's <c>DataFlags</c> enum, scoped to the
+/// channels exposed by v1 of the SDK. Combine with <c>|</c>:
+/// <c>Trades | Info</c>.
+/// </summary>
+[Flags]
+public enum SubscribeFlags : byte
+{
+    /// <summary>
+    /// <c>InfoSnapshot</c> + incremental info updates (carries
+    /// <c>LastTradePrice</c>, <c>LastTradeSize</c>, status, etc.).
+    /// </summary>
+    Info = 0x02,
+
+    /// <summary>
+    /// Live trade prints and corrections (<c>TradeBust</c>), plus the
+    /// per-symbol recent-trades history snapshot on subscribe.
+    /// </summary>
+    Trades = 0x10,
+}

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -1,0 +1,209 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace B3.MarketData.WebSocketClient;
+
+/// <summary>
+/// Binary wire format for the B3MarketDataPlatform WebSocket protocol.
+/// Mirrors a minimal subset of the server's <c>WireProtocol</c> + the
+/// <c>MessageType</c> enum, just for the v1 SDK surface.
+/// Layout: <c>[length u16][type u16][payload]</c>, little-endian; length
+/// includes the 4-byte header.
+/// </summary>
+internal static class WireFormat
+{
+    public const int FramingHeaderSize = 4;
+
+    /// <summary>SBE schema's <c>Price</c>/<c>PriceOptional</c> exponent (1e-4).</summary>
+    public const decimal PriceScale = 10_000m;
+
+    public enum MessageType : ushort
+    {
+        Subscribe = 0x0001,
+        Unsubscribe = 0x0002,
+        SubscribeOk = 0x0010,
+        SubscribeError = 0x0011,
+        Unsubscribed = 0x0012,
+        InfoSnapshot = 0x0021,
+        Trade = 0x0033,
+        TradeBust = 0x0035,
+        ServerStatus = 0x0050,
+    }
+
+    // InfoSnapshot field-mask bit positions. Must match the server's
+    // WireProtocol field constants (Field*). Only the bits the SDK
+    // surfaces are listed here; unknown bits are ignored at decode time
+    // (their 8 bytes are still consumed in mask-bit order).
+    public const int FieldOpeningPrice = 0;
+    public const int FieldClosingPrice = 1;
+    public const int FieldHighPrice = 2;
+    public const int FieldLowPrice = 3;
+    public const int FieldLastTradePrice = 4;
+    public const int FieldLastTradeSize = 5;
+    public const int FieldSettlementPrice = 6;
+    public const int FieldTheoreticalOpeningPrice = 7;
+    public const int FieldTheoreticalOpeningSize = 8;
+    public const int FieldAuctionImbalanceSize = 9;
+    public const int FieldTradeVolume = 10;
+    public const int FieldVwapPrice = 11;
+    public const int FieldNetChange = 12;
+    public const int FieldNumberOfTrades = 13;
+    public const int FieldOpenInterest = 14;
+    public const int FieldPriceBandLow = 15;
+    public const int FieldPriceBandHigh = 16;
+    public const int FieldTradingReferencePrice = 17;
+    public const int FieldAvgDailyTradedQty = 18;
+    public const int FieldMaxTradeVol = 19;
+    public const int FieldTradingStatus = 20;
+    public const int FieldTradingEvent = 21;
+    public const int FieldPriceLimitType = 22;
+    public const int FieldMinPriceIncrement = 23;
+
+    public static bool TryReadHeader(ReadOnlySpan<byte> src, out ushort length, out MessageType type)
+    {
+        if (src.Length < FramingHeaderSize)
+        {
+            length = 0;
+            type = 0;
+            return false;
+        }
+        length = BinaryPrimitives.ReadUInt16LittleEndian(src);
+        type = (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(src[2..]);
+        return true;
+    }
+
+    /// <summary>
+    /// Encode a <c>Subscribe</c> frame: <c>[flags u8][symLen u8][symbol UTF-8…]</c>.
+    /// Returns the total frame length written.
+    /// </summary>
+    public static int WriteSubscribe(Span<byte> dest, SubscribeFlags flags, string symbol)
+    {
+        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[(FramingHeaderSize + 2)..]);
+        ushort totalLen = (ushort)(FramingHeaderSize + 1 + 1 + symbolLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)MessageType.Subscribe);
+        dest[FramingHeaderSize] = (byte)flags;
+        dest[FramingHeaderSize + 1] = (byte)symbolLen;
+        return totalLen;
+    }
+
+    /// <summary>Encode an <c>Unsubscribe</c> frame: <c>[securityId u64]</c>.</summary>
+    public static int WriteUnsubscribe(Span<byte> dest, ulong securityId)
+    {
+        const ushort totalLen = FramingHeaderSize + 8;
+        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)MessageType.Unsubscribe);
+        BinaryPrimitives.WriteUInt64LittleEndian(dest[FramingHeaderSize..], securityId);
+        return totalLen;
+    }
+
+    public static (ulong SecurityId, byte Flags, string Symbol) ReadSubscribeOk(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        byte flags = payload[8];
+        byte symLen = payload[9];
+        string sym = Encoding.UTF8.GetString(payload.Slice(10, symLen));
+        return (secId, flags, sym);
+    }
+
+    public static (string Symbol, byte ErrorCode) ReadSubscribeError(ReadOnlySpan<byte> payload)
+    {
+        byte errorCode = payload[0];
+        byte symLen = payload[1];
+        string sym = Encoding.UTF8.GetString(payload.Slice(2, symLen));
+        return (sym, errorCode);
+    }
+
+    public static bool ReadServerStatus(ReadOnlySpan<byte> payload) => payload[0] != 0;
+
+    public static (ulong SecurityId, long Price, long Qty, long TradeId) ReadTrade(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
+        long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[16..]);
+        long tradeId = BinaryPrimitives.ReadInt64LittleEndian(payload[24..]);
+        return (secId, price, qty, tradeId);
+    }
+
+    public static (ulong SecurityId, long TradeId) ReadTradeBust(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        long tradeId = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
+        return (secId, tradeId);
+    }
+
+    /// <summary>
+    /// Decode an <c>InfoSnapshot</c> body into a populated event.
+    /// Only fields whose bit is set in <c>fieldMask</c> are present in
+    /// the payload, in bit order, as <c>i64</c>. Unknown bits (above
+    /// <see cref="FieldMinPriceIncrement"/>) are still consumed so the
+    /// SDK keeps reading future fields without alignment damage.
+    /// </summary>
+    public static InfoSnapshotEvent ReadInfoSnapshot(ReadOnlySpan<byte> payload, string symbol, DateTime receivedUtc)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(payload[8..]);
+
+        decimal? opening = null, closing = null, high = null, low = null;
+        decimal? lastTradePrice = null;
+        long? lastTradeSize = null;
+        decimal? settlement = null, vwap = null;
+        long? trades = null, openInterest = null;
+        decimal? bandLow = null, bandHigh = null, refPx = null;
+        long? volume = null, status = null, evt = null;
+
+        int offset = 12;
+        for (int bit = 0; bit < 32; bit++)
+        {
+            if ((mask & (1u << bit)) == 0) continue;
+            long v = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+            offset += 8;
+            switch (bit)
+            {
+                case FieldOpeningPrice: opening = v / PriceScale; break;
+                case FieldClosingPrice: closing = v / PriceScale; break;
+                case FieldHighPrice: high = v / PriceScale; break;
+                case FieldLowPrice: low = v / PriceScale; break;
+                case FieldLastTradePrice: lastTradePrice = v / PriceScale; break;
+                case FieldLastTradeSize: lastTradeSize = v; break;
+                case FieldSettlementPrice: settlement = v / PriceScale; break;
+                case FieldVwapPrice: vwap = v / PriceScale; break;
+                case FieldNumberOfTrades: trades = v; break;
+                case FieldOpenInterest: openInterest = v; break;
+                case FieldPriceBandLow: bandLow = v / PriceScale; break;
+                case FieldPriceBandHigh: bandHigh = v / PriceScale; break;
+                case FieldTradingReferencePrice: refPx = v / PriceScale; break;
+                case FieldTradeVolume: volume = v; break;
+                case FieldTradingStatus: status = v; break;
+                case FieldTradingEvent: evt = v; break;
+                // Other bits (TheoreticalOpening*, Auction*, NetChange,
+                // AvgDailyTradedQty, MaxTradeVol, PriceLimitType,
+                // MinPriceIncrement) are consumed but not surfaced in
+                // the v1 typed event.
+            }
+        }
+
+        return new InfoSnapshotEvent
+        {
+            SecurityId = secId,
+            Symbol = symbol,
+            ReceivedUtc = receivedUtc,
+            OpeningPrice = opening,
+            ClosingPrice = closing,
+            HighPrice = high,
+            LowPrice = low,
+            LastTradePrice = lastTradePrice,
+            LastTradeSize = lastTradeSize,
+            SettlementPrice = settlement,
+            VwapPrice = vwap,
+            NumberOfTrades = trades,
+            OpenInterest = openInterest,
+            PriceBandLow = bandLow,
+            PriceBandHigh = bandHigh,
+            TradingReferencePrice = refPx,
+            TradeVolume = volume,
+            TradingStatus = status,
+            TradingEvent = evt,
+        };
+    }
+}

--- a/tests/B3.MarketData.WebSocketClient.Tests/B3.MarketData.WebSocketClient.Tests.csproj
+++ b/tests/B3.MarketData.WebSocketClient.Tests/B3.MarketData.WebSocketClient.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.MarketData.WebSocketClient\B3.MarketData.WebSocketClient.csproj" />
+    <!-- The integration test reuses WebSocketHost / SubscriptionManager / WireProtocol
+         to exercise the SDK end-to-end against the real server. -->
+    <ProjectReference Include="..\..\src\B3.Umdf.Server\B3.Umdf.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -1,0 +1,256 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using B3.MarketData.WebSocketClient;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+/// <summary>
+/// End-to-end test of <see cref="MarketDataClient"/> against a tiny
+/// in-process WebSocket server that speaks the B3MarketDataPlatform
+/// binary wire format. Covers the typical reference-price flow:
+/// <c>ServerStatus → SubscribeOk → Trade → InfoSnapshot</c>, plus
+/// <c>SubscribeError</c>.
+/// </summary>
+public class MarketDataClientIntegrationTests
+{
+    private static int FindFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    [Fact]
+    public async Task SubscribeOk_Then_Trade_DecodesAndScalesPrice()
+    {
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            // Wait for the SDK's Subscribe frame, then push back
+            // SubscribeOk + Trade.
+            var sym = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 12345, sym, ct);
+            await TestWsServer.SendTradeAsync(ws, securityId: 12345, price: 36_7800, qty: 100, tradeId: 1, ct);
+
+            // Hold the socket open until the test cancels.
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        var receivedTrade = new TaskCompletionSource<TradeEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.Trade += t => receivedTrade.TrySetResult(t);
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4");
+
+        var trade = await receivedTrade.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(12345UL, trade.SecurityId);
+        Assert.Equal("PETR4", trade.Symbol);
+        Assert.Equal(36.78m, trade.Price);
+        Assert.Equal(100L, trade.Qty);
+        Assert.Equal(1L, trade.TradeId);
+        Assert.True(client.TryGetSecurityId("PETR4", out var resolved));
+        Assert.Equal(12345UL, resolved);
+    }
+
+    [Fact]
+    public async Task SubscribeError_IsSurfacedAsTypedEvent()
+    {
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var sym = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            await TestWsServer.SendSubscribeErrorAsync(ws, sym, errorCode: 0x01, ct); // UnknownSymbol
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        var got = new TaskCompletionSource<SubscribeErrorEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.SubscribeError += e => got.TrySetResult(e);
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("UNKWN");
+
+        var err = await got.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("UNKWN", err.Symbol);
+        Assert.Equal(SubscribeErrorCode.UnknownSymbol, err.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Reconnect_TransparentlyReSubscribes()
+    {
+        var port = FindFreePort();
+        int subscribesSeen = 0;
+        var firstSubscribeReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSubscribeReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var sym = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            int n = Interlocked.Increment(ref subscribesSeen);
+            if (n == 1) firstSubscribeReceived.TrySetResult(true);
+            else if (n == 2) secondSubscribeReceived.TrySetResult(true);
+
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 7, sym, ct);
+
+            if (n == 1)
+            {
+                // Force the SDK to reconnect by closing the socket.
+                await ws.CloseAsync(WebSocketCloseStatus.EndpointUnavailable, "test reconnect", ct);
+                return;
+            }
+
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+            ReconnectInitialDelay = TimeSpan.FromMilliseconds(50),
+            ReconnectMaxDelay = TimeSpan.FromMilliseconds(200),
+        });
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4");
+
+        await firstSubscribeReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        // After the server closes, the SDK should reconnect and re-issue Subscribe.
+        await secondSubscribeReceived.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(subscribesSeen >= 2, $"expected ≥ 2 subscribes after reconnect, saw {subscribesSeen}");
+    }
+
+    private static async Task WaitUntil(Func<bool> pred, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (pred()) return;
+            await Task.Delay(20);
+        }
+    }
+}
+
+/// <summary>
+/// Minimal in-process WebSocket server used to drive the SDK from tests.
+/// Hosts a single <c>/ws</c> endpoint that hands the open socket to the
+/// caller-supplied handler. The handler is responsible for the
+/// per-test conversation; cancellation is passed through on dispose.
+/// </summary>
+internal sealed class TestWsServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly CancellationTokenSource _cts = new();
+
+    private TestWsServer(WebApplication app) { _app = app; }
+
+    public static async Task<TestWsServer> StartAsync(int port, Func<WebSocket, CancellationToken, Task> handler)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
+        builder.Logging.ClearProviders();
+        var app = builder.Build();
+        app.UseWebSockets(new WebSocketOptions { KeepAliveInterval = TimeSpan.FromSeconds(30) });
+        var server = new TestWsServer(app);
+        app.Map("/ws", async (HttpContext ctx) =>
+        {
+            if (!ctx.WebSockets.IsWebSocketRequest) { ctx.Response.StatusCode = 400; return; }
+            using var ws = await ctx.WebSockets.AcceptWebSocketAsync();
+            try { await handler(ws, server._cts.Token); }
+            catch (OperationCanceledException) { /* shutdown */ }
+            catch { /* swallow — server side */ }
+        });
+        await app.StartAsync();
+        return server;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        try { await _app.StopAsync(); } catch { }
+        await _app.DisposeAsync();
+        _cts.Dispose();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    public static async Task<string> ReadSubscribeAsync(WebSocket ws, CancellationToken ct)
+    {
+        var buffer = new byte[1024];
+        int filled = 0;
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer, filled, buffer.Length - filled), ct);
+            filled += result.Count;
+        } while (!result.EndOfMessage);
+
+        // [len u16][type u16=0x0001][flags u8][symLen u8][symbol]
+        ushort len = BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        ushort type = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(2));
+        if (type != 0x0001) throw new InvalidOperationException($"expected Subscribe, got 0x{type:X4}");
+        byte symLen = buffer[5];
+        return Encoding.UTF8.GetString(buffer, 6, symLen);
+    }
+
+    public static Task SendSubscribeOkAsync(WebSocket ws, ulong securityId, string symbol, CancellationToken ct)
+    {
+        // [len u16][type u16=0x0010][secId u64][flags u8][symLen u8][symbol]
+        var symBytes = Encoding.UTF8.GetBytes(symbol);
+        ushort total = (ushort)(4 + 8 + 1 + 1 + symBytes.Length);
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0010);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), securityId);
+        buf[12] = (byte)0x10; // Trades flag
+        buf[13] = (byte)symBytes.Length;
+        symBytes.CopyTo(buf, 14);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendSubscribeErrorAsync(WebSocket ws, string symbol, byte errorCode, CancellationToken ct)
+    {
+        // [len u16][type u16=0x0011][errorCode u8][symLen u8][symbol]
+        var symBytes = Encoding.UTF8.GetBytes(symbol);
+        ushort total = (ushort)(4 + 1 + 1 + symBytes.Length);
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0011);
+        buf[4] = errorCode;
+        buf[5] = (byte)symBytes.Length;
+        symBytes.CopyTo(buf, 6);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendTradeAsync(WebSocket ws, ulong securityId, long price, long qty, long tradeId, CancellationToken ct)
+    {
+        // [len u16][type u16=0x0033][secId u64][price i64][qty i64][tradeId i64]
+        const ushort total = 4 + 8 + 8 + 8 + 8;
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0033);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), securityId);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(12), price);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(20), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(28), tradeId);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+}

--- a/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
@@ -1,0 +1,86 @@
+using B3.MarketData.WebSocketClient;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+/// <summary>
+/// Pure-decode tests for <see cref="WireFormat"/>. These don't open a
+/// socket — they encode bytes the same way the server's
+/// <c>WireProtocol</c> does and assert the SDK decodes them into the
+/// typed events.
+/// </summary>
+public class WireFormatTests
+{
+    [Fact]
+    public void Trade_RoundTrip_ScalesPriceWithSbeExponent()
+    {
+        // Encode a Trade frame the way the server would.
+        Span<byte> buf = stackalloc byte[36];
+        WriteServerTradeFrame(buf, securityId: 42, price: 12_3456, qty: 100, tradeId: 7);
+
+        Assert.True(WireFormat.TryReadHeader(buf, out var len, out var type));
+        Assert.Equal(36, len);
+        Assert.Equal(WireFormat.MessageType.Trade, type);
+
+        var (secId, price, qty, tradeId) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        Assert.Equal(42UL, secId);
+        Assert.Equal(12_3456L, price);
+        Assert.Equal(100L, qty);
+        Assert.Equal(7L, tradeId);
+
+        // Scaling: raw 12_3456 with exponent -4 == 12.3456
+        decimal scaled = price / WireFormat.PriceScale;
+        Assert.Equal(12.3456m, scaled);
+    }
+
+    [Fact]
+    public void Subscribe_FramesContainFlagsAndSymbol()
+    {
+        Span<byte> buf = stackalloc byte[64];
+        int len = WireFormat.WriteSubscribe(buf, SubscribeFlags.Trades | SubscribeFlags.Info, "PETR4");
+
+        Assert.True(WireFormat.TryReadHeader(buf, out var totalLen, out var type));
+        Assert.Equal(len, totalLen);
+        Assert.Equal(WireFormat.MessageType.Subscribe, type);
+        // [flags=0x12][symLen=5][PETR4]
+        Assert.Equal((byte)0x12, buf[4]);
+        Assert.Equal((byte)5, buf[5]);
+        Assert.Equal((byte)'P', buf[6]);
+        Assert.Equal((byte)'4', buf[10]);
+    }
+
+    [Fact]
+    public void InfoSnapshot_DecodesOnlySetFields_AndAppliesPriceScale()
+    {
+        // Set bits: LastTradePrice (4) and LastTradeSize (5).
+        uint mask = (1u << WireFormat.FieldLastTradePrice) | (1u << WireFormat.FieldLastTradeSize);
+        Span<byte> buf = stackalloc byte[256];
+        // header(4) + secId(8) + mask(4) + 2 * i64
+        ushort total = 4 + 8 + 4 + 16;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.InfoSnapshot);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 99UL);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf[12..], mask);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[16..], 25_5000L); // 25.5000
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[24..], 200L);
+
+        var ev = WireFormat.ReadInfoSnapshot(buf[4..total], "PETR4", DateTime.UtcNow);
+        Assert.Equal(99UL, ev.SecurityId);
+        Assert.Equal("PETR4", ev.Symbol);
+        Assert.Equal(25.5m, ev.LastTradePrice);
+        Assert.Equal(200L, ev.LastTradeSize);
+        // Unset fields stay null.
+        Assert.Null(ev.OpeningPrice);
+        Assert.Null(ev.VwapPrice);
+    }
+
+    private static void WriteServerTradeFrame(Span<byte> dest, ulong securityId, long price, long qty, long tradeId)
+    {
+        const ushort totalLen = 4 + 8 + 8 + 8 + 8;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)WireFormat.MessageType.Trade);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[12..], price);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[20..], qty);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[28..], tradeId);
+    }
+}


### PR DESCRIPTION
Closes #5.

Adds the **`B3.MarketData.WebSocketClient`** NuGet package — a typed C# SDK over the WebSocket distribution layer. Covers the v1 scope listed in the issue: Trades, Info, ServerStatus, TradeBust, SubscribeError, reconnect+replay, DI, bounded back-pressure, SourceLink + deterministic build.

## What ships

- `src/B3.MarketData.WebSocketClient/` — new project (`net10.0`, MIT, IsPackable, README packed, SourceLink via `Microsoft.SourceLink.GitHub`).
- Public API: `MarketDataClient`, `MarketDataClientOptions`, `SubscribeFlags`, event records (`TradeEvent`, `TradeBustEvent`, `InfoSnapshotEvent`, `ServerStatusEvent`, `SubscribeErrorEvent`, `ConnectionStateChangedEvent`), `AddMarketDataClient` DI extension.
- Wire codec mirrors the subset of `src/B3.Umdf.Server/WireProtocol.cs` consumers need; handles coalesced WS frames; applies the SBE `-4` price exponent (`decimal` already scaled).
- Bounded `Channel<Action>` for back-pressure with **DropOldest** default (`Block`, `Throw` also supported); `DroppedEventCount` exposed.
- Reconnect: exponential backoff 250 ms → 30 s with ~25 % additive jitter, automatic re-issue of every active subscription on the new socket.

## Tests

`tests/B3.MarketData.WebSocketClient.Tests` — xunit, all green (6 tests, plus full suite still 100 % green):
- `WireFormatTests` — pure decode + price-scale round-trip + Subscribe encoding.
- `MarketDataClientIntegrationTests` — end-to-end against an in-process WebSocket server: SubscribeOk + Trade flow, SubscribeError surfaced as typed event, reconnect-replay (server force-closes, SDK reconnects, re-issues Subscribe transparently).

## Docs

- `docs/CLIENT-SDK.md` — quickstart, DI, reconnect, back-pressure table.
- README docs index links the new doc.

## Bug found while writing tests

The `SubscribeError` dispatch threw `ArgumentException` because `Enum.IsDefined(typeof(SubscribeErrorCode), (int)code)` was passed an `int` when the enum's underlying type is `byte`. Fixed by passing the `byte` value directly. The integration test for SubscribeError caught it.