### PR TITLE
Allow single-group live push-mode (relax multi-group guard)

### DIFF
--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -472,8 +472,13 @@ FeedHandler? singleFeed = null;
 
 var feedLogger = loggerFactory.CreateLogger<FeedHandler>();
 
-if (groupIds.Count > 1)
+if (groupIds.Count > 1 || packetSource is null)
 {
+    // Live push-mode (multicast/unicast, packetSource == null): receive threads call
+    // PushPacket/PushPacketBatch directly — works for any group count, including 1
+    // (e.g. matching-platform's single-EQT bridge deployment, see issue #13).
+    // Source-driven mode (packetSource != null) keeps the multi-group MultiFeedManager
+    // it always used.
     multiFeed = packetSource is null
         ? new MultiFeedManager(
             groupFeedHandlers,
@@ -496,8 +501,8 @@ if (groupIds.Count > 1)
 }
 else
 {
-    if (packetSource is null)
-        throw new InvalidOperationException("Single-group live multicast mode is not supported; use multiple groups.");
+    // Source-driven single-group: replay path. FeedHandler avoids the per-group
+    // dispatcher overhead since there's exactly one source feeding one group.
     singleFeed = new FeedHandler(packetSource, groupFeedHandlers[groupIds[0]], feedLogger, marketDataHandler: groupMdHandlers[groupIds[0]]);
 }
 


### PR DESCRIPTION
Closes #13.

## Problem

`Program.cs:500` rejected any `channelGroups` of size 1 in live mode (`packetSource is null`) with:

```
System.InvalidOperationException: Single-group live multicast mode is not supported; use multiple groups.
```

Downstream worked around it by declaring a phantom DRV group with unicast binds on unused ports, just to satisfy the guard. Ugly enough to be worth fixing.

## Root cause

The guard predates the live push-mode path. It was correct when single-group meant only PCAP replay, which needs the merged `FeedHandler` constructor (`packetSource != null`). But for live multicast/unicast deployments — where receive threads call `MultiFeedManager.PushPacket` directly — `MultiFeedManager` already supports any group count ≥ 1:

- Documented push-mode ctor (`MultiFeedManager.cs:202`): "Live-push constructor with per-group handlers (no internal dispatcher)".
- Push-mode startup branch (`MultiFeedManager.cs:247-252`): "No source -> live push mode: receive threads will call PushPacket directly."
- Already exercised with a single group by `Feed.Tests/MultiFeedManagerTests.cs:50`: `new MultiFeedManager(new[] { 0 }, handler)`.

## Fix

Reroute the conditional in `Program.cs`: when `packetSource is null` (live push-mode), always use `MultiFeedManager`, regardless of group count. Single-group replay (`packetSource != null`) continues to use `FeedHandler` (no per-group dispatcher overhead).

```diff
- if (groupIds.Count > 1)
+ if (groupIds.Count > 1 || packetSource is null)
  {
      multiFeed = packetSource is null
          ? new MultiFeedManager(groupFeedHandlers, ...)
          : new MultiFeedManager(packetSource, groupFeedHandlers, ...);
      ...
  }
  else
  {
-     if (packetSource is null)
-         throw new InvalidOperationException("Single-group live multicast mode is not supported; use multiple groups.");
      singleFeed = new FeedHandler(packetSource, groupFeedHandlers[groupIds[0]], ...);
  }
```

## Why option 1 (transport-aware) wasn't picked

The issue suggested making the guard transport-aware (`unicast` only). But the multi-group restriction never had a transport reason — it was a wiring-mode limitation (push vs pull). Removing the guard for the entire push-mode path is more honest than gating it on `transport == unicast`, and it also fixes the symmetric multicast-with-one-group case if anyone ever runs into it.

## Validation

- Solution build: clean (0 warnings).
- Full suite: **464 tests pass** across 7 projects, including `MultiFeedManagerTests` which already validates single-group push-mode.
- Downstream: `B3TradingPlatform`'s `integration-real-stack-v1` can now drop the phantom DRV group from its real-stack overlay config.