### PR TITLE
perf(ci): committed BDN baselines + opt-in perf-smoke comparison workflow (refs #19)

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -1,0 +1,78 @@
+# Perf-smoke: runs the three representative microbenchmarks and compares
+# results against committed baselines under docs/perf/baselines/.
+#
+# WHY OPT-IN: BenchmarkDotNet on shared GitHub-hosted runners is high-noise
+# (variable host load, no CPU pinning, no fixed governor). Treat any
+# regression reported here as ADVISORY unless it reproduces on stable
+# hardware. To opt a PR into this workflow, add the `run-perf` label.
+#
+# This workflow is deliberately NOT in the required-checks set.
+# See docs/perf/baselines/README.md and issue #19.
+
+name: perf-smoke
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+jobs:
+  perf-smoke:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-perf')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore
+
+      - name: Run Book benchmarks (BookManagerOnPacket + BookSide)
+        working-directory: benchmarks/B3.Umdf.Book.Benchmarks
+        run: |
+          dotnet run -c Release --no-build -- \
+            --filter '*BookManagerOnPacketBenchmarks*|*BookSideBenchmarks*' \
+            --exporters json
+
+      - name: Run Feed benchmarks (MpscPacketRing)
+        working-directory: benchmarks/B3.Umdf.Feed.Benchmarks
+        run: |
+          dotnet run -c Release --no-build -- \
+            --filter '*MpscPacketRingBenchmarks*' \
+            --exporters json
+
+      - name: Upload BDN artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bdn-artifacts
+          path: |
+            benchmarks/B3.Umdf.Book.Benchmarks/BenchmarkDotNet.Artifacts/
+            benchmarks/B3.Umdf.Feed.Benchmarks/BenchmarkDotNet.Artifacts/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Compare against baselines
+        run: |
+          shopt -s nullglob
+          reports=()
+          for f in benchmarks/B3.Umdf.Book.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full.json \
+                  benchmarks/B3.Umdf.Feed.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full.json; do
+            reports+=(--report "$f")
+          done
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "No BenchmarkDotNet -report-full.json files found." >&2
+            exit 1
+          fi
+          dotnet run -c Release --no-build --project tools/PerfBaselineCompare -- \
+            --baselines docs/perf/baselines \
+            "${reports[@]}"

--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -17,6 +17,8 @@
     <Project Path="tools/PcapRptSeqAnalyzer/PcapRptSeqAnalyzer.csproj" />
     <Project Path="tools/PcapTrafficCharacterizer/PcapTrafficCharacterizer.csproj" />
     <Project Path="tools/InboundLatencyProbe/InboundLatencyProbe.csproj" />
+    <Project Path="tools/PerfBaselineCompare/PerfBaselineCompare.csproj" />
+    <Project Path="tools/PerfBaselineCompare.Tests/PerfBaselineCompare.Tests.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/B3.MarketData.WebSocketClient.Tests/B3.MarketData.WebSocketClient.Tests.csproj" />

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,8 +1,19 @@
 # UMDF Traffic Characterization (Phase 0)
 
-> See also: [`mbp-stream.md`](mbp-stream.md) — MBP wire stream design,
-> protocol additions, and bandwidth measurements vs MBO on the hot-symbol
-> trace (45–98% reduction depending on the conflation window).
+> See also:
+> - [`mbp-stream.md`](mbp-stream.md) — MBP wire stream design,
+>   protocol additions, and bandwidth measurements vs MBO on the
+>   hot-symbol trace (45–98% reduction depending on the conflation
+>   window).
+> - [`baselines/`](baselines/) — machine-readable BenchmarkDotNet
+>   baselines used by the opt-in `perf-smoke` workflow
+>   (`.github/workflows/perf-smoke.yml`). To run that workflow on a
+>   PR, add the `run-perf` label; otherwise it only runs on manual
+>   `workflow_dispatch`. Treat regressions as advisory until they
+>   reproduce on stable hardware. See
+>   [`baselines/README.md`](baselines/README.md) for the file format,
+>   refresh procedure, and the rule that perf-affecting PRs must
+>   update the affected baseline JSON in the same PR.
 
 Ground-truth per-channel statistics extracted from recorded B3 UMDF
 PCAPs, used to design realistic dispatcher / ring benchmarks instead

--- a/docs/perf/baselines/BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols512.json
+++ b/docs/perf/baselines/BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols512.json
@@ -1,0 +1,15 @@
+{
+  "benchmark": "BookManagerOnPacketBenchmarks",
+  "method": "OnPacket_DispatchLoop",
+  "params": { "MessageCount": 10000, "SymbolCount": 512 },
+  "ops_per_invocation": 10000,
+  "captured_at": "2026-04-27",
+  "captured_on": "AMD EPYC 7763 (per docs/perf/onpacket-profiling.md table)",
+  "runtime": "net10.0 Release",
+  "metrics": {
+    "mean_ns_per_op": 62.0,
+    "alloc_b_per_op": 32.0
+  },
+  "tolerance": { "mean_pct": 15, "alloc_pct": 25 },
+  "notes": "Doc-sourced from docs/perf/onpacket-profiling.md (Throughput baseline + Allocation findings). Replace with a fresh capture on stable hardware before treating as a hard CI gate; tolerances are intentionally loose because GitHub-hosted runners are noisy."
+}

--- a/docs/perf/baselines/BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols64.json
+++ b/docs/perf/baselines/BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols64.json
@@ -1,0 +1,15 @@
+{
+  "benchmark": "BookManagerOnPacketBenchmarks",
+  "method": "OnPacket_DispatchLoop",
+  "params": { "MessageCount": 10000, "SymbolCount": 64 },
+  "ops_per_invocation": 10000,
+  "captured_at": "2026-04-27",
+  "captured_on": "AMD EPYC 7763 (per docs/perf/onpacket-profiling.md table)",
+  "runtime": "net10.0 Release",
+  "metrics": {
+    "mean_ns_per_op": 53.0,
+    "alloc_b_per_op": 32.0
+  },
+  "tolerance": { "mean_pct": 15, "alloc_pct": 25 },
+  "notes": "Doc-sourced from docs/perf/onpacket-profiling.md (Throughput baseline + Allocation findings). Replace with a fresh capture on stable hardware before treating as a hard CI gate; tolerances are intentionally loose because GitHub-hosted runners are noisy."
+}

--- a/docs/perf/baselines/BookSideBenchmarks.Current_SortedDictionary.json
+++ b/docs/perf/baselines/BookSideBenchmarks.Current_SortedDictionary.json
@@ -1,0 +1,11 @@
+{
+  "benchmark": "BookSideBenchmarks",
+  "method": "Current_SortedDictionary",
+  "params": { "OperationCount": 100000 },
+  "captured_at": null,
+  "captured_on": "not yet captured on stable hardware",
+  "runtime": "net10.0 Release",
+  "metrics": {},
+  "tolerance": { "mean_pct": 15, "alloc_pct": 25 },
+  "notes": "Schema-only placeholder. The committed prose docs do not record a single number for the baseline BookSide implementation in isolation, so we deliberately omit metrics rather than fabricate them. The perf-smoke workflow will surface this row as MISSING until the metrics are populated from a real capture (see docs/perf/baselines/README.md). Tracked under issue #19."
+}

--- a/docs/perf/baselines/MpscPacketRingBenchmarks.Run.json
+++ b/docs/perf/baselines/MpscPacketRingBenchmarks.Run.json
@@ -1,0 +1,11 @@
+{
+  "benchmark": "MpscPacketRingBenchmarks",
+  "method": "Run",
+  "params": { "ProducerCount": 1, "PacketsPerProducer": 100000 },
+  "captured_at": null,
+  "captured_on": "not yet captured on stable hardware",
+  "runtime": "net10.0 Release",
+  "metrics": {},
+  "tolerance": { "mean_pct": 20, "alloc_pct": 25 },
+  "notes": "Schema-only placeholder. No prose baseline number was committed for MpscPacketRing; metrics are omitted on purpose. Will be populated once the perf-smoke workflow is run on a stable runner. Tracked under issue #19."
+}

--- a/docs/perf/baselines/README.md
+++ b/docs/perf/baselines/README.md
@@ -1,0 +1,94 @@
+# Perf baselines (machine-readable)
+
+This directory holds one JSON file per `(benchmark, method, parameter set)`
+that we want the opt-in perf-smoke CI workflow
+(`.github/workflows/perf-smoke.yml`) to compare BenchmarkDotNet runs
+against. The comparison tool lives at
+[`tools/PerfBaselineCompare/`](../../../tools/PerfBaselineCompare/) and the
+broader rationale is tracked in
+[issue #19](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/19).
+
+## File format
+
+Each `*.json` file in this directory is treated as a baseline. Shape:
+
+```jsonc
+{
+  "benchmark": "BookManagerOnPacketBenchmarks",   // BDN class (short name)
+  "method":    "OnPacket_DispatchLoop",           // [Benchmark] method name
+  "params":    { "MessageCount": 10000, "SymbolCount": 64 }, // BDN [Params] subset
+  "ops_per_invocation": 10000,                    // optional; divides BDN per-call numbers
+  "captured_at": "2026-04-27",                    // ISO date
+  "captured_on": "AMD EPYC 7763",                 // human-readable hardware tag
+  "runtime":     "net10.0 Release",
+  "metrics": {
+    "mean_ns_per_op": 53.0,                       // optional — omit to skip the gate
+    "alloc_b_per_op": 32.0                        // optional — omit to skip the gate
+  },
+  "tolerance": { "mean_pct": 15, "alloc_pct": 25 },
+  "notes": "Free-form text. Always note the source of the numbers."
+}
+```
+
+Notes:
+
+* `params` is a **subset match** against BenchmarkDotNet's `Parameters`
+  field, so a baseline only needs to list the params it cares about.
+* If a metric is omitted under `metrics`, that metric is **not enforced** for
+  this row. We use this for benchmarks where the committed prose docs
+  don't include a defensible number — better to ship a schema-only
+  placeholder than to fabricate one.
+* `ops_per_invocation` is required when a `[Benchmark]` method runs an
+  inner loop. BDN reports per-invocation numbers; the comparer divides
+  by `ops_per_invocation` so the JSON stays in human-friendly per-item
+  units.
+* Tolerances are intentionally loose. Treat regressions as **advisory**
+  unless they reproduce on stable hardware (see "Hardware caveat" below).
+
+## How to refresh a baseline
+
+1. On a quiet machine (no other CPU/GC pressure, fixed CPU governor),
+   build Release and run the relevant suite, e.g.:
+
+   ```bash
+   cd benchmarks/B3.Umdf.Book.Benchmarks
+   dotnet run -c Release -- --filter '*BookManagerOnPacketBenchmarks*'
+   ```
+
+2. Find the per-benchmark report under
+   `BenchmarkDotNet.Artifacts/results/*-report-full.json`.
+3. Copy the `Mean` (ns) and `Memory.BytesAllocatedPerOperation` values
+   for each parameter row you have a baseline for. Divide both by
+   `ops_per_invocation` if the benchmark loops internally.
+4. Update `metrics.mean_ns_per_op` / `metrics.alloc_b_per_op` and bump
+   `captured_at` / `captured_on`.
+5. Commit the JSON change in the **same PR** as the perf-affecting code
+   change. PRs that move perf MUST update the affected baseline JSON;
+   reviewers should reject perf-affecting PRs that don't.
+
+## Hardware caveat
+
+The current numbers for `BookManagerOnPacketBenchmarks` come from the
+prose tables in [`docs/perf/onpacket-profiling.md`](../onpacket-profiling.md)
+(captured on AMD EPYC 7763). They are committed so the comparison tool
+and CI workflow have something to chew on, **not** because we trust them
+as a long-term gate. Two follow-up steps before treating them as a hard
+gate:
+
+1. Re-capture on the same stable runner that CI will use.
+2. Tighten the tolerances once we know the run-to-run noise on that
+   runner.
+
+Until that's done, `.github/workflows/perf-smoke.yml` is opt-in (label
+`run-perf` or manual dispatch) and explicitly **not** wired into the
+required-checks list.
+
+## Why some files are schema-only
+
+`BookSideBenchmarks.*.json` and `MpscPacketRingBenchmarks.*.json` ship
+without populated `metrics`. The committed prose docs don't include a
+single defensible number for those benchmarks in isolation, so we'd
+rather commit a no-metric placeholder (which the comparer treats as
+"matched but nothing to gate on") than fabricate numbers that quietly
+drift. Populating those numbers is a follow-up to issue #19 and should
+happen the first time the perf-smoke workflow runs on a stable runner.

--- a/tools/PerfBaselineCompare.Tests/ComparerTests.cs
+++ b/tools/PerfBaselineCompare.Tests/ComparerTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using B3.Umdf.Tools.PerfBaselineCompare;
+
+namespace B3.Umdf.Tools.PerfBaselineCompare.Tests;
+
+/// <summary>
+/// Exercises <see cref="Comparer.Compare"/> against a small canned BDN
+/// report so the regression / pass / missing branches are all locked in
+/// without spinning up the real benchmark suite.
+/// </summary>
+public class ComparerTests
+{
+    // Canned BDN-shaped report: one benchmark with two parameter sets.
+    // Mean is in nanoseconds-per-invocation (BDN's native unit); the
+    // BookManager benchmark loops MessageCount times per invocation, so
+    // for OpsPerInvocation=10000 a Mean of 530000 ns ≈ 53 ns/op.
+    private const string SampleReport = """
+      {
+        "Title": "sample",
+        "Benchmarks": [
+          {
+            "Type": "B3.Umdf.Book.Benchmarks.BookManagerOnPacketBenchmarks",
+            "Method": "OnPacket_DispatchLoop",
+            "Parameters": "MessageCount=10000, SymbolCount=64",
+            "Statistics": { "Mean": 530000.0 },
+            "Memory": { "BytesAllocatedPerOperation": 320000 }
+          },
+          {
+            "Type": "B3.Umdf.Book.Benchmarks.BookManagerOnPacketBenchmarks",
+            "Method": "OnPacket_DispatchLoop",
+            "Parameters": "MessageCount=10000, SymbolCount=512",
+            "Statistics": { "Mean": 800000.0 },
+            "Memory": { "BytesAllocatedPerOperation": 320000 }
+          }
+        ]
+      }
+      """;
+
+    private static JsonDocument Report() => JsonDocument.Parse(SampleReport);
+
+    private static Baseline MakeBaseline(
+        double? meanNs = 53.0,
+        double? allocB = 32.0,
+        double meanTol = 10,
+        double allocTol = 20,
+        int symbolCount = 64,
+        string method = "OnPacket_DispatchLoop",
+        string benchmark = "BookManagerOnPacketBenchmarks")
+    {
+        return new Baseline
+        {
+            Benchmark = benchmark,
+            Method = method,
+            Params = new Dictionary<string, JsonElement>
+            {
+                ["MessageCount"] = JsonDocument.Parse("10000").RootElement.Clone(),
+                ["SymbolCount"] = JsonDocument.Parse(symbolCount.ToString()).RootElement.Clone(),
+            },
+            OpsPerInvocation = 10000,
+            Metrics = new BaselineMetrics { MeanNsPerOp = meanNs, AllocBPerOp = allocB },
+            Tolerance = new BaselineTolerance { MeanPct = meanTol, AllocPct = allocTol },
+        };
+    }
+
+    [Fact]
+    public void WithinTolerance_Passes()
+    {
+        var results = Comparer.Compare(new[] { MakeBaseline() }, Report());
+
+        var r = Assert.Single(results);
+        Assert.Equal("PASS", r.Status);
+        Assert.NotNull(r.ObservedMeanNsPerOp);
+        Assert.Equal(53.0, r.ObservedMeanNsPerOp!.Value, 1);
+        Assert.Equal(32.0, r.ObservedAllocBPerOp!.Value, 1);
+    }
+
+    [Fact]
+    public void MeanOverTolerance_Fails()
+    {
+        // Observed for SymbolCount=512 row is 80 ns/op; baseline 62 ns/op,
+        // tolerance 10% → ~28% delta should trip the gate.
+        var baseline = MakeBaseline(meanNs: 62.0, allocB: 32.0, symbolCount: 512);
+
+        var r = Assert.Single(Comparer.Compare(new[] { baseline }, Report()));
+        Assert.Equal("FAIL", r.Status);
+        Assert.True(r.MeanPctDelta is > 10);
+        Assert.Contains("mean", r.Message);
+    }
+
+    [Fact]
+    public void AllocOverTolerance_Fails()
+    {
+        // Observed alloc is 32 B/op; baseline 20 B/op, tol 20% → +60% delta.
+        var baseline = MakeBaseline(meanNs: 53.0, allocB: 20.0, allocTol: 20);
+
+        var r = Assert.Single(Comparer.Compare(new[] { baseline }, Report()));
+        Assert.Equal("FAIL", r.Status);
+        Assert.True(r.AllocPctDelta is > 20);
+        Assert.Contains("alloc", r.Message);
+    }
+
+    [Fact]
+    public void MissingBenchmark_ReportsClearMessage()
+    {
+        var baseline = MakeBaseline(method: "DoesNotExist");
+
+        var r = Assert.Single(Comparer.Compare(new[] { baseline }, Report()));
+        Assert.Equal("MISSING", r.Status);
+        Assert.Contains("No matching benchmark", r.Message);
+        Assert.Contains("DoesNotExist", r.Message);
+    }
+
+    [Fact]
+    public void MissingMetric_IsNotEnforced()
+    {
+        // Baseline declares only mean; alloc is unset and must not trigger a
+        // failure even if the BDN row reports allocations.
+        var baseline = MakeBaseline(meanNs: 53.0, allocB: null);
+
+        var r = Assert.Single(Comparer.Compare(new[] { baseline }, Report()));
+        Assert.Equal("PASS", r.Status);
+        Assert.Null(r.AllocPctDelta);
+    }
+
+    [Fact]
+    public void ParamsMatch_RequiresAllListedKeys()
+    {
+        var parsed = Comparer.ParseBdnParams("MessageCount=10000, SymbolCount=64");
+        Assert.Equal("10000", parsed["MessageCount"]);
+        Assert.Equal("64", parsed["SymbolCount"]);
+
+        var want = new Dictionary<string, JsonElement>
+        {
+            ["MessageCount"] = JsonDocument.Parse("10000").RootElement.Clone(),
+            ["SymbolCount"] = JsonDocument.Parse("64").RootElement.Clone(),
+        };
+        Assert.True(Comparer.ParamsMatch("MessageCount=10000, SymbolCount=64", want));
+        Assert.False(Comparer.ParamsMatch("MessageCount=10000, SymbolCount=512", want));
+        Assert.False(Comparer.ParamsMatch("MessageCount=10000", want));
+    }
+}

--- a/tools/PerfBaselineCompare.Tests/PerfBaselineCompare.Tests.csproj
+++ b/tools/PerfBaselineCompare.Tests/PerfBaselineCompare.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PerfBaselineCompare\PerfBaselineCompare.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tools/PerfBaselineCompare.Tests/Resources/sample-bdn-report.json
+++ b/tools/PerfBaselineCompare.Tests/Resources/sample-bdn-report.json
@@ -1,0 +1,25 @@
+{
+  "Title": "sample",
+  "Benchmarks": [
+    { "Type": "B3.Umdf.Book.Benchmarks.BookManagerOnPacketBenchmarks",
+      "Method": "OnPacket_DispatchLoop",
+      "Parameters": "MessageCount=10000, SymbolCount=64",
+      "Statistics": { "Mean": 530000.0 },
+      "Memory": { "BytesAllocatedPerOperation": 320000 } },
+    { "Type": "B3.Umdf.Book.Benchmarks.BookManagerOnPacketBenchmarks",
+      "Method": "OnPacket_DispatchLoop",
+      "Parameters": "MessageCount=10000, SymbolCount=512",
+      "Statistics": { "Mean": 620000.0 },
+      "Memory": { "BytesAllocatedPerOperation": 320000 } },
+    { "Type": "B3.Umdf.Book.Benchmarks.BookSideBenchmarks",
+      "Method": "Current_SortedDictionary",
+      "Parameters": "OperationCount=100000",
+      "Statistics": { "Mean": 5000000.0 },
+      "Memory": { "BytesAllocatedPerOperation": 1234 } },
+    { "Type": "B3.Umdf.Feed.Benchmarks.MpscPacketRingBenchmarks",
+      "Method": "Run",
+      "Parameters": "ProducerCount=1, PacketsPerProducer=100000",
+      "Statistics": { "Mean": 12345678.0 },
+      "Memory": { "BytesAllocatedPerOperation": 99 } }
+  ]
+}

--- a/tools/PerfBaselineCompare/Baseline.cs
+++ b/tools/PerfBaselineCompare/Baseline.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.Umdf.Tools.PerfBaselineCompare;
+
+/// <summary>
+/// Strongly-typed shape for our committed baseline JSONs under
+/// <c>docs/perf/baselines/</c>. Designed to be hand-edited; missing
+/// metrics are treated as "not enforced".
+/// </summary>
+public sealed class Baseline
+{
+    [JsonPropertyName("benchmark")]
+    public string Benchmark { get; set; } = "";
+
+    [JsonPropertyName("method")]
+    public string Method { get; set; } = "";
+
+    /// <summary>
+    /// Subset match against BDN's <c>Parameters</c> field
+    /// (e.g. <c>{"MessageCount":10000, "SymbolCount":64}</c>).
+    /// All listed keys must match; extras in the BDN row are ignored.
+    /// </summary>
+    [JsonPropertyName("params")]
+    public Dictionary<string, JsonElement> Params { get; set; } = new();
+
+    /// <summary>
+    /// BenchmarkDotNet reports per-invocation numbers. When a benchmark
+    /// processes N items in a single Benchmark call (e.g. a tight inner
+    /// loop), set this to N so the comparer reports per-item metrics
+    /// matching the doc baselines.
+    /// </summary>
+    [JsonPropertyName("ops_per_invocation")]
+    public long? OpsPerInvocation { get; set; }
+
+    [JsonPropertyName("metrics")]
+    public BaselineMetrics Metrics { get; set; } = new();
+
+    [JsonPropertyName("tolerance")]
+    public BaselineTolerance Tolerance { get; set; } = new();
+
+    [JsonPropertyName("notes")]
+    public string? Notes { get; set; }
+}
+
+public sealed class BaselineMetrics
+{
+    [JsonPropertyName("mean_ns_per_op")]
+    public double? MeanNsPerOp { get; set; }
+
+    [JsonPropertyName("alloc_b_per_op")]
+    public double? AllocBPerOp { get; set; }
+}
+
+public sealed class BaselineTolerance
+{
+    /// <summary>Allowed positive % delta of mean_ns_per_op vs baseline.</summary>
+    [JsonPropertyName("mean_pct")]
+    public double MeanPct { get; set; } = 10;
+
+    /// <summary>Allowed positive % delta of alloc_b_per_op vs baseline.</summary>
+    [JsonPropertyName("alloc_pct")]
+    public double AllocPct { get; set; } = 20;
+}

--- a/tools/PerfBaselineCompare/Comparer.cs
+++ b/tools/PerfBaselineCompare/Comparer.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace B3.Umdf.Tools.PerfBaselineCompare;
+
+/// <summary>
+/// Result of comparing one baseline against a BDN report.
+/// Status indicates whether the baseline was satisfied, exceeded the
+/// tolerance, or could not be matched against any benchmark in the report.
+/// </summary>
+public sealed record ComparisonResult(
+    Baseline Baseline,
+    string Status, // "PASS", "FAIL", "MISSING"
+    double? ObservedMeanNsPerOp,
+    double? ObservedAllocBPerOp,
+    double? MeanPctDelta,
+    double? AllocPctDelta,
+    string Message);
+
+public static class Comparer
+{
+    /// <summary>
+    /// Compares <paramref name="baselines"/> against benchmark rows in a
+    /// BenchmarkDotNet report JSON document. Returns one result per baseline.
+    /// </summary>
+    public static List<ComparisonResult> Compare(IReadOnlyList<Baseline> baselines, JsonDocument bdnReport)
+    {
+        var benchmarks = bdnReport.RootElement.TryGetProperty("Benchmarks", out var b)
+            ? b
+            : throw new InvalidDataException("BDN report missing 'Benchmarks' array.");
+
+        var results = new List<ComparisonResult>(baselines.Count);
+        foreach (var baseline in baselines)
+        {
+            results.Add(CompareOne(baseline, benchmarks));
+        }
+        return results;
+    }
+
+    private static ComparisonResult CompareOne(Baseline baseline, JsonElement benchmarks)
+    {
+        JsonElement? match = null;
+        foreach (var bench in benchmarks.EnumerateArray())
+        {
+            if (!TryGetString(bench, "Type", out var type) ||
+                !TryGetString(bench, "Method", out var method))
+            {
+                continue;
+            }
+
+            if (!TypeMatches(type, baseline.Benchmark)) continue;
+            if (!string.Equals(method, baseline.Method, StringComparison.Ordinal)) continue;
+
+            var paramString = TryGetString(bench, "Parameters", out var p) ? p : "";
+            if (!ParamsMatch(paramString, baseline.Params)) continue;
+
+            match = bench;
+            break;
+        }
+
+        if (match is null)
+        {
+            return new ComparisonResult(
+                baseline,
+                "MISSING",
+                null, null, null, null,
+                $"No matching benchmark in report for {baseline.Benchmark}.{baseline.Method} {ParamsToString(baseline.Params)}");
+        }
+
+        double divisor = baseline.OpsPerInvocation is { } n && n > 0 ? n : 1;
+
+        double? observedMeanPerOp = null;
+        if (match.Value.TryGetProperty("Statistics", out var stats) &&
+            stats.TryGetProperty("Mean", out var mean) &&
+            mean.ValueKind == JsonValueKind.Number)
+        {
+            observedMeanPerOp = mean.GetDouble() / divisor;
+        }
+
+        double? observedAllocPerOp = null;
+        if (match.Value.TryGetProperty("Memory", out var mem) &&
+            mem.ValueKind == JsonValueKind.Object &&
+            mem.TryGetProperty("BytesAllocatedPerOperation", out var bytes) &&
+            bytes.ValueKind == JsonValueKind.Number)
+        {
+            observedAllocPerOp = bytes.GetDouble() / divisor;
+        }
+
+        double? meanDelta = null;
+        bool meanFail = false;
+        if (baseline.Metrics.MeanNsPerOp is { } baseMean && baseMean > 0 && observedMeanPerOp is { } obsMean)
+        {
+            meanDelta = (obsMean - baseMean) / baseMean * 100.0;
+            if (meanDelta > baseline.Tolerance.MeanPct) meanFail = true;
+        }
+
+        double? allocDelta = null;
+        bool allocFail = false;
+        if (baseline.Metrics.AllocBPerOp is { } baseAlloc && observedAllocPerOp is { } obsAlloc)
+        {
+            // Avoid divide-by-zero; if baseline alloc is 0, treat any observed >0 as a regression.
+            if (baseAlloc > 0)
+            {
+                allocDelta = (obsAlloc - baseAlloc) / baseAlloc * 100.0;
+                if (allocDelta > baseline.Tolerance.AllocPct) allocFail = true;
+            }
+            else
+            {
+                allocDelta = obsAlloc > 0 ? double.PositiveInfinity : 0;
+                if (obsAlloc > 0) allocFail = true;
+            }
+        }
+
+        var status = (meanFail || allocFail) ? "FAIL" : "PASS";
+        var msg = status == "PASS"
+            ? "within tolerance"
+            : $"regression: " +
+              (meanFail ? $"mean +{meanDelta:F1}% > {baseline.Tolerance.MeanPct}% " : "") +
+              (allocFail ? $"alloc +{allocDelta:F1}% > {baseline.Tolerance.AllocPct}%" : "");
+
+        return new ComparisonResult(
+            baseline,
+            status,
+            observedMeanPerOp,
+            observedAllocPerOp,
+            meanDelta,
+            allocDelta,
+            msg.Trim());
+    }
+
+    private static bool TypeMatches(string bdnType, string baselineBenchmark)
+    {
+        // Match the unqualified class name; baseline files use the short name.
+        if (string.Equals(bdnType, baselineBenchmark, StringComparison.Ordinal)) return true;
+        var lastDot = bdnType.LastIndexOf('.');
+        var simple = lastDot >= 0 ? bdnType[(lastDot + 1)..] : bdnType;
+        return string.Equals(simple, baselineBenchmark, StringComparison.Ordinal);
+    }
+
+    internal static bool ParamsMatch(string bdnParams, IReadOnlyDictionary<string, JsonElement> wanted)
+    {
+        if (wanted.Count == 0) return true;
+        var parsed = ParseBdnParams(bdnParams);
+        foreach (var (k, v) in wanted)
+        {
+            if (!parsed.TryGetValue(k, out var actual)) return false;
+            if (!ParamValueEquals(v, actual)) return false;
+        }
+        return true;
+    }
+
+    internal static Dictionary<string, string> ParseBdnParams(string parameters)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(parameters)) return result;
+        foreach (var part in parameters.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0) continue;
+            result[part[..eq].Trim()] = part[(eq + 1)..].Trim();
+        }
+        return result;
+    }
+
+    private static bool ParamValueEquals(JsonElement want, string actual)
+    {
+        return want.ValueKind switch
+        {
+            JsonValueKind.Number => want.GetDouble().ToString("R", CultureInfo.InvariantCulture)
+                                        == ParseNumber(actual)?.ToString("R", CultureInfo.InvariantCulture)
+                                    || want.ToString() == actual,
+            JsonValueKind.String => string.Equals(want.GetString(), actual, StringComparison.Ordinal),
+            JsonValueKind.True => actual.Equals("True", StringComparison.OrdinalIgnoreCase),
+            JsonValueKind.False => actual.Equals("False", StringComparison.OrdinalIgnoreCase),
+            _ => string.Equals(want.ToString(), actual, StringComparison.Ordinal),
+        };
+
+        static double? ParseNumber(string s) =>
+            double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var d) ? d : null;
+    }
+
+    private static bool TryGetString(JsonElement element, string name, out string value)
+    {
+        if (element.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String)
+        {
+            value = v.GetString() ?? "";
+            return true;
+        }
+        value = "";
+        return false;
+    }
+
+    private static string ParamsToString(IReadOnlyDictionary<string, JsonElement> p)
+    {
+        if (p.Count == 0) return "(no params)";
+        return "{" + string.Join(", ", p.Select(kv => $"{kv.Key}={kv.Value}")) + "}";
+    }
+}

--- a/tools/PerfBaselineCompare/PerfBaselineCompare.csproj
+++ b/tools/PerfBaselineCompare/PerfBaselineCompare.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>B3.Umdf.Tools.PerfBaselineCompare</RootNamespace>
+    <AssemblyName>perf-baseline-compare</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="PerfBaselineCompare.Tests" />
+  </ItemGroup>
+</Project>

--- a/tools/PerfBaselineCompare/Program.cs
+++ b/tools/PerfBaselineCompare/Program.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using B3.Umdf.Tools.PerfBaselineCompare;
+
+// Usage:
+//   perf-baseline-compare --baselines <dir> --report <bdn-report.json> [--report <other.json> ...]
+//
+// Exits 0 if every baseline that has a metric stays within tolerance.
+// Exits 1 if any baseline regresses or cannot be matched.
+// Exits 2 on argument / IO errors.
+
+string? baselineDir = null;
+var reports = new List<string>();
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--baselines":
+        case "-b":
+            if (++i >= args.Length) return Fail("--baselines requires a path");
+            baselineDir = args[i];
+            break;
+        case "--report":
+        case "-r":
+            if (++i >= args.Length) return Fail("--report requires a path");
+            reports.Add(args[i]);
+            break;
+        case "--help":
+        case "-h":
+            Console.WriteLine("Usage: perf-baseline-compare --baselines <dir> --report <file> [--report <file> ...]");
+            return 0;
+        default:
+            return Fail($"Unknown argument: {args[i]}");
+    }
+}
+
+if (baselineDir is null) return Fail("Missing --baselines <dir>");
+if (reports.Count == 0) return Fail("Missing --report <file>");
+if (!Directory.Exists(baselineDir)) return Fail($"Baselines directory not found: {baselineDir}");
+
+var baselineFiles = Directory.GetFiles(baselineDir, "*.json", SearchOption.TopDirectoryOnly)
+    .OrderBy(f => f, StringComparer.Ordinal)
+    .ToList();
+if (baselineFiles.Count == 0)
+{
+    Console.Error.WriteLine($"No baseline JSON files in {baselineDir}");
+    return 2;
+}
+
+var baselines = new List<Baseline>(baselineFiles.Count);
+foreach (var path in baselineFiles)
+{
+    try
+    {
+        var json = File.ReadAllText(path);
+        var b = JsonSerializer.Deserialize<Baseline>(json,
+            new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
+        if (b is null) { Console.Error.WriteLine($"Skipping empty baseline: {path}"); continue; }
+        baselines.Add(b);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to parse baseline {path}: {ex.Message}");
+        return 2;
+    }
+}
+
+// Combine all benchmark rows from every supplied report so a single
+// invocation can validate the full perf-smoke suite.
+var combined = new List<JsonElement>();
+foreach (var r in reports)
+{
+    if (!File.Exists(r)) return Fail($"Report not found: {r}");
+    try
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(r));
+        if (!doc.RootElement.TryGetProperty("Benchmarks", out var arr))
+        {
+            Console.Error.WriteLine($"Report missing 'Benchmarks' array: {r}");
+            return 2;
+        }
+        foreach (var el in arr.EnumerateArray())
+        {
+            // Clone so we can keep references after the JsonDocument is disposed.
+            combined.Add(el.Clone());
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to parse report {r}: {ex.Message}");
+        return 2;
+    }
+}
+
+var combinedJson = JsonSerializer.SerializeToDocument(new { Benchmarks = combined });
+var results = Comparer.Compare(baselines, combinedJson);
+
+PrintTable(results);
+
+bool failed = results.Any(r => r.Status != "PASS");
+return failed ? 1 : 0;
+
+static int Fail(string message)
+{
+    Console.Error.WriteLine(message);
+    return 2;
+}
+
+static void PrintTable(List<ComparisonResult> results)
+{
+    Console.WriteLine();
+    Console.WriteLine("Perf baseline comparison");
+    Console.WriteLine(new string('=', 96));
+    Console.WriteLine($"{"STATUS",-7} {"BENCHMARK.METHOD",-55} {"MEAN Δ%",10} {"ALLOC Δ%",12}");
+    Console.WriteLine(new string('-', 96));
+    foreach (var r in results)
+    {
+        var name = $"{r.Baseline.Benchmark}.{r.Baseline.Method}";
+        if (name.Length > 55) name = name[..55];
+        var mean = r.MeanPctDelta.HasValue ? $"{r.MeanPctDelta.Value:+0.0;-0.0;0.0}" : "n/a";
+        var alloc = r.AllocPctDelta.HasValue ? $"{r.AllocPctDelta.Value:+0.0;-0.0;0.0}" : "n/a";
+        Console.WriteLine($"{r.Status,-7} {name,-55} {mean,10} {alloc,12}");
+        if (r.Status != "PASS") Console.WriteLine($"        → {r.Message}");
+    }
+    Console.WriteLine(new string('=', 96));
+    int pass = results.Count(r => r.Status == "PASS");
+    int fail = results.Count(r => r.Status == "FAIL");
+    int miss = results.Count(r => r.Status == "MISSING");
+    Console.WriteLine($"Total: {results.Count}  Pass: {pass}  Fail: {fail}  Missing: {miss}");
+}
+
+// Make Program a partial class so the test project can reference internals via
+// InternalsVisibleTo if ever needed; today the comparer logic is in its own type.
+public partial class Program { }


### PR DESCRIPTION
Quick wins for the first two audit findings on #19. The remaining
findings (microbench coverage gaps; live-traffic parameterization)
are intentionally deferred to follow-up PRs so this scaffold can
land small.

## What this PR adds

### A. Machine-readable baselines (`docs/perf/baselines/`)
One JSON file per `(benchmark, method, parameter set)`:

| File | Source of numbers |
|---|---|
| `BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols64.json` | `docs/perf/onpacket-profiling.md` (53 ns/op, 32 B/op @ 64 symbols, AMD EPYC 7763) |
| `BookManagerOnPacketBenchmarks.OnPacket_DispatchLoop-Symbols512.json` | same doc, 62 ns/op, 32 B/op @ 512 symbols |
| `BookSideBenchmarks.Current_SortedDictionary.json` | **schema only — no metrics** |
| `MpscPacketRingBenchmarks.Run.json` | **schema only — no metrics** |

**Why doc-sourced for now:** the only defensible numbers we have
today are the prose tables already committed in `docs/perf/`. They
were captured on AMD EPYC 7763 in a prior audit cycle, not on the
runner CI will use. The `notes` field on every populated baseline
calls this out explicitly and asks for a fresh capture on stable
hardware before the numbers are treated as a hard gate. Tolerances
(`mean_pct=15`, `alloc_pct=25`) are deliberately loose to absorb
shared-runner noise until that re-capture happens.

**Why two files are schema-only:** `BookSideBenchmarks` and
`MpscPacketRingBenchmarks` have no defensible single number in the
committed prose docs, so we ship the file with `metrics: {}` rather
than fabricate one. The comparer matches the row but has nothing to
gate on — populating these is a straightforward follow-up the first
time the workflow runs on a stable runner.

`docs/perf/baselines/README.md` documents the format, refresh
procedure, hardware caveats, and the rule that **PRs altering perf
MUST update the affected baseline JSON in the same PR**.

### B. `tools/PerfBaselineCompare`
Tiny .NET 10 console + xUnit test project (uses only `System.Text.Json`
— no new external deps). It:

* Loads every `*.json` from a baselines dir.
* Reads one or more BDN `*-report-full.json` files.
* For each baseline, finds the matching benchmark by `Type` +
  `Method` + parameter subset, computes `mean_pct_delta` and
  `alloc_pct_delta`, and prints a pass/fail table.
* Exits non-zero on regression or unmatched baseline.
* Supports `ops_per_invocation` so baselines stay in per-item units
  even when a `[Benchmark]` method runs an inner loop (which
  `BookManagerOnPacketBenchmarks` does — `MessageCount` items per
  invocation).

Six unit tests cover: within-tolerance pass, mean-over-tolerance
fail, alloc-over-tolerance fail, missing-benchmark message,
metric-omitted (not enforced), and parameter matching. Sanity-checked
locally against canned BDN-shaped reports — exits 0 within tolerance
and exits 1 with a clear `'mean +69.8% > 15%'`-style message when
over.

### C. `.github/workflows/perf-smoke.yml`
Triggers:
* `workflow_dispatch` — always available.
* `pull_request` — only runs when the PR carries the **`run-perf`**
  label.

Steps: checkout → setup-dotnet 10.x → restore → build → run the
three suites with `--filter '*BookManagerOnPacketBenchmarks*|*BookSideBenchmarks*|*MpscPacketRingBenchmarks*'`
→ upload BDN artifacts → invoke `PerfBaselineCompare` against
`docs/perf/baselines/`.

The workflow's header comment explains that BDN on shared
GitHub-hosted runners is high-noise and that regressions should be
treated as **advisory** until reproduced on stable HW. The workflow
is **not** wired into required status checks.

### D. `docs/perf/README.md`
Updated the doc TOC to point at `baselines/` and explain the
`run-perf` label convention.

## Verification
* `dotnet build -c Release --nologo` → **0 warnings, 0 errors**.
* `dotnet test -c Release --nologo --no-build` → **498 / 498 pass**
  (existing suite + 6 new `ComparerTests`).
* `PerfBaselineCompare` exercised end-to-end against canned BDN
  reports: exits 0 when within tolerance, exits 1 with a clear
  regression message when over.

## Out of scope (deferred)
* Microbenches for `StaleMboBuffer.Drain`, `GroupConflationHandler.Flush`,
  `ChannelHandler` reorder, `SymbolStateRegistry` forced-heal —
  audit finding #3, separate PR.
* Parameterizing benchmarks for the documented 118 kpps real-traffic
  burst — audit finding #4, separate PR.
* No refactor of existing benchmark code in this PR.

Refs #19.