### PR TITLE
fix(server,compose): WS 1001 close on shutdown + frontend gated on backend health (refs #18)

### DIFF
--- a/docker-compose.multicast.yml
+++ b/docker-compose.multicast.yml
@@ -67,5 +67,6 @@ services:
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     depends_on:
-      - consumer
+      consumer:
+        condition: service_healthy
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,6 @@ services:
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -689,7 +689,7 @@ subscriptionManager?.StopRankingsTimer();
 if (wsHost is not null)
 {
     await Task.Delay(TimeSpan.FromSeconds(shutdownDrainSeconds));
-    await wsHost.StopAsync();
+    await wsHost.StopAsync(TimeSpan.FromSeconds(shutdownDrainSeconds));
     await wsHost.DisposeAsync();
 }
 

--- a/src/B3.Umdf.Server/ClientSession.cs
+++ b/src/B3.Umdf.Server/ClientSession.cs
@@ -544,6 +544,32 @@ public sealed class ClientSession : IDisposable
         }
     }
 
+    /// <summary>
+    /// Send a clean WebSocket close frame (1001 Going Away by default; here we use
+    /// <see cref="WebSocketCloseStatus.EndpointUnavailable"/> which maps to status
+    /// code 1001) so the peer learns the server is shutting down rather than seeing
+    /// a TCP RST. Idempotent: no-op once the socket has left the Open state.
+    /// Bounded by the supplied <paramref name="cancellationToken"/> so the host's
+    /// shutdown drain budget remains in control.
+    /// </summary>
+    public async Task RequestGracefulCloseAsync(string statusDescription, CancellationToken cancellationToken)
+    {
+        if (Socket.State != WebSocketState.Open) return;
+        try
+        {
+            await Socket.CloseOutputAsync(
+                WebSocketCloseStatus.EndpointUnavailable,
+                statusDescription,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+        catch (WebSocketException ex)
+        {
+            _logger.LogWarning("Graceful close failed for {ClientId}: {Error}", Id, ex.Message);
+        }
+    }
+
     public void Cancel()
     {
         if (_cts.IsCancellationRequested)

--- a/src/B3.Umdf.Server/WebSocketHost.cs
+++ b/src/B3.Umdf.Server/WebSocketHost.cs
@@ -418,10 +418,38 @@ public sealed class WebSocketHost : IAsyncDisposable
         });
     }
 
-    public async Task StopAsync()
+    /// <summary>
+    /// Gracefully stop the host. Before tearing down Kestrel we send a clean
+    /// WebSocket close frame (1001 / EndpointUnavailable) to every active client
+    /// so they observe an orderly shutdown rather than a connection reset. The
+    /// per-client close handshake is bounded by <paramref name="closeHandshakeBudget"/>
+    /// (defaults to 5 seconds when unset) so a misbehaving peer cannot hold the
+    /// shutdown open indefinitely.
+    /// </summary>
+    public async Task StopAsync(TimeSpan closeHandshakeBudget = default)
     {
-        if (_app is not null)
-            await _app.StopAsync();
+        if (_app is null) return;
+
+        if (closeHandshakeBudget <= TimeSpan.Zero)
+            closeHandshakeBudget = TimeSpan.FromSeconds(5);
+
+        var sessions = _subscriptionManager.EnumerateAllClients()
+            .Select(kv => kv.Value)
+            .ToList();
+        if (sessions.Count > 0)
+        {
+            using var cts = new CancellationTokenSource(closeHandshakeBudget);
+            var tasks = new Task[sessions.Count];
+            for (int i = 0; i < sessions.Count; i++)
+                tasks[i] = sessions[i].RequestGracefulCloseAsync("server shutting down", cts.Token);
+            try { await Task.WhenAll(tasks).ConfigureAwait(false); }
+            catch { /* per-client failures already logged inside RequestGracefulCloseAsync */ }
+            _logger.LogInformation(
+                "Sent WebSocket close (1001) to {Count} active client(s) before stopping Kestrel",
+                sessions.Count);
+        }
+
+        await _app.StopAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
@@ -189,6 +189,46 @@ public class WebSocketHostIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task StopAsync_SendsCloseFrameWith1001ToActiveClients()
+    {
+        var (host, sm, port, cts) = await StartHostAsync();
+        var ws = new ClientWebSocket();
+        try
+        {
+            await ws.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/ws"), CancellationToken.None);
+            await WaitUntil(() => sm.ClientCount == 1, TimeSpan.FromSeconds(3));
+
+            // Trigger graceful shutdown — should send WebSocket Close (1001) to active clients
+            // before tearing down Kestrel. Kicked off in the background so we can drain frames.
+            var stopTask = host.StopAsync(TimeSpan.FromSeconds(5));
+
+            // Drain frames until we observe the Close frame. The server may emit a
+            // ServerStatus message on connect, so skip non-Close frames.
+            var buffer = new byte[1024];
+            WebSocketReceiveResult? result = null;
+            using var receiveCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            while (!receiveCts.IsCancellationRequested)
+            {
+                result = await ws.ReceiveAsync(buffer, receiveCts.Token);
+                if (result.MessageType == WebSocketMessageType.Close) break;
+            }
+
+            Assert.NotNull(result);
+            Assert.Equal(WebSocketMessageType.Close, result!.MessageType);
+            Assert.Equal(WebSocketCloseStatus.EndpointUnavailable, ws.CloseStatus);
+
+            await stopTask;
+        }
+        finally
+        {
+            cts.Cancel();
+            await host.DisposeAsync();
+            sm.Dispose();
+            ws.Dispose();
+        }
+    }
+
     private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;


### PR DESCRIPTION
Implements two quick-win fixes from the issue #18 audit (see audit findings comment on the issue).

## Task A — graceful WebSocket close on shutdown
Today, when the consumer shuts down, Kestrel just stops and clients see a TCP RST instead of a proper WebSocket close frame.

- New `ClientSession.RequestGracefulCloseAsync(description, ct)` sends `WebSocketCloseStatus.EndpointUnavailable` (1001 / "server shutting down") if the socket is still `Open`. Idempotent; swallows `OperationCanceledException`/`ObjectDisposedException` and warn-logs other `WebSocketException`s.
- `WebSocketHost.StopAsync` now takes an optional `closeHandshakeBudget` (default 5 s) and broadcasts the 1001 close to every active session via `SubscriptionManager.EnumerateAllClients()` before tearing down Kestrel. The budget caps total wait so a stuck peer cannot hang shutdown.
- `Program.cs` passes `UMDF_SHUTDOWN_DRAIN_SECONDS` as the close-handshake budget, keeping a single knob for the whole shutdown window.

### Test
New `StopAsync_SendsCloseFrameWith1001ToActiveClients` in `WebSocketHostIntegrationTests.cs` connects a real `ClientWebSocket`, calls `host.StopAsync(...)`, drains incoming frames, and asserts `MessageType == Close` and `CloseStatus == EndpointUnavailable`.

## Task B — frontend gated on backend health
Plain `depends_on` in compose only waits for container start, not health. The existing Dockerfile already declares a `HEALTHCHECK` so promoting the dependency is free.

- `docker-compose.yml`: `frontend.depends_on.backend.condition: service_healthy`.
- `docker-compose.multicast.yml`: `frontend.depends_on.consumer.condition: service_healthy` (mirrors the existing `publisher → consumer` wiring).
- `docker-compose.ghcr.yml` unchanged — it only overrides the backend image; frontend wiring is inherited.
- No new healthcheck added; existing Dockerfile `HEALTHCHECK` schedule preserved.

## Validation
- `dotnet build -c Release --nologo`: **0 warnings, 0 errors**
- `dotnet test -c Release --nologo --no-build`: **471 passed**, 0 failed, 0 skipped (was 470 prior to PR #21 baseline; +1 from the new shutdown test).

Refs #18.