### PR TITLE
Add NuGet release workflow for the WebSocketClient SDK

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,80 @@
+name: Publish NuGet — B3.MarketData.WebSocketClient
+
+# Publishes the SDK to nuget.org when a tag matching `v*` is pushed
+# (e.g. `v0.1.0`, `v0.2.0-preview.1`). The tag itself drives the
+# package version so we don't have to bump the csproj for every release.
+#
+# Required repo secret: `NUGET_API_KEY` — a nuget.org API key with
+# "Push new packages and package versions" scope for the
+# `B3.MarketData.WebSocketClient` package id.
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Override package version (e.g. 0.1.0). Leave empty to use the tag.'
+        required: false
+        default: ''
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Resolve package version
+        id: ver
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            ver="${{ inputs.version }}"
+          else
+            tag="${GITHUB_REF##*/}"
+            ver="${tag#v}"
+          fi
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+          echo "Resolved package version: $ver"
+
+      - name: Restore
+        run: dotnet restore src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+
+      - name: Build
+        run: dotnet build src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj -c Release --no-restore -p:PackageVersion=${{ steps.ver.outputs.version }}
+
+      - name: Test (full suite)
+        run: dotnet test B3MarketDataPlatform.slnx -c Release --verbosity minimal
+
+      - name: Pack
+        run: dotnet pack src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.ver.outputs.version }}
+
+      - name: List artifacts
+        run: ls -la ./artifacts
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: ./artifacts/*.*nupkg
+
+      - name: Push to nuget.org
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::NUGET_API_KEY secret is not configured."
+            exit 1
+          fi
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "$NUGET_API_KEY" \
+            --skip-duplicate

--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -7,7 +7,7 @@
     <!-- Packaging -->
     <IsPackable>true</IsPackable>
     <PackageId>B3.MarketData.WebSocketClient</PackageId>
-    <Version>0.1.0</Version>
+    <Version Condition="'$(PackageVersion)' == ''">0.1.0</Version>
     <Authors>pedrosakuma</Authors>
     <Description>Typed C# subscriber SDK for the B3MarketDataPlatform WebSocket distribution layer (v1: trades, info snapshots, server status). Built-in reconnect with transparent re-subscribe and bounded back-pressure.</Description>
     <PackageTags>b3;marketdata;websocket;sdk;trades;reference-price</PackageTags>


### PR DESCRIPTION
Pipeline para publicar `B3.MarketData.WebSocketClient` no nuget.org.

## Como dispara
- **Push de tag `v*`** (ex.: `v0.1.0`, `v0.2.0-preview.1`). O nome da tag (sem o `v`) vira a versão do pacote via `-p:PackageVersion`.
- **`workflow_dispatch`** com input `version` opcional, pra disparos manuais.

## Etapas
```
restore → build → dotnet test (suite completa) → pack (.nupkg + .snupkg)
        → upload-artifact → dotnet nuget push --skip-duplicate
```

## Mudança no csproj
`<Version>` virou condicional (`'$(PackageVersion)' == ''`), então:
- `dotnet pack` local ainda gera `0.1.0` por padrão.
- CI sobrescreve via `-p:PackageVersion=<versão da tag>` sem precisar commitar bump.

## O que falta fora do PR (você precisa fazer)
1. Reservar/registrar o id `B3.MarketData.WebSocketClient` no nuget.org.
2. Gerar uma API key (escopo *Push new packages and package versions* para esse id) e adicionar como secret `NUGET_API_KEY` no repo.
3. Após merge, criar a primeira release: `git tag v0.1.0 && git push origin v0.1.0`.

## Validação local
`dotnet pack ... -p:PackageVersion=0.1.0-test` produziu `.nupkg` + `.snupkg` corretamente.