### PR TITLE
feat(sbe): consumer-side defensive validation for varData + SBE header (refs #15)

### DIFF
--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -25,6 +25,7 @@
     <Project Path="tests/B3.Umdf.Feed.Tests/B3.Umdf.Feed.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Fuzz.Tests/B3.Umdf.Fuzz.Tests.csproj" />
     <Project Path="tests/B3.Umdf.PcapReplay.Tests/B3.Umdf.PcapReplay.Tests.csproj" />
+    <Project Path="tests/B3.Umdf.Sbe.Tests/B3.Umdf.Sbe.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Server.Tests/B3.Umdf.Server.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Transport.Tests/B3.Umdf.Transport.Tests.csproj" />
   </Folder>

--- a/src/B3.Umdf.Sbe/SafeSbeText.cs
+++ b/src/B3.Umdf.Sbe/SafeSbeText.cs
@@ -1,0 +1,82 @@
+using System.Text;
+
+namespace B3.Umdf.Sbe;
+
+/// <summary>
+/// Defensive readers for SBE variable-length string composites (issue #15).
+///
+/// The generated <c>TextEncoding.Create</c> / <c>VarString.Create</c> helpers slice the buffer
+/// using the on-wire length prefix without verifying that the buffer actually contains that
+/// many bytes. A malformed or truncated UMDF packet can therefore trigger an
+/// <see cref="ArgumentOutOfRangeException"/> deep inside the parser. These helpers replicate
+/// the same wire layout but bounds-check first and return <c>false</c> instead of throwing,
+/// so the caller can drop the message and bump a parse-error counter.
+///
+/// Wire layout (must mirror <c>TextEncoding.cs</c> / <c>VarString.cs</c> in the generated SBE
+/// composites — keep in sync if the schema ever changes):
+/// <list type="bullet">
+///   <item><c>TextEncoding</c>: <c>byte length</c> (1-byte prefix) + <c>length</c> ASCII/UTF-8 bytes.</item>
+///   <item><c>VarString</c>:    <c>ushort length</c> (2-byte LE prefix) + <c>length</c> UTF-8 bytes.</item>
+/// </list>
+/// </summary>
+public static class SafeSbeText
+{
+    internal const int TextEncodingLengthPrefix = 1;
+    internal const int VarStringLengthPrefix = 2;
+
+    /// <summary>
+    /// Safely decode a <c>TextEncoding</c> composite (1-byte length prefix + UTF-8 data).
+    /// Returns <c>false</c> if the buffer is too small to contain the prefix or the declared
+    /// payload. On failure <paramref name="value"/> is set to <see cref="string.Empty"/>.
+    /// </summary>
+    public static bool TryReadTextEncoding(ReadOnlySpan<byte> buffer, out string value)
+    {
+        if (buffer.Length < TextEncodingLengthPrefix)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        int length = buffer[0];
+        int total = TextEncodingLengthPrefix + length;
+        if (buffer.Length < total)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = length == 0
+            ? string.Empty
+            : Encoding.UTF8.GetString(buffer.Slice(TextEncodingLengthPrefix, length));
+        return true;
+    }
+
+    /// <summary>
+    /// Safely decode a <c>VarString</c> composite (2-byte little-endian length prefix + UTF-8 data).
+    /// Returns <c>false</c> if the buffer is too small to contain the prefix or the declared
+    /// payload. On failure <paramref name="value"/> is set to <see cref="string.Empty"/>.
+    /// </summary>
+    public static bool TryReadVarString(ReadOnlySpan<byte> buffer, out string value)
+    {
+        if (buffer.Length < VarStringLengthPrefix)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        // Wire format is little-endian (SBE default and what MemoryMarshal.AsRef<ushort> produces
+        // on the LE platforms we run on); use BinaryPrimitives for an explicit, portable read.
+        ushort length = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        int total = VarStringLengthPrefix + length;
+        if (buffer.Length < total)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = length == 0
+            ? string.Empty
+            : Encoding.UTF8.GetString(buffer.Slice(VarStringLengthPrefix, length));
+        return true;
+    }
+}

--- a/src/B3.Umdf.Sbe/SbeValidationMetrics.cs
+++ b/src/B3.Umdf.Sbe/SbeValidationMetrics.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.Metrics;
+
+namespace B3.Umdf.Sbe;
+
+/// <summary>
+/// Defensive-validation counters for issue #15. Published on the shared <c>"B3.Umdf"</c> meter
+/// so the existing OTLP / Prometheus pipeline (see <c>MetricsRegistry</c> in B3.Umdf.Server)
+/// picks them up automatically without a project reference cycle.
+/// </summary>
+public static class SbeValidationMetrics
+{
+    public static readonly Meter Meter = new("B3.Umdf", "1.0.0");
+
+    /// <summary>Incremented when the SBE message header fails schema/version validation.</summary>
+    public static readonly Counter<long> HeaderMismatches =
+        Meter.CreateCounter<long>("umdf.sbe.header_mismatches");
+
+    /// <summary>Incremented when the message header cannot even be read (buffer &lt; 8 bytes).</summary>
+    public static readonly Counter<long> HeaderTruncated =
+        Meter.CreateCounter<long>("umdf.sbe.header_truncated");
+}

--- a/src/B3.Umdf.Sbe/ValidatingSbeDispatcher.cs
+++ b/src/B3.Umdf.Sbe/ValidatingSbeDispatcher.cs
@@ -1,0 +1,136 @@
+using B3.Umdf.Mbo.Sbe.V16;
+
+namespace B3.Umdf.Sbe;
+
+/// <summary>
+/// Reason a buffer was rejected by <see cref="ValidatingSbeDispatcher"/>.
+/// </summary>
+public enum SbeHeaderRejectReason
+{
+    /// <summary>Buffer was smaller than <see cref="MessageHeader.MESSAGE_SIZE"/>.</summary>
+    HeaderTruncated,
+    /// <summary>Header <c>SchemaId</c> did not match the expected value.</summary>
+    SchemaIdMismatch,
+    /// <summary>Header <c>Version</c> exceeded <see cref="ValidatingSbeDispatcher.MaxSupportedVersion"/>.</summary>
+    VersionUnsupported,
+    /// <summary>Header <c>BlockLength</c> exceeded the bytes remaining in the buffer.</summary>
+    BlockLengthImplausible,
+}
+
+/// <summary>
+/// Information passed to <see cref="ValidatingSbeDispatcher.OnHeaderMismatch"/> when the dispatcher
+/// rejects a buffer. The <c>BufferLength</c> rather than the buffer itself is supplied because the
+/// callback may be invoked from a hot ref-struct context.
+/// </summary>
+public readonly record struct SbeHeaderRejection(
+    SbeHeaderRejectReason Reason,
+    ushort SchemaId,
+    ushort Version,
+    ushort TemplateId,
+    ushort BlockLength,
+    int BufferLength);
+
+/// <summary>
+/// Defensive wrapper around the generated <see cref="SbeDispatcher"/> (issue #15).
+/// Validates the SBE message header (SchemaId / Version / BlockLength) before delegating
+/// to the generated dispatcher so a malformed or wrong-schema packet cannot drive the
+/// codegen parser into an out-of-range slice.
+///
+/// Designed as a drop-in alternative — <see cref="Dispatch{T}"/> mirrors the signature of
+/// <c>SbeDispatcher.Dispatch&lt;T&gt;</c> so callers can swap the call site to
+/// <c>validator.Dispatch(buf, ref handler)</c> without further changes.
+/// </summary>
+public sealed class ValidatingSbeDispatcher
+{
+    /// <summary>SBE schema id for the B3 UMDF schema (b3-market-data-messages-2.2.0.xml, <c>id="2"</c>).</summary>
+    public const ushort DefaultSchemaId = 2;
+    /// <summary>Highest <c>sinceVersion</c> that the bundled <c>SbeSourceGenerator</c> generates code for.</summary>
+    public const ushort DefaultMaxSupportedVersion = 16;
+
+    /// <summary>Expected <c>SchemaId</c>. Headers carrying any other value are rejected.</summary>
+    public ushort ExpectedSchemaId { get; }
+    /// <summary>Inclusive upper bound on accepted header <c>Version</c>.</summary>
+    public ushort MaxSupportedVersion { get; }
+    /// <summary>When <c>true</c> (default), buffers that fail validation are skipped and not dispatched.</summary>
+    public bool SkipOnMismatch { get; }
+    /// <summary>When <c>true</c> (default), <c>BlockLength &gt; remaining-buffer</c> is treated as a mismatch.</summary>
+    public bool ValidateBlockLength { get; }
+
+    /// <summary>Optional callback invoked once per rejection — useful for logging or test assertions.</summary>
+    public Action<SbeHeaderRejection>? OnHeaderMismatch { get; }
+
+    public ValidatingSbeDispatcher(
+        ushort expectedSchemaId = DefaultSchemaId,
+        ushort maxSupportedVersion = DefaultMaxSupportedVersion,
+        bool skipOnMismatch = true,
+        bool validateBlockLength = true,
+        Action<SbeHeaderRejection>? onHeaderMismatch = null)
+    {
+        ExpectedSchemaId = expectedSchemaId;
+        MaxSupportedVersion = maxSupportedVersion;
+        SkipOnMismatch = skipOnMismatch;
+        ValidateBlockLength = validateBlockLength;
+        OnHeaderMismatch = onHeaderMismatch;
+    }
+
+    /// <summary>
+    /// Validates the SBE header at the start of <paramref name="buffer"/> and, if it passes,
+    /// delegates to <see cref="SbeDispatcher.Dispatch{T}"/>. Returns <c>true</c> only if the
+    /// buffer was successfully dispatched.
+    /// </summary>
+    public bool Dispatch<T>(ReadOnlySpan<byte> buffer, ref T handler)
+        where T : struct, ISbeMessageHandler
+    {
+        if (!MessageHeader.TryReadHeader(buffer, out var blockLength, out var templateId, out var schemaId, out var version))
+        {
+            SbeValidationMetrics.HeaderTruncated.Add(1);
+            OnHeaderMismatch?.Invoke(new SbeHeaderRejection(
+                SbeHeaderRejectReason.HeaderTruncated, 0, 0, 0, 0, buffer.Length));
+            return false;
+        }
+
+        if (schemaId != ExpectedSchemaId)
+        {
+            return Reject(SbeHeaderRejectReason.SchemaIdMismatch, buffer, ref handler,
+                schemaId, version, templateId, blockLength);
+        }
+
+        if (version > MaxSupportedVersion)
+        {
+            return Reject(SbeHeaderRejectReason.VersionUnsupported, buffer, ref handler,
+                schemaId, version, templateId, blockLength);
+        }
+
+        if (ValidateBlockLength)
+        {
+            int remaining = buffer.Length - MessageHeader.MESSAGE_SIZE;
+            if (blockLength > remaining)
+            {
+                return Reject(SbeHeaderRejectReason.BlockLengthImplausible, buffer, ref handler,
+                    schemaId, version, templateId, blockLength);
+            }
+        }
+
+        return SbeDispatcher.Dispatch(buffer, ref handler);
+    }
+
+    private bool Reject<T>(
+        SbeHeaderRejectReason reason,
+        ReadOnlySpan<byte> buffer,
+        ref T handler,
+        ushort schemaId,
+        ushort version,
+        ushort templateId,
+        ushort blockLength) where T : struct, ISbeMessageHandler
+    {
+        SbeValidationMetrics.HeaderMismatches.Add(1,
+            new KeyValuePair<string, object?>("reason", reason.ToString()));
+        OnHeaderMismatch?.Invoke(new SbeHeaderRejection(
+            reason, schemaId, version, templateId, blockLength, buffer.Length));
+
+        if (SkipOnMismatch)
+            return false;
+
+        return SbeDispatcher.Dispatch(buffer, ref handler);
+    }
+}

--- a/tests/B3.Umdf.Sbe.Tests/B3.Umdf.Sbe.Tests.csproj
+++ b/tests/B3.Umdf.Sbe.Tests/B3.Umdf.Sbe.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Umdf.Sbe\B3.Umdf.Sbe.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Umdf.Sbe.Tests/SafeSbeTextTests.cs
+++ b/tests/B3.Umdf.Sbe.Tests/SafeSbeTextTests.cs
@@ -1,0 +1,107 @@
+using System.Buffers.Binary;
+using System.Text;
+using B3.Umdf.Sbe;
+
+namespace B3.Umdf.Sbe.Tests;
+
+public class SafeSbeTextTests
+{
+    // ── TextEncoding (1-byte length prefix + UTF-8) ──────────────────────────────
+
+    [Fact]
+    public void TryReadTextEncoding_EmptyBuffer_ReturnsFalse()
+    {
+        Assert.False(SafeSbeText.TryReadTextEncoding(ReadOnlySpan<byte>.Empty, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadTextEncoding_TruncatedPayload_ReturnsFalse()
+    {
+        // Length prefix says 5 bytes but only 2 follow.
+        ReadOnlySpan<byte> buf = new byte[] { 5, (byte)'a', (byte)'b' };
+        Assert.False(SafeSbeText.TryReadTextEncoding(buf, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadTextEncoding_ZeroLength_ReturnsTrueWithEmpty()
+    {
+        ReadOnlySpan<byte> buf = new byte[] { 0 };
+        Assert.True(SafeSbeText.TryReadTextEncoding(buf, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadTextEncoding_ValidPayload_DecodesString()
+    {
+        var data = Encoding.UTF8.GetBytes("PETR4");
+        var buf = new byte[1 + data.Length];
+        buf[0] = (byte)data.Length;
+        data.CopyTo(buf, 1);
+
+        Assert.True(SafeSbeText.TryReadTextEncoding(buf, out var s));
+        Assert.Equal("PETR4", s);
+    }
+
+    [Fact]
+    public void TryReadTextEncoding_ExtraTrailingBytes_StillDecodesDeclaredLength()
+    {
+        // 3 declared bytes followed by garbage; we must only decode the 3 bytes.
+        ReadOnlySpan<byte> buf = new byte[] { 3, (byte)'A', (byte)'B', (byte)'C', 0xFF, 0xFE };
+        Assert.True(SafeSbeText.TryReadTextEncoding(buf, out var s));
+        Assert.Equal("ABC", s);
+    }
+
+    // ── VarString (2-byte LE length prefix + UTF-8) ──────────────────────────────
+
+    [Fact]
+    public void TryReadVarString_EmptyBuffer_ReturnsFalse()
+    {
+        Assert.False(SafeSbeText.TryReadVarString(ReadOnlySpan<byte>.Empty, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadVarString_OnlyOnePrefixByte_ReturnsFalse()
+    {
+        ReadOnlySpan<byte> buf = new byte[] { 0x05 };
+        Assert.False(SafeSbeText.TryReadVarString(buf, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadVarString_TruncatedPayload_ReturnsFalse()
+    {
+        // Length prefix says 10 bytes; only 4 follow.
+        var buf = new byte[6];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, 10);
+        Encoding.UTF8.GetBytes("data").CopyTo(buf, 2);
+
+        Assert.False(SafeSbeText.TryReadVarString(buf, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadVarString_ZeroLength_ReturnsTrueWithEmpty()
+    {
+        var buf = new byte[2];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, 0);
+
+        Assert.True(SafeSbeText.TryReadVarString(buf, out var s));
+        Assert.Equal(string.Empty, s);
+    }
+
+    [Fact]
+    public void TryReadVarString_ValidUtf8_DecodesString()
+    {
+        // "Ação" is multi-byte in UTF-8 — exercises real UTF-8 decoding.
+        var payload = Encoding.UTF8.GetBytes("Ação");
+        var buf = new byte[2 + payload.Length];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)payload.Length);
+        payload.CopyTo(buf, 2);
+
+        Assert.True(SafeSbeText.TryReadVarString(buf, out var s));
+        Assert.Equal("Ação", s);
+    }
+}

--- a/tests/B3.Umdf.Sbe.Tests/ValidatingSbeDispatcherTests.cs
+++ b/tests/B3.Umdf.Sbe.Tests/ValidatingSbeDispatcherTests.cs
@@ -1,0 +1,175 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Sbe;
+
+namespace B3.Umdf.Sbe.Tests;
+
+public class ValidatingSbeDispatcherTests
+{
+    private const ushort SchemaId = 2;
+    private const ushort SupportedVersion = 16;
+
+    /// <summary>Builds an 8-byte SBE message header followed by <paramref name="extraPayload"/> bytes.</summary>
+    private static byte[] BuildHeader(ushort templateId, ushort schemaId, ushort version, ushort blockLength, int extraPayload = 0)
+    {
+        var buf = new byte[MessageHeader.MESSAGE_SIZE + extraPayload];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(0, 2), blockLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2, 2), templateId);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4, 2), schemaId);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(6, 2), version);
+        return buf;
+    }
+
+    [Fact]
+    public void Dispatch_ValidHeader_DispatchesSuccessfullyWithoutMismatch()
+    {
+        // SequenceReset_1 has BLOCK_LENGTH=0 so an 8-byte header alone is a complete message.
+        var buf = BuildHeader(templateId: 1, schemaId: SchemaId, version: 0, blockLength: 0);
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(
+            expectedSchemaId: SchemaId,
+            maxSupportedVersion: SupportedVersion,
+            onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.True(dispatched);
+        Assert.Null(rejection);
+        Assert.Equal(1, handler.DispatchCount);
+        Assert.Equal(1, handler.LastTemplateId);
+    }
+
+    [Fact]
+    public void Dispatch_SchemaIdMismatch_FiresCallbackAndSkips()
+    {
+        var buf = BuildHeader(templateId: 1, schemaId: 999, version: 0, blockLength: 0);
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(
+            expectedSchemaId: SchemaId,
+            maxSupportedVersion: SupportedVersion,
+            onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.False(dispatched);
+        Assert.NotNull(rejection);
+        Assert.Equal(SbeHeaderRejectReason.SchemaIdMismatch, rejection!.Value.Reason);
+        Assert.Equal((ushort)999, rejection.Value.SchemaId);
+        Assert.Equal(0, handler.DispatchCount);
+    }
+
+    [Fact]
+    public void Dispatch_VersionUnsupported_FiresCallbackAndSkips()
+    {
+        var buf = BuildHeader(templateId: 1, schemaId: SchemaId, version: 99, blockLength: 0);
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(
+            expectedSchemaId: SchemaId,
+            maxSupportedVersion: SupportedVersion,
+            onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.False(dispatched);
+        Assert.NotNull(rejection);
+        Assert.Equal(SbeHeaderRejectReason.VersionUnsupported, rejection!.Value.Reason);
+        Assert.Equal((ushort)99, rejection.Value.Version);
+        Assert.Equal(0, handler.DispatchCount);
+    }
+
+    [Fact]
+    public void Dispatch_HeaderTruncated_FiresCallbackAndSkips()
+    {
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        ReadOnlySpan<byte> tiny = new byte[] { 0x01, 0x02 };
+        bool dispatched = dispatcher.Dispatch(tiny, ref handler);
+
+        Assert.False(dispatched);
+        Assert.NotNull(rejection);
+        Assert.Equal(SbeHeaderRejectReason.HeaderTruncated, rejection!.Value.Reason);
+        Assert.Equal(0, handler.DispatchCount);
+    }
+
+    [Fact]
+    public void Dispatch_BlockLengthExceedsBuffer_FiresCallbackAndSkips()
+    {
+        // Header says blockLength=200 but buffer carries only 0 extra payload bytes.
+        var buf = BuildHeader(templateId: 1, schemaId: SchemaId, version: 0, blockLength: 200);
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.False(dispatched);
+        Assert.NotNull(rejection);
+        Assert.Equal(SbeHeaderRejectReason.BlockLengthImplausible, rejection!.Value.Reason);
+        Assert.Equal(0, handler.DispatchCount);
+    }
+
+    [Fact]
+    public void Dispatch_SchemaMismatch_WithSkipOnMismatchFalse_StillDispatches()
+    {
+        // Wrong schemaId, but skipOnMismatch=false → still delegates to SbeDispatcher.
+        // We use templateId=1 with blockLength=0 so the underlying dispatcher succeeds.
+        var buf = BuildHeader(templateId: 1, schemaId: 999, version: 0, blockLength: 0);
+        SbeHeaderRejection? rejection = null;
+        var dispatcher = new ValidatingSbeDispatcher(
+            expectedSchemaId: SchemaId,
+            maxSupportedVersion: SupportedVersion,
+            skipOnMismatch: false,
+            onHeaderMismatch: r => rejection = r);
+
+        var handler = new CountingHandler();
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.True(dispatched);
+        Assert.NotNull(rejection); // callback still fires for visibility
+        Assert.Equal(1, handler.DispatchCount);
+    }
+
+    /// <summary>Minimal <see cref="ISbeMessageHandler"/> stub that just counts invocations.</summary>
+    private struct CountingHandler : ISbeMessageHandler
+    {
+        public int DispatchCount;
+        public int LastTemplateId;
+
+        public void OnSequenceReset_1(in SequenceReset_1DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 1; }
+        public void OnSequence_2(in Sequence_2DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 2; }
+        public void OnEmptyBook_9(in EmptyBook_9DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 9; }
+        public void OnChannelReset_11(in ChannelReset_11DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 11; }
+        public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 3; }
+        public void OnSecurityGroupPhase_10(in SecurityGroupPhase_10DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 10; }
+        public void OnSecurityDefinition_12(in SecurityDefinition_12DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 12; }
+        public void OnNews_5(in News_5DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 5; }
+        public void OnOpeningPrice_15(in OpeningPrice_15DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 15; }
+        public void OnTheoreticalOpeningPrice_16(in TheoreticalOpeningPrice_16DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 16; }
+        public void OnClosingPrice_17(in ClosingPrice_17DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 17; }
+        public void OnAuctionImbalance_19(in AuctionImbalance_19DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 19; }
+        public void OnQuantityBand_21(in QuantityBand_21DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 21; }
+        public void OnPriceBand_22(in PriceBand_22DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 22; }
+        public void OnHighPrice_24(in HighPrice_24DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 24; }
+        public void OnLowPrice_25(in LowPrice_25DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 25; }
+        public void OnLastTradePrice_27(in LastTradePrice_27DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 27; }
+        public void OnSettlementPrice_28(in SettlementPrice_28DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 28; }
+        public void OnOpenInterest_29(in OpenInterest_29DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 29; }
+        public void OnSnapshotFullRefresh_Header_30(in SnapshotFullRefresh_Header_30DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 30; }
+        public void OnOrder_MBO_50(in Order_MBO_50DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 50; }
+        public void OnDeleteOrder_MBO_51(in DeleteOrder_MBO_51DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 51; }
+        public void OnMassDeleteOrders_MBO_52(in MassDeleteOrders_MBO_52DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 52; }
+        public void OnTrade_53(in Trade_53DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 53; }
+        public void OnForwardTrade_54(in ForwardTrade_54DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 54; }
+        public void OnExecutionSummary_55(in ExecutionSummary_55DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 55; }
+        public void OnExecutionStatistics_56(in ExecutionStatistics_56DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 56; }
+        public void OnTradeBust_57(in TradeBust_57DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 57; }
+        public void OnSnapshotFullRefresh_Orders_MBO_71(in SnapshotFullRefresh_Orders_MBO_71DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 71; }
+        public void OnHeaderMessage_0(in HeaderMessage_0DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 0; }
+        public void OnUnknownMessage(int templateId, int blockLength, int version, ReadOnlySpan<byte> payload) { DispatchCount++; LastTemplateId = templateId; }
+    }
+}


### PR DESCRIPTION
Refs #15.

## Why a wrapper layer instead of patching codegen
The audit for #15 found three under-defended SBE parse paths, all in code that ships from `SbeSourceGenerator` 1.6.1:

1. `TextEncoding.Create` (`generated/.../V16/Composites/TextEncoding.cs:28-32`) — `buffer.Slice(1, length)` with no bounds check.
2. `VarString.Create`   (`generated/.../V16/Composites/VarString.cs:28-32`)   — same pattern with a 2-byte prefix.
3. `SbeDispatcher.Dispatch` (`generated/.../V16/Dispatcher/SbeDispatcher.cs`) — does not validate `SchemaId` / `Version` / plausible `BlockLength` before delegating to per-template parsers.

Everything under `src/B3.Umdf.Sbe/generated/` is regenerated on every build, so fixing the upstream package is the right long-term path; in the meantime we add **consumer-side wrappers** that callers can opt into without touching codegen.

## What this PR adds

| File | Purpose |
| --- | --- |
| `src/B3.Umdf.Sbe/SafeSbeText.cs` | `TryReadTextEncoding` / `TryReadVarString` — bounds-checked alternatives to `Composites.*.Create()`. Return `false` on truncation instead of throwing `ArgumentOutOfRangeException`. |
| `src/B3.Umdf.Sbe/ValidatingSbeDispatcher.cs` | Thin wrapper around `SbeDispatcher.Dispatch` that reads the `MessageHeader` first and validates `SchemaId` (default `2`), `Version` (default `<= 16`), and `BlockLength` (must fit in the remaining buffer) before delegating. Configurable: `SkipOnMismatch` (default `true`), `OnHeaderMismatch` callback, individual toggles. |
| `src/B3.Umdf.Sbe/SbeValidationMetrics.cs` | Counters `umdf.sbe.header_mismatches` (tagged with `reason`) and `umdf.sbe.header_truncated` published on the existing `B3.Umdf` meter so the OTLP / Prometheus pipeline picks them up automatically. |
| `tests/B3.Umdf.Sbe.Tests/` (new project) | 16 unit tests — see below. |

## Integration points changed
- `B3MarketDataPlatform.slnx` — the new `B3.Umdf.Sbe.Tests` project is registered alongside the other test projects.
- **No live-path call sites changed.** Per the issue's edge-case guidance, wiring `ValidatingSbeDispatcher` into `MarketDataManager`/`BookManager` would require touching generic struct handlers and existing test fixtures, so it's deferred to a follow-up. The helpers are independently valuable: they're the building blocks the live path will swap to once we're ready.

## Tests
Before: 470 passing. After: **486 passing** (+16, 0 failures).

`SafeSbeTextTests` (10 tests):
- empty buffer, length-prefix truncation, declared-length truncation, zero length, valid decode (incl. multi-byte UTF-8 `Ação` for VarString), trailing-garbage tolerance.

`ValidatingSbeDispatcherTests` (6 tests):
- valid header → dispatches and counter stays at zero.
- `SchemaId` mismatch → callback fires, dispatch skipped.
- `Version > MaxSupported` → callback fires, dispatch skipped.
- header truncated (< 8 bytes) → callback fires with `HeaderTruncated`.
- `BlockLength > remaining` → callback fires with `BlockLengthImplausible`.
- `SkipOnMismatch = false` → callback still fires but underlying dispatch still runs (back-compat mode).

## Don'ts respected
- No file under `src/B3.Umdf.Sbe/generated/` was modified.
- No new NuGet packages.
- `SbeSourceGenerator` version unchanged (`1.6.1`).
- No unrelated refactors.