### PR TITLE
Docs: point consumers at the published NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,11 @@ MARKETDATA_TAG=v1.0.0 docker compose -f docker-compose.yml -f docker-compose.ghc
 The frontend is a dev-only demo UI and is **not** published to GHCR; it
 continues to build locally from `./frontend` in both modes. Downstream
 services (e.g. `B3TradingPlatform`) consume the backend's WebSocket
-directly — see [docs/WEBSOCKET_API.md](docs/WEBSOCKET_API.md).
+directly — see [docs/WEBSOCKET_API.md](docs/WEBSOCKET_API.md). For .NET
+consumers, the typed SDK is published on NuGet:
+[`B3.MarketData.WebSocketClient`](https://www.nuget.org/packages/B3.MarketData.WebSocketClient)
+(`dotnet add package B3.MarketData.WebSocketClient`) — see
+[docs/CLIENT-SDK.md](docs/CLIENT-SDK.md).
 
 ## B3 schema
 

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -1,5 +1,7 @@
 # Client SDK — `B3.MarketData.WebSocketClient`
 
+[![NuGet](https://img.shields.io/nuget/v/B3.MarketData.WebSocketClient.svg)](https://www.nuget.org/packages/B3.MarketData.WebSocketClient)
+
 A typed, allocation-aware C# SDK for consuming the
 B3MarketDataPlatform WebSocket distribution layer. The package wraps
 the binary wire protocol described in
@@ -10,11 +12,23 @@ reconnect + replay transparently.
 
 | Item | Value |
 |------|-------|
-| Package id | `B3.MarketData.WebSocketClient` |
+| Package id | [`B3.MarketData.WebSocketClient`](https://www.nuget.org/packages/B3.MarketData.WebSocketClient) |
 | Target | `net10.0` |
 | License | MIT |
 | Public surface | `MarketDataClient`, `MarketDataClientOptions`, event records, `SubscribeFlags` |
 | Source | `src/B3.MarketData.WebSocketClient/` |
+
+## Install
+
+```sh
+dotnet add package B3.MarketData.WebSocketClient
+```
+
+Or pin a specific version in your `csproj`:
+
+```xml
+<PackageReference Include="B3.MarketData.WebSocketClient" Version="0.1.0" />
+```
 
 ## Quickstart
 

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -10,6 +10,12 @@ info snapshots, server status) — the same surface documented in
 exposed as typed events with the SBE 4-decimal price exponent already
 applied so consumers never see the raw `i64` mantissa.
 
+## Install
+
+```sh
+dotnet add package B3.MarketData.WebSocketClient
+```
+
 ```csharp
 using B3.MarketData.WebSocketClient;
 


### PR DESCRIPTION
Pequeno follow-up do release `v0.1.0` no nuget.org.

- `docs/CLIENT-SDK.md`: badge do NuGet + seção **Install** com `dotnet add package` e snippet de `<PackageReference>`.
- `src/B3.MarketData.WebSocketClient/README.md` (readme empacotado no .nupkg): mesmo snippet de install antes do quickstart.
- `README.md`: menção breve na seção da WebSocket API apontando pro pacote.