### PR TITLE
Add unicast transport mode for bridge-network compose deployments

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,15 +112,35 @@ publisher (`--replay-to-multicast --multicast-config`).
 
 Optional channel fields:
 
+- `transport` — `multicast` (default) or `unicast`. Set to `unicast` for Docker Compose bridge networks where the publisher (e.g. `B3MatchingPlatform`'s `exchange-simulator` in bridge mode) emits UMDF as plain UDP and IPv4 multicast is not forwarded between sibling containers. In `unicast` mode the consumer binds to `multicastGroup`:`port` (treat `multicastGroup` as the bind address; typically `0.0.0.0`, or a specific NIC IP) and skips the IGMP join entirely. `sourceAddress` and `localAddress` are rejected in `unicast` mode because they are IGMP/SSM-only. See [issue #10](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/10).
 - `sourceAddress` — enables source-specific multicast (SSM), receiving only from the given sender IP.
 - `localAddress` — selects the local NIC/IP used for the multicast membership join (ASM or SSM).
 - `receiveBufferBytes` — per-socket UDP receive buffer size. When omitted, the consumer picks per-channel-type defaults: **16 MiB** for `IncrementalA`/`IncrementalB`, **8 MiB** for `SnapshotRecovery`, **2 MiB** for `InstrumentDefinition`. All values are still capped by `net.core.rmem_max`.
+
+Example — unicast (Docker Compose bridge):
+
+```json
+{
+  "channelGroups": [
+    {
+      "name": "EQT",
+      "channels": [
+        { "channelId": 84, "type": "IncrementalA",        "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30084 },
+        { "channelId": 84, "type": "IncrementalB",        "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30085 },
+        { "channelId": 84, "type": "InstrumentDefinition","transport": "unicast", "multicastGroup": "0.0.0.0", "port": 31084 },
+        { "channelId": 84, "type": "SnapshotRecovery",    "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 30184 }
+      ]
+    }
+  ]
+}
+```
 
 When `--replay-to-multicast` is enabled, the same JSON is reused as the publish map:
 
 - `multicastGroup` + `port` become the destination endpoint.
 - `localAddress` becomes the optional local bind/interface for outgoing multicast.
 - `sourceAddress` is ignored in publisher mode.
+- `transport` is ignored in publisher mode (replay-to-multicast only emits multicast; for unicast publishing use `B3MatchingPlatform`'s exchange-simulator).
 - `channelGroups` count/order must match the replay input order so `groupId → multicast route` stays deterministic.
 
 > **Note on `receiveSocketCount`** — exists in `ChannelEntryConfig` to bind multiple sockets per channel via `SO_REUSEPORT`. On **Linux multicast** every bound socket receives a *copy* of each datagram (REUSEPORT only load-balances unicast). Replicating sockets multiplies CPU cost without enlarging the effective kernel buffer. Leave at `1` for multicast and rely on `rmem_max` instead.

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -312,7 +312,12 @@ else if (multicastConfig is not null)
         int g = feedConfig.ChannelGroups.IndexOf(group);
         Console.WriteLine($"  Channel group {g}: {group.Name}");
         foreach (var ch in group.Channels)
-            Console.WriteLine($"    {ch.Type,-25} <- {ch.MulticastGroup}:{ch.Port}");
+        {
+            var transport = MulticastFeedConfig.ParseTransport(ch.Transport);
+            Console.WriteLine(transport == TransportKind.Unicast
+                ? $"    {ch.Type,-25} <- unicast {ch.MulticastGroup}:{ch.Port}"
+                : $"    {ch.Type,-25} <- {ch.MulticastGroup}:{ch.Port}");
+        }
     }
 
     var multicastSources = new List<MulticastPacketSource>();

--- a/src/B3.Umdf.Transport/ChannelConfig.cs
+++ b/src/B3.Umdf.Transport/ChannelConfig.cs
@@ -11,4 +11,5 @@ public sealed record ChannelConfig(
     IPAddress? LocalAddress = null,
     int ReceiveBufferBytes = 16 * 1024 * 1024,
     int ChannelGroup = 0,
-    int ReceiveSocketCount = 1);
+    int ReceiveSocketCount = 1,
+    TransportKind Transport = TransportKind.Multicast);

--- a/src/B3.Umdf.Transport/MulticastFeedConfig.cs
+++ b/src/B3.Umdf.Transport/MulticastFeedConfig.cs
@@ -43,10 +43,27 @@ public sealed class MulticastFeedConfig
                     LocalAddress: ch.LocalAddress is not null ? IPAddress.Parse(ch.LocalAddress) : null,
                     ReceiveBufferBytes: ch.ReceiveBufferBytes ?? DefaultReceiveBufferBytesFor(ch.Type),
                     ChannelGroup: g,
-                    ReceiveSocketCount: Math.Max(1, ch.ReceiveSocketCount ?? 1)));
+                    ReceiveSocketCount: Math.Max(1, ch.ReceiveSocketCount ?? 1),
+                    Transport: ParseTransport(ch.Transport)));
             }
         }
         return configs;
+    }
+
+    /// <summary>
+    /// Parses the optional <c>transport</c> field. Accepts "multicast" and "unicast"
+    /// (case-insensitive). Null/empty → <see cref="TransportKind.Multicast"/> (back-compat).
+    /// </summary>
+    public static TransportKind ParseTransport(string? transport)
+    {
+        if (string.IsNullOrWhiteSpace(transport))
+            return TransportKind.Multicast;
+        if (transport.Equals("multicast", StringComparison.OrdinalIgnoreCase))
+            return TransportKind.Multicast;
+        if (transport.Equals("unicast", StringComparison.OrdinalIgnoreCase))
+            return TransportKind.Unicast;
+        throw new InvalidOperationException(
+            $"Invalid transport '{transport}'. Expected 'multicast' or 'unicast'.");
     }
 
     /// <summary>
@@ -137,6 +154,18 @@ public sealed class ChannelEntryConfig
     /// </summary>
     [JsonPropertyName("receiveSocketCount")]
     public int? ReceiveSocketCount { get; set; }
+
+    /// <summary>
+    /// Wire transport for ingest. Optional; defaults to <c>multicast</c> for
+    /// back-compat. Set to <c>unicast</c> to bind to <see cref="MulticastGroup"/>:<see cref="Port"/>
+    /// without issuing an IGMP join. Required for Docker Compose bridge networks where
+    /// the publisher (e.g. B3MatchingPlatform's exchange-simulator) emits unicast UDP.
+    /// In <c>unicast</c> mode <see cref="MulticastGroup"/> is the bind address (typically
+    /// <c>0.0.0.0</c>) and <see cref="SourceAddress"/>/<see cref="LocalAddress"/> are
+    /// rejected because they are IGMP/SSM-only.
+    /// </summary>
+    [JsonPropertyName("transport")]
+    public string? Transport { get; set; }
 }
 
 [JsonSerializable(typeof(MulticastFeedConfig))]

--- a/src/B3.Umdf.Transport/MulticastPacketSource.cs
+++ b/src/B3.Umdf.Transport/MulticastPacketSource.cs
@@ -18,6 +18,7 @@ public sealed class MulticastPacketSource : IPacketSource
     private readonly Socket _socket;
     private readonly ChannelType _channelType;
     private readonly int _channelGroup;
+    private readonly TransportKind _transport;
     private readonly ILogger _logger;
 
     // Membership info retained so we can leave and rejoin the multicast group on demand
@@ -55,6 +56,7 @@ public sealed class MulticastPacketSource : IPacketSource
 
     public ChannelType ChannelType => _channelType;
     public int ChannelGroup => _channelGroup;
+    public TransportKind Transport => _transport;
     public bool IsJoined { get { lock (_membershipLock) return _isJoined; } }
 
     // Test-only: exposes whether the recvmmsg batch state (POH buffer pool +
@@ -71,8 +73,24 @@ public sealed class MulticastPacketSource : IPacketSource
         if (config.LocalAddress is not null)
             ValidateIPv4(config.LocalAddress, nameof(config.LocalAddress));
 
+        // Unicast transport: bind only, no IGMP join. SourceAddress/LocalAddress are
+        // IGMP/SSM-only — reject explicitly so misconfigurations fail fast instead of
+        // being silently ignored. See issue #10 (Docker Compose bridge deployments).
+        if (config.Transport == TransportKind.Unicast)
+        {
+            if (config.SourceAddress is not null)
+                throw new ArgumentException(
+                    "sourceAddress is not valid with transport=unicast (it is a source-specific multicast / IGMP-only field).",
+                    nameof(config));
+            if (config.LocalAddress is not null)
+                throw new ArgumentException(
+                    "localAddress is not valid with transport=unicast (it is a multicast membership / IGMP-only field). Use multicastGroup as the bind address (e.g. 0.0.0.0 or a specific NIC IP).",
+                    nameof(config));
+        }
+
         _channelType = config.Type;
         _channelGroup = config.ChannelGroup;
+        _transport = config.Transport;
         _multicastGroup = config.MulticastGroup;
         _port = config.Port;
         _localAddress = config.LocalAddress;
@@ -114,7 +132,15 @@ public sealed class MulticastPacketSource : IPacketSource
 
         socket.ReceiveBufferSize = config.ReceiveBufferBytes;
         int actualReceiveBufferBytes = socket.ReceiveBufferSize;
-        socket.Bind(new IPEndPoint(IPAddress.Any, config.Port));
+
+        // Multicast: bind to wildcard so the kernel delivers any datagram for the joined
+        // group/port regardless of the destination IP carried by the NIC.
+        // Unicast: bind to the configured address (typically 0.0.0.0; can be a NIC IP
+        // to restrict ingress to a single interface).
+        var bindAddress = config.Transport == TransportKind.Unicast
+            ? config.MulticastGroup
+            : IPAddress.Any;
+        socket.Bind(new IPEndPoint(bindAddress, config.Port));
 
         if (actualReceiveBufferBytes < config.ReceiveBufferBytes)
         {
@@ -129,7 +155,16 @@ public sealed class MulticastPacketSource : IPacketSource
                 config.ReceiveBufferBytes);
         }
 
-        if (config.SourceAddress is not null)
+        if (config.Transport == TransportKind.Unicast)
+        {
+            // No IGMP join: the kernel delivers unicast datagrams addressed to (bind, port)
+            // directly. _isJoined is set true so callers treat the source as "ready to receive";
+            // Leave/Rejoin become no-ops (see those methods).
+            _logger.LogInformation(
+                "Listening unicast UDP on {Bind}:{Port} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes})",
+                bindAddress, config.Port, _channelType, _channelGroup, actualReceiveBufferBytes);
+        }
+        else if (config.SourceAddress is not null)
         {
             var localAddress = config.LocalAddress ?? IPAddress.Any;
             socket.SetSocketOption(
@@ -172,6 +207,7 @@ public sealed class MulticastPacketSource : IPacketSource
     /// </summary>
     public void LeaveMulticastGroup()
     {
+        if (_transport == TransportKind.Unicast) return;
         lock (_membershipLock)
         {
             if (!_isJoined) return;
@@ -222,6 +258,7 @@ public sealed class MulticastPacketSource : IPacketSource
     /// </summary>
     public void RejoinMulticastGroup()
     {
+        if (_transport == TransportKind.Unicast) return;
         lock (_membershipLock)
         {
             if (_isJoined) return;

--- a/src/B3.Umdf.Transport/TransportKind.cs
+++ b/src/B3.Umdf.Transport/TransportKind.cs
@@ -1,0 +1,22 @@
+namespace B3.Umdf.Transport;
+
+/// <summary>
+/// Wire transport selected per channel for ingest.
+/// </summary>
+public enum TransportKind
+{
+    /// <summary>
+    /// IPv4 multicast (default). The configured group address must be in 224.0.0.0/4
+    /// and the consumer issues an IGMP join (ASM) or source-specific join (SSM).
+    /// </summary>
+    Multicast = 0,
+
+    /// <summary>
+    /// Plain unicast UDP. The consumer binds to <see cref="ChannelConfig.MulticastGroup"/>
+    /// (treated as bind address; typically <c>0.0.0.0</c>) and <see cref="ChannelConfig.Port"/>
+    /// without issuing any IGMP join. Required for Docker Compose bridge networks where
+    /// IPv4 multicast is not forwarded between sibling containers and the publisher
+    /// (e.g. B3MatchingPlatform's exchange-simulator) emits UMDF frames as unicast UDP.
+    /// </summary>
+    Unicast = 1,
+}

--- a/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceUnicastTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceUnicastTests.cs
@@ -1,0 +1,175 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Transport.Tests;
+
+public class MulticastPacketSourceUnicastTests
+{
+    [Fact]
+    public void ParseTransport_DefaultsToMulticast()
+    {
+        Assert.Equal(TransportKind.Multicast, MulticastFeedConfig.ParseTransport(null));
+        Assert.Equal(TransportKind.Multicast, MulticastFeedConfig.ParseTransport(""));
+        Assert.Equal(TransportKind.Multicast, MulticastFeedConfig.ParseTransport("multicast"));
+        Assert.Equal(TransportKind.Multicast, MulticastFeedConfig.ParseTransport("MULTICAST"));
+    }
+
+    [Fact]
+    public void ParseTransport_AcceptsUnicastCaseInsensitive()
+    {
+        Assert.Equal(TransportKind.Unicast, MulticastFeedConfig.ParseTransport("unicast"));
+        Assert.Equal(TransportKind.Unicast, MulticastFeedConfig.ParseTransport("Unicast"));
+        Assert.Equal(TransportKind.Unicast, MulticastFeedConfig.ParseTransport("UNICAST"));
+    }
+
+    [Fact]
+    public void ParseTransport_RejectsUnknownValues()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => MulticastFeedConfig.ParseTransport("tcp"));
+        Assert.Contains("multicast", ex.Message);
+        Assert.Contains("unicast", ex.Message);
+    }
+
+    [Fact]
+    public void Load_ParsesUnicastTransportField()
+    {
+        var json = """
+        {
+          "channelGroups": [{
+            "name": "EQT",
+            "channels": [
+              { "channelId": 84, "type": "IncrementalA",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": 0 },
+              { "channelId": 84, "type": "IncrementalB",                                  "multicastGroup": "224.0.20.85", "port": 30085 }
+            ]
+          }]
+        }
+        """;
+
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, json);
+            var configs = MulticastFeedConfig.Load(tmp).ToChannelConfigs();
+            Assert.Equal(2, configs.Count);
+            Assert.Equal(TransportKind.Unicast, configs[0].Transport);
+            Assert.Equal(TransportKind.Multicast, configs[1].Transport);
+        }
+        finally { File.Delete(tmp); }
+    }
+
+    [Fact]
+    public void Ctor_Unicast_BindsAndDoesNotJoinMulticastGroup()
+    {
+        var config = new ChannelConfig(
+            ChannelId: 1,
+            Type: ChannelType.IncrementalA,
+            MulticastGroup: IPAddress.Any,
+            Port: 0,
+            ReceiveBufferBytes: 64 * 1024,
+            Transport: TransportKind.Unicast);
+
+        using var src = new MulticastPacketSource(config);
+
+        Assert.Equal(TransportKind.Unicast, src.Transport);
+        Assert.True(src.IsJoined, "unicast source should report ready");
+        Assert.Equal(1, src.MembershipJoins);
+    }
+
+    [Fact]
+    public async Task Ctor_Unicast_ReceivesLoopbackDatagram()
+    {
+        // Bind to ephemeral port on loopback, send a unicast datagram to it,
+        // verify the source returns it without ever issuing an IGMP join.
+        int port = GetEphemeralUdpPort();
+        var config = new ChannelConfig(
+            ChannelId: 1,
+            Type: ChannelType.IncrementalA,
+            MulticastGroup: IPAddress.Loopback,
+            Port: port,
+            ReceiveBufferBytes: 64 * 1024,
+            Transport: TransportKind.Unicast);
+
+        using var src = new MulticastPacketSource(config);
+
+        var payload = new byte[] { 1, 2, 3, 4, 5 };
+        using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+        {
+            sender.SendTo(payload, new IPEndPoint(IPAddress.Loopback, port));
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var pkt = await src.ReceiveAsync(cts.Token);
+        try
+        {
+            Assert.Equal(payload, pkt.Data.ToArray());
+            Assert.Equal(ChannelType.IncrementalA, pkt.Channel);
+        }
+        finally
+        {
+            pkt.Release();
+        }
+    }
+
+    [Fact]
+    public void Ctor_Unicast_RejectsSourceAddress()
+    {
+        var config = new ChannelConfig(
+            ChannelId: 1,
+            Type: ChannelType.IncrementalA,
+            MulticastGroup: IPAddress.Any,
+            Port: 0,
+            SourceAddress: IPAddress.Parse("10.0.0.1"),
+            ReceiveBufferBytes: 64 * 1024,
+            Transport: TransportKind.Unicast);
+
+        var ex = Assert.Throws<ArgumentException>(() => new MulticastPacketSource(config));
+        Assert.Contains("sourceAddress", ex.Message);
+    }
+
+    [Fact]
+    public void Ctor_Unicast_RejectsLocalAddress()
+    {
+        var config = new ChannelConfig(
+            ChannelId: 1,
+            Type: ChannelType.IncrementalA,
+            MulticastGroup: IPAddress.Any,
+            Port: 0,
+            LocalAddress: IPAddress.Parse("10.0.0.1"),
+            ReceiveBufferBytes: 64 * 1024,
+            Transport: TransportKind.Unicast);
+
+        var ex = Assert.Throws<ArgumentException>(() => new MulticastPacketSource(config));
+        Assert.Contains("localAddress", ex.Message);
+    }
+
+    [Fact]
+    public void LeaveAndRejoin_AreNoOpForUnicast()
+    {
+        var config = new ChannelConfig(
+            ChannelId: 1,
+            Type: ChannelType.IncrementalA,
+            MulticastGroup: IPAddress.Any,
+            Port: 0,
+            ReceiveBufferBytes: 64 * 1024,
+            Transport: TransportKind.Unicast);
+
+        using var src = new MulticastPacketSource(config);
+        long joinsBefore = src.MembershipJoins;
+        long leavesBefore = src.MembershipLeaves;
+
+        src.LeaveMulticastGroup();
+        src.RejoinMulticastGroup();
+
+        Assert.True(src.IsJoined, "unicast source IsJoined should remain true");
+        Assert.Equal(joinsBefore, src.MembershipJoins);
+        Assert.Equal(leavesBefore, src.MembershipLeaves);
+    }
+
+    private static int GetEphemeralUdpPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
Closes #10.

## Problem

`MulticastPacketSource` always called `SetMulticastOption(AddMembership, ...)` regardless of the configured group address, so any JSON config with a non-multicast `multicastGroup` (e.g. `0.0.0.0` for a Docker Compose bridge deployment) failed with `SocketException (22): Invalid argument` at startup. This blocked `B3TradingPlatform`'s `integration-real-stack-v1` from consuming UMDF unicast emitted by `B3MatchingPlatform`'s `exchange-simulator` (option A from `B3MatchingPlatform#88`).

## Approach — Option A from issue #10

Explicit opt-in `transport` field per channel (`multicast` default for back-compat, `unicast` to skip the IGMP join and just bind to `multicastGroup`:`port`). `sourceAddress` and `localAddress` are rejected with a clear `ArgumentException` in `unicast` mode because they are IGMP/SSM-only semantics, and `Leave/RejoinMulticastGroup` become no-ops (the snapshot-suspend state machine silently degrades to always-on for unicast, which is fine because there is no kernel-side multicast filtering to gain).

Scope: consumer-side only — `MulticastPacketSink` / `--replay-to-multicast` continue to emit multicast (use `B3MatchingPlatform`'s exchange-simulator for unicast publishing).

## Changes

- `src/B3.Umdf.Transport/TransportKind.cs` (new) — `enum { Multicast, Unicast }`.
- `ChannelConfig` — new `Transport` param (default `Multicast`, additive).
- `MulticastFeedConfig` — new optional JSON field `transport`; `ParseTransport()` (case-insensitive; rejects unknown values).
- `MulticastPacketSource` ctor — unicast path: skip multicast/SSM joins, bind to `(multicastGroup, port)`, reject `sourceAddress`/`localAddress`, log `Listening unicast UDP on …`.
- `MulticastPacketSource.Leave/RejoinMulticastGroup` — early-return for `Unicast`; counters untouched.
- `Program.cs` — startup banner shows `<- unicast bind:port` for unicast channels.
- `docs/CONFIGURATION.md` — new `transport` field documented with bridge-compose example.
- New `MulticastPacketSourceUnicastTests` (9 cases): parse paths, default → multicast, ctor binds + receives loopback datagram, rejects `sourceAddress`/`localAddress`, leave/rejoin no-ops.

## Validation

- Solution build: clean (0 warnings).
- Full test suite: **464 tests pass** across all 7 projects (12 in `B3.Umdf.Transport.Tests` including 9 new + 3 parse-only).

## Acceptance criteria (from issue #10)

- [x] Option A selected and documented (rationale: smallest change, explicit, mirrors publisher-side decision in `B3MatchingPlatform#88`).
- [x] Implemented in `MulticastPacketSource`. Sinks unchanged (out of scope per plan).
- [x] `docs/CONFIGURATION.md` updated.
- [ ] End-to-end docker-compose validation against `B3MatchingPlatform`'s `exchange-simulator.bridge.json` — to be confirmed downstream as part of `B3TradingPlatform`'s `integration-real-stack-v1`.

## Out of scope

- Sink / publisher / `--replay-to-multicast` unicast support.
- TCP transport.
- Multicast tuning, kernel buffer changes.