### PR TITLE
feat(health): /health returns 503 when groups stale beyond threshold (refs #16)

### DIFF
--- a/src/B3.Umdf.ConsoleApp/Bootstrap.cs
+++ b/src/B3.Umdf.ConsoleApp/Bootstrap.cs
@@ -116,14 +116,23 @@ internal static class HealthCheckCommand
 {
     public static async Task<int?> TryRunAsync(string[] args)
     {
-        if (args.Length != 1 || args[0] != "--health-check") return null;
+        if (args.Length != 1) return null;
+        string mode;
+        if (args[0] == "--health-check") mode = "live";
+        else if (args[0] == "--health-check=full" || args[0] == "--health-check=health") mode = "health";
+        else if (args[0] == "--health-check=live") mode = "live";
+        else return null;
         try
         {
             using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
             var port = Environment.GetEnvironmentVariable("UMDF_WS_PORT")
                 ?? Environment.GetEnvironmentVariable("WS_PORT")
                 ?? "8080";
-            var resp = await http.GetAsync($"http://localhost:{port}/live");
+            // "live" probes /live (liveness, always 200 unless the process is dead).
+            // "full"/"health" probes /health which returns 503 when feed groups
+            // are stuck in non-Streaming state past UMDF_HEALTH_MAX_STALE_SECONDS.
+            var path = mode == "health" ? "/health" : "/live";
+            var resp = await http.GetAsync($"http://localhost:{port}{path}");
             return resp.IsSuccessStatusCode ? 0 : 1;
         }
         catch { return 1; }

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -526,7 +526,11 @@ if (subscriptionManager is not null)
         slowClientThreshold: slowClientThreshold,
         slowClientMaxTicks: slowClientMaxTicks,
         clientMaxPendingBytes: clientMaxPendingBytes,
-        clientCoalesceWindowMs: clientCoalesceWindowMs);
+        clientCoalesceWindowMs: clientCoalesceWindowMs)
+    {
+        HealthMaxStaleSeconds = settings.HealthMaxStaleSeconds,
+        HealthFailOnRecovery = settings.HealthFailOnRecovery,
+    };
 
     // Wire up feed state and last-packet providers for /health endpoint
     if (multiFeed is not null)

--- a/src/B3.Umdf.Server/ApiModels.cs
+++ b/src/B3.Umdf.Server/ApiModels.cs
@@ -8,6 +8,13 @@ public sealed class HealthResponse
     public string Uptime { get; set; } = "";
     public Dictionary<string, string>? FeedGroups { get; set; }
     public Dictionary<string, double>? SecondsSinceLastPacket { get; set; }
+    /// <summary>
+    /// Populated only when the endpoint is reporting an unhealthy condition
+    /// (HTTP 503). Lists the feed groups that exceeded the configured
+    /// stale-recovery threshold. Absent on healthy responses to keep the
+    /// legacy JSON shape unchanged for existing consumers.
+    /// </summary>
+    public string? Reason { get; set; }
 }
 
 public sealed class SymbolsResponse

--- a/src/B3.Umdf.Server/AppSettings.cs
+++ b/src/B3.Umdf.Server/AppSettings.cs
@@ -239,6 +239,27 @@ public sealed class AppSettings
     /// </summary>
     public long StaleEscapeTimeoutMs { get; set; } = 60_000;
 
+    /// <summary>
+    /// Threshold (seconds) beyond which a feed group still in a non-Streaming
+    /// state (the channel-level <see cref="B3.Umdf.Feed.FeedState.WaitInstrumentDefinition"/>
+    /// "stuck in bootstrap/recovery" condition) causes <c>GET /health</c> to
+    /// return HTTP 503. Until the threshold elapses (measured from the last
+    /// observed packet for the group, or from process start when no packet
+    /// has yet been received), the endpoint stays 200/initializing so cold
+    /// starts don't fail readiness gates. Default 60 s. CLI: env
+    /// <c>UMDF_HEALTH_MAX_STALE_SECONDS</c>.
+    /// </summary>
+    public int HealthMaxStaleSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Master switch for the <c>/health</c> stale-recovery → 503 behavior.
+    /// When false, the endpoint preserves its legacy always-200 contract
+    /// (status + per-group state in body) regardless of staleness. Defaults
+    /// to true so orchestrators can gate readiness on stale state out of the
+    /// box. CLI: env <c>UMDF_HEALTH_FAIL_ON_RECOVERY</c>.
+    /// </summary>
+    public bool HealthFailOnRecovery { get; set; } = true;
+
     /// <summary>Load settings from a JSON file.</summary>
     public static AppSettings LoadFromFile(string path)
     {
@@ -346,6 +367,10 @@ public sealed class AppSettings
             PerSymbolFanoutSuppressLowPct = psLow;
         if (long.TryParse(Environment.GetEnvironmentVariable("UMDF_STALE_ESCAPE_TIMEOUT_MS"), out var staleEscapeMs))
             StaleEscapeTimeoutMs = staleEscapeMs;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_HEALTH_MAX_STALE_SECONDS"), out var healthStaleSec) && healthStaleSec >= 0)
+            HealthMaxStaleSeconds = healthStaleSec;
+        if (TryParseBoolean(Environment.GetEnvironmentVariable("UMDF_HEALTH_FAIL_ON_RECOVERY"), out var healthFail))
+            HealthFailOnRecovery = healthFail;
 
         // ── Legacy environment variable fallbacks ──
         // Pre-UMDF_* naming, retained for the shell-less Docker image (compose files

--- a/src/B3.Umdf.Server/WebSocketHost.cs
+++ b/src/B3.Umdf.Server/WebSocketHost.cs
@@ -47,6 +47,25 @@ public sealed class WebSocketHost : IAsyncDisposable
     public Func<long>? RecoveryEventTotalProvider { get; set; }
 
     /// <summary>
+    /// Threshold (seconds) beyond which a feed group reported in a non-Streaming
+    /// state by <see cref="FeedStateProvider"/> causes <c>GET /health</c> to
+    /// return HTTP 503. Staleness is measured from the group's last observed
+    /// packet (via <see cref="LastPacketTimestampProvider"/>); for groups that
+    /// have never received a packet, process uptime is used so cold starts
+    /// don't fail readiness gates until the threshold elapses. Defaults to
+    /// 60 s. Mirrors <c>AppSettings.HealthMaxStaleSeconds</c>.
+    /// </summary>
+    public int HealthMaxStaleSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Master switch for the <c>/health</c> stale-recovery → 503 behavior.
+    /// When false, the endpoint preserves its legacy always-200 contract
+    /// (status + per-group state in body) regardless of staleness. Defaults
+    /// to true. Mirrors <c>AppSettings.HealthFailOnRecovery</c>.
+    /// </summary>
+    public bool HealthFailOnRecovery { get; set; } = true;
+
+    /// <summary>
     /// Additional <c>System.Diagnostics.Metrics.Meter</c> names to expose via
     /// the Prometheus <c>/metrics</c> endpoint. The host always exposes the
     /// <c>"B3.Umdf"</c> meter (defined by <see cref="MetricsRegistry"/>);
@@ -155,17 +174,56 @@ public sealed class WebSocketHost : IAsyncDisposable
                 Status = _subscriptionManager.IsReady ? "ready" : "initializing",
                 Uptime = _uptime.Elapsed.ToString(@"hh\:mm\:ss"),
             };
+            IReadOnlyDictionary<string, string>? states = null;
             if (FeedStateProvider is not null)
-                result.FeedGroups = new Dictionary<string, string>(FeedStateProvider());
+            {
+                states = FeedStateProvider();
+                result.FeedGroups = new Dictionary<string, string>(states);
+            }
+            IReadOnlyDictionary<string, long>? lastPackets = null;
             if (LastPacketTimestampProvider is not null)
             {
-                var timestamps = LastPacketTimestampProvider();
-                var seconds = new Dictionary<string, double>(timestamps.Count);
+                lastPackets = LastPacketTimestampProvider();
+                var seconds = new Dictionary<string, double>(lastPackets.Count);
                 long now = Environment.TickCount64;
-                foreach (var (k, v) in timestamps)
+                foreach (var (k, v) in lastPackets)
                     seconds[k] = v > 0 ? (now - v) / 1000.0 : -1.0;
                 result.SecondsSinceLastPacket = seconds;
             }
+
+            // Stale-recovery gate: a group reported as non-Streaming for longer
+            // than HealthMaxStaleSeconds flips the response to 503 so that
+            // orchestrators can fail readiness on stuck groups. Cold-start
+            // semantics: when no packet has yet been seen for a group we
+            // measure staleness against process uptime, so /health stays 200
+            // until the threshold elapses (matches existing /ready behavior).
+            if (HealthFailOnRecovery && states is not null && HealthMaxStaleSeconds >= 0)
+            {
+                long now = Environment.TickCount64;
+                double uptimeSec = _uptime.Elapsed.TotalSeconds;
+                List<string>? unhealthy = null;
+                foreach (var (group, state) in states)
+                {
+                    if (string.Equals(state, nameof(FeedState.Streaming), StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    double staleSec;
+                    if (lastPackets is not null && lastPackets.TryGetValue(group, out var ticks) && ticks > 0)
+                        staleSec = (now - ticks) / 1000.0;
+                    else
+                        staleSec = uptimeSec;
+                    if (staleSec > HealthMaxStaleSeconds)
+                    {
+                        unhealthy ??= new List<string>();
+                        unhealthy.Add($"{group}={state} for {staleSec:F0}s");
+                    }
+                }
+                if (unhealthy is not null)
+                {
+                    result.Reason = "Stale recovery: " + string.Join(", ", unhealthy);
+                    return Results.Json(result, AppJsonContext.Default.HealthResponse, statusCode: 503);
+                }
+            }
+
             return Results.Json(result, AppJsonContext.Default.HealthResponse);
         });
 

--- a/tests/B3.Umdf.Server.Tests/HealthEndpointTests.cs
+++ b/tests/B3.Umdf.Server.Tests/HealthEndpointTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text.Json;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Verifies the <c>/health</c> stale-recovery → 503 contract added for
+/// orchestrator-driven readiness gating (issue #16). The endpoint returns
+/// 200 while feed groups are Streaming or while still bootstrapping within
+/// the configured threshold, and 503 (with a populated <c>Reason</c>)
+/// once a non-Streaming group exceeds the threshold.
+/// </summary>
+public class HealthEndpointTests
+{
+    private static int FindFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    private sealed class HostHandle : IAsyncDisposable
+    {
+        public required WebSocketHost Host { get; init; }
+        public required SubscriptionManager Sm { get; init; }
+        public required CancellationTokenSource Cts { get; init; }
+        public required int Port { get; init; }
+
+        public async ValueTask DisposeAsync()
+        {
+            Cts.Cancel();
+            await Host.StopAsync();
+            await Host.DisposeAsync();
+            Sm.Dispose();
+        }
+    }
+
+    private static async Task<HostHandle> StartAsync(
+        Dictionary<string, string> states,
+        Dictionary<string, long> lastPacketTicks,
+        int maxStaleSeconds = 60,
+        bool failOnRecovery = true)
+    {
+        var sm = new SubscriptionManager();
+        var host = new WebSocketHost(sm)
+        {
+            HealthMaxStaleSeconds = maxStaleSeconds,
+            HealthFailOnRecovery = failOnRecovery,
+            FeedStateProvider = () => states,
+            LastPacketTimestampProvider = () => lastPacketTicks,
+        };
+        var port = FindFreePort();
+        var cts = new CancellationTokenSource();
+        await host.StartAsync(port, cts.Token);
+        return new HostHandle { Host = host, Sm = sm, Cts = cts, Port = port };
+    }
+
+    private static async Task<(HttpStatusCode status, JsonElement body)> GetHealthAsync(int port)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var resp = await http.GetAsync($"http://127.0.0.1:{port}/health");
+        var json = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return (resp.StatusCode, doc.RootElement.Clone());
+    }
+
+    [Fact]
+    public async Task Health_AllGroupsStreaming_Returns200_NoReason()
+    {
+        var states = new Dictionary<string, string> { ["G0"] = "Streaming", ["G1"] = "Streaming" };
+        var ticks = new Dictionary<string, long> { ["G0"] = Environment.TickCount64, ["G1"] = Environment.TickCount64 };
+        await using var h = await StartAsync(states, ticks);
+
+        var (status, body) = await GetHealthAsync(h.Port);
+        Assert.Equal(HttpStatusCode.OK, status);
+        Assert.False(body.TryGetProperty("reason", out var reason) && reason.ValueKind == JsonValueKind.String,
+            "reason field must be absent on healthy responses");
+    }
+
+    [Fact]
+    public async Task Health_NonStreamingWithinThreshold_Returns200()
+    {
+        // Group G0 is non-Streaming but received a packet just now → staleness ≈ 0s,
+        // well below the 60s default.
+        var states = new Dictionary<string, string> { ["G0"] = "WaitInstrumentDefinition" };
+        var ticks = new Dictionary<string, long> { ["G0"] = Environment.TickCount64 };
+        await using var h = await StartAsync(states, ticks);
+
+        var (status, _) = await GetHealthAsync(h.Port);
+        Assert.Equal(HttpStatusCode.OK, status);
+    }
+
+    [Fact]
+    public async Task Health_NonStreamingBeyondThreshold_Returns503_WithReason()
+    {
+        // Last packet 10s ago, threshold 1s → unhealthy.
+        var states = new Dictionary<string, string> { ["G0"] = "WaitInstrumentDefinition" };
+        var ticks = new Dictionary<string, long> { ["G0"] = Environment.TickCount64 - 10_000 };
+        await using var h = await StartAsync(states, ticks, maxStaleSeconds: 1);
+
+        var (status, body) = await GetHealthAsync(h.Port);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, status);
+        Assert.True(body.TryGetProperty("reason", out var reason));
+        Assert.Equal(JsonValueKind.String, reason.ValueKind);
+        Assert.Contains("G0", reason.GetString());
+    }
+
+    [Fact]
+    public async Task Health_FailOnRecoveryDisabled_Returns200_EvenWhenStale()
+    {
+        var states = new Dictionary<string, string> { ["G0"] = "WaitInstrumentDefinition" };
+        var ticks = new Dictionary<string, long> { ["G0"] = Environment.TickCount64 - 10_000 };
+        await using var h = await StartAsync(states, ticks, maxStaleSeconds: 1, failOnRecovery: false);
+
+        var (status, body) = await GetHealthAsync(h.Port);
+        Assert.Equal(HttpStatusCode.OK, status);
+        Assert.False(body.TryGetProperty("reason", out var reason) && reason.ValueKind == JsonValueKind.String);
+    }
+
+    [Fact]
+    public async Task Health_ColdStart_NoSnapshotYet_Returns200_NotUnhealthy()
+    {
+        // No packet seen yet (ticks=0). Process uptime is sub-second on a freshly
+        // started host, well under the 60s default → must NOT report 503 just
+        // because the group hasn't reached Streaming yet.
+        var states = new Dictionary<string, string> { ["G0"] = "WaitInstrumentDefinition" };
+        var ticks = new Dictionary<string, long> { ["G0"] = 0 };
+        await using var h = await StartAsync(states, ticks, maxStaleSeconds: 60);
+
+        var (status, body) = await GetHealthAsync(h.Port);
+        Assert.Equal(HttpStatusCode.OK, status);
+        Assert.Equal("initializing", body.GetProperty("status").GetString());
+    }
+}


### PR DESCRIPTION
Resolves the audit finding in #16: \`/health\` previously stayed 200 even when feed groups were stuck in non-Streaming state, leaving orchestrators no way to gate readiness on stale recovery.

## New env vars

| Var | Default | Effect |
|-----|---------|--------|
| \`UMDF_HEALTH_MAX_STALE_SECONDS\` | \`60\` | Threshold past which a non-Streaming group flips \`/health\` to HTTP 503. \`0\` means "any non-Streaming group is unhealthy after one second". |
| \`UMDF_HEALTH_FAIL_ON_RECOVERY\` | \`true\` | Master switch. Set to \`false\` (or \`0\`/\`off\`) to restore the legacy always-200 contract. |

Both surface as \`AppSettings.HealthMaxStaleSeconds\` / \`HealthFailOnRecovery\` and are wired through to \`WebSocketHost\` from \`Program.cs\`.

## /health semantics

\`/health\` continues to return its existing JSON shape (\`status\`, \`uptime\`, \`feedGroups\`, \`secondsSinceLastPacket\`) — only one **optional** field was added: \`reason\`, populated only on 503 responses. Existing consumers that parse the body see no schema break.

The endpoint flips to **HTTP 503** when \`HealthFailOnRecovery\` is true **and** any feed group reported by \`FeedStateProvider\` is non-Streaming **and** its staleness exceeds \`HealthMaxStaleSeconds\`.

### Per-group timestamp source / cold-start behavior

This codebase's channel-level \`FeedState\` enum is \`WaitInstrumentDefinition → Streaming\` (per-symbol healing lives in \`SymbolStateRegistry\`/\`BookManager\`). There is no separate \`Recovery\`/\`CatchUp\` state and no \`LastTransitionUtc\` on the handler. Per the issue's edge-case fallback, staleness is computed from the existing \`FeedHandler.LastPacketTicks\` provider already wired to the host:

* If the group has received at least one packet → staleness = \`now - LastPacketTicks\`.
* If no packet yet (\`LastPacketTicks == 0\`) → staleness = process uptime, so cold starts return **200/initializing** under the threshold and only flip to 503 once the bootstrap window has clearly elapsed. \`/ready\` and \`/health\` therefore agree on the bootstrap window.

Trade-off (documented inline in \`MapHealthEndpoints\`): a non-Streaming group that is still receiving incremental traffic will not be flagged. That matches the operational meaning we want — the failure signal is "stuck without traffic past the threshold", not "stuck while traffic flows".

## Dockerfile

\`HEALTHCHECK\` is **unchanged** (still \`--health-check\`, still probes \`/live\`) for backward compat with operators who already rely on liveness-only semantics. Operators who want orchestrator readiness gated on the stricter check can opt in by switching the CMD to:

\`\`\`
CMD [\"/app/B3.Umdf.ConsoleApp\", \"--health-check=full\"]
\`\`\`

\`HealthCheckCommand\` in \`Bootstrap.cs\` was extended to accept \`--health-check=full\` (alias \`--health-check=health\`) which probes \`/health\` and treats 503 as failure. Bare \`--health-check\` and the new \`--health-check=live\` continue to probe \`/live\`.

## Tests

New \`tests/B3.Umdf.Server.Tests/HealthEndpointTests.cs\` mirrors the existing \`WebSocketHostIntegrationTests\` (real Kestrel on a loopback ephemeral port). Five cases:

1. All groups \`Streaming\` → 200, no \`reason\`.
2. One group non-Streaming, last packet just now → 200.
3. One group non-Streaming, last packet > threshold → 503, \`reason\` mentions the group.
4. \`HealthFailOnRecovery=false\` → 200 even when stale.
5. Cold start (\`LastPacketTicks == 0\`, fresh host) → 200/initializing, **not** 503.

Full suite: **475 / 475 passing** (470 prior + 5 new). Build: 0 warnings, 0 errors.

Refs #16.