### PR TITLE
feat(protocol): ServerHello handshake + SymbolDelisted notification (refs #17)

### DIFF
--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -16,6 +16,16 @@ export const MSG = {
   CANDLE_UPDATE: 0x0061,
   SYMBOL_STALE_STATUS: 0x0070,
   RECOVERY_PROGRESS: 0x0080,
+  SYMBOL_DELISTED: 0x0071,
+  SERVER_HELLO: 0x00A0,
+};
+
+// Bitfield positions for ServerHello.capabilities. Mirror of the server's
+// `ServerCapabilities` enum. Unknown bits MUST be ignored — never gate behaviour
+// on the absence of a known bit (forward compatibility).
+export const SERVER_CAPABILITIES = {
+  SNAPSHOT_ON_SUBSCRIBE: 0x0001,
+  SYMBOL_DELISTED_NOTIFICATION: 0x0002,
 };
 
 export const MSG_NAMES = Object.fromEntries(Object.entries(MSG).map(([k, v]) => [v, k]));
@@ -272,6 +282,17 @@ export function parseMessage(buf, baseOffset, msgLen) {
         staleByKind[kindId] = count;
       }
       return { type: 'RecoveryProgress', totalSymbols, totalStaleSymbols, staleByKind };
+    }
+    case MSG.SERVER_HELLO: {
+      const protocolVersion = v.getUint32(o, true); o += 4;
+      const capabilities = v.getUint32(o, true); o += 4;
+      const buildLen = v.getUint8(o); o += 1;
+      const buildVersion = decoder.decode(new Uint8Array(buf, baseOffset + o, buildLen));
+      return { type: 'ServerHello', protocolVersion, capabilities, buildVersion };
+    }
+    case MSG.SYMBOL_DELISTED: {
+      const securityId = v.getBigUint64(o, true);
+      return { type: 'SymbolDelisted', securityId };
     }
     default:
       return null;

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -924,6 +924,28 @@ function handleMessage(msg) {
       if (msg.ready && !wasReady) resubscribeAll();
       break;
     }
+    case 'ServerHello': {
+      // Stash the negotiated protocol version + capabilities + build for diagnostics.
+      // UI surfacing is intentionally minimal: log + post for any future status bar.
+      log(`Server protocol v${msg.protocolVersion} (build ${msg.buildVersion}, caps 0x${msg.capabilities.toString(16)})`, 'log-info');
+      postMessage({
+        type: 'serverHello',
+        protocolVersion: msg.protocolVersion,
+        capabilities: msg.capabilities,
+        buildVersion: msg.buildVersion,
+      });
+      break;
+    }
+    case 'SymbolDelisted': {
+      const id = secIdStr(msg.securityId);
+      const sub = subscriptions.get(id);
+      log(`Symbol ${sub ? sub.symbol : id} delisted by venue`, 'log-info');
+      // Server has already cleaned up its side; drop the local subscription so we
+      // stop trying to render it. No Unsubscribe frame needed.
+      if (sub) subscriptions.delete(id);
+      mark(D_SUBS | D_ALLINFO);
+      break;
+    }
     case 'SymbolStaleStatus': {
       const id = secIdStr(msg.securityId);
       const sub = subscriptions.get(id);

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -1,5 +1,19 @@
 namespace B3.MarketData.WebSocketClient;
 
+/// <summary>
+/// Mirror of the server's <c>ServerCapabilities</c> bitfield. Surfaced so client
+/// callers can inspect <see cref="ServerHelloEvent.Capabilities"/> without
+/// hard-coding bit positions. Unknown bits MUST be ignored — never gate behaviour
+/// on the absence of a known bit (that's how forward-compat breaks).
+/// </summary>
+[Flags]
+public enum ServerCapabilities : uint
+{
+    None = 0,
+    SnapshotOnSubscribe = 0x0001,
+    SymbolDelistedNotification = 0x0002,
+}
+
 /// <summary>Connection state surfaced via <see cref="MarketDataClient.ConnectionStateChanged"/>.</summary>
 public enum ConnectionState
 {
@@ -79,6 +93,38 @@ public sealed class InfoSnapshotEvent
 /// "do not subscribe yet".
 /// </summary>
 public readonly record struct ServerStatusEvent(bool Ready, DateTime ReceivedUtc);
+
+/// <summary>
+/// First server-initiated frame on a fresh connection. Carries the server-side
+/// protocol version, advertised capabilities bitfield, and build version string.
+/// Surfaced both as the <c>MarketDataClient.ServerHello</c> event and snapshotted
+/// on the <c>MarketDataClient.LastServerHello</c> property so late subscribers can
+/// still inspect the negotiation result.
+/// </summary>
+/// <param name="ProtocolVersion">Server's wire-protocol version. The SDK treats
+/// any value &gt;= 1 as compatible today; bumps signal a breaking change.</param>
+/// <param name="Capabilities">Bitfield of optional features the server advertises.
+/// Unknown bits MUST be treated as reserved; do not gate behaviour on their absence.</param>
+/// <param name="BuildVersion">Free-form server build identifier (assembly version,
+/// semver, or git SHA). Surface as-is to operators; do not parse.</param>
+/// <param name="ReceivedUtc">UTC timestamp at which the SDK received the frame.</param>
+public readonly record struct ServerHelloEvent(
+    uint ProtocolVersion,
+    ServerCapabilities Capabilities,
+    string BuildVersion,
+    DateTime ReceivedUtc);
+
+/// <summary>
+/// Terminal notification for a previously-subscribed security. Risk consumers
+/// MUST stop expecting further data for <see cref="SecurityId"/>; UI consumers
+/// SHOULD remove the symbol from their listings. Server has already torn down
+/// its per-symbol subscription map by the time this fires, so the SDK does NOT
+/// auto-unsubscribe (no Unsubscribe frame is sent).
+/// </summary>
+public readonly record struct SymbolDelistedEvent(
+    ulong SecurityId,
+    string Symbol,
+    DateTime ReceivedUtc);
 
 /// <summary>
 /// Returned by the server when a <c>Subscribe</c> can't be satisfied.

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -70,8 +70,23 @@ public sealed class MarketDataClient : IAsyncDisposable
     public event Action<TradeBustEvent>? TradeBust;
     public event Action<InfoSnapshotEvent>? InfoSnapshot;
     public event Action<ServerStatusEvent>? ServerStatus;
+    public event Action<ServerHelloEvent>? ServerHello;
+    public event Action<SymbolDelistedEvent>? SymbolDelisted;
     public event Action<SubscribeErrorEvent>? SubscribeError;
     public event Action<ConnectionStateChangedEvent>? ConnectionStateChanged;
+
+    /// <summary>
+    /// Most recently received <c>ServerHello</c> (if any). Cached on the dispatch
+    /// thread and snapshotted under <c>_stateLock</c> so callers that connect after
+    /// the handshake event has already fired can still read the negotiated values.
+    /// Reset to <c>null</c> on every reconnect attempt.
+    /// </summary>
+    public ServerHelloEvent? LastServerHello
+    {
+        get { lock (_stateLock) return _lastServerHello; }
+    }
+
+    private ServerHelloEvent? _lastServerHello;
 
     /// <summary>Current connection state. Updated by the run loop.</summary>
     public ConnectionState State
@@ -193,6 +208,7 @@ public sealed class MarketDataClient : IAsyncDisposable
             {
                 ChangeState(ConnectionState.Connecting, error: null);
                 socket = new ClientWebSocket();
+                lock (_stateLock) _lastServerHello = null;
                 await socket.ConnectAsync(_options.Endpoint, ct).ConfigureAwait(false);
                 _socket = socket;
                 ChangeState(ConnectionState.Connected, error: null);
@@ -311,6 +327,21 @@ public sealed class MarketDataClient : IAsyncDisposable
             {
                 bool ready = WireFormat.ReadServerStatus(payload);
                 Enqueue(() => ServerStatus?.Invoke(new ServerStatusEvent(ready, receivedUtc)));
+                break;
+            }
+            case WireFormat.MessageType.ServerHello:
+            {
+                var (ver, caps, build) = WireFormat.ReadServerHello(payload);
+                var ev = new ServerHelloEvent(ver, caps, build, receivedUtc);
+                lock (_stateLock) _lastServerHello = ev;
+                Enqueue(() => ServerHello?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.SymbolDelisted:
+            {
+                ulong secId = WireFormat.ReadSymbolDelisted(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                Enqueue(() => SymbolDelisted?.Invoke(new SymbolDelistedEvent(secId, symbol, receivedUtc)));
                 break;
             }
             case WireFormat.MessageType.SubscribeOk:

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -28,6 +28,8 @@ internal static class WireFormat
         Trade = 0x0033,
         TradeBust = 0x0035,
         ServerStatus = 0x0050,
+        SymbolDelisted = 0x0071,
+        ServerHello = 0x00A0,
     }
 
     // InfoSnapshot field-mask bit positions. Must match the server's
@@ -115,6 +117,24 @@ internal static class WireFormat
     }
 
     public static bool ReadServerStatus(ReadOnlySpan<byte> payload) => payload[0] != 0;
+
+    /// <summary>
+    /// Decode a <c>ServerHello</c> payload (everything after the 4-byte framing
+    /// header). Layout: <c>[u32 protocolVersion][u32 capabilities][u8 buildVerLen][buildVer UTF-8…]</c>.
+    /// </summary>
+    public static (uint ProtocolVersion, ServerCapabilities Capabilities, string BuildVersion) ReadServerHello(
+        ReadOnlySpan<byte> payload)
+    {
+        uint version = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+        var caps = (ServerCapabilities)BinaryPrimitives.ReadUInt32LittleEndian(payload[4..]);
+        byte buildLen = payload[8];
+        string build = Encoding.UTF8.GetString(payload.Slice(9, buildLen));
+        return (version, caps, build);
+    }
+
+    /// <summary>Decode a <c>SymbolDelisted</c> payload: <c>[securityId u64]</c>.</summary>
+    public static ulong ReadSymbolDelisted(ReadOnlySpan<byte> payload)
+        => BinaryPrimitives.ReadUInt64LittleEndian(payload);
 
     public static (ulong SecurityId, long Price, long Qty, long TradeId) ReadTrade(ReadOnlySpan<byte> payload)
     {

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -17,6 +17,37 @@ namespace B3.Umdf.Server;
 internal static class SnapshotEmitter
 {
     /// <summary>
+    /// Cached UTF-8 build-version string used in every <see cref="MessageType.ServerHello"/>
+    /// frame. Sourced from the assembly version once at first access — no per-connection
+    /// reflection cost on the hot connect path.
+    /// </summary>
+    private static readonly string s_serverBuildVersion =
+        typeof(SnapshotEmitter).Assembly.GetName().Version?.ToString() ?? "0.0.0.0";
+
+    /// <summary>
+    /// Capabilities advertised in the handshake. Kept as a single source of truth so
+    /// tests can assert against it without re-deriving the bitmask.
+    /// </summary>
+    internal const ServerCapabilities AdvertisedCapabilities =
+        ServerCapabilities.SnapshotOnSubscribe | ServerCapabilities.SymbolDelistedNotification;
+
+    /// <summary>
+    /// Send a <see cref="MessageType.ServerHello"/> as the very first server-initiated
+    /// frame. Carries protocol version + capabilities + server build so clients can
+    /// negotiate features and surface the build version to operators.
+    /// </summary>
+    public static bool SendServerHello(ClientSession session)
+    {
+        var buf = new byte[WireProtocol.ServerHelloMaxSize];
+        int len = WireProtocol.WriteServerHello(
+            buf,
+            WireProtocol.ProtocolVersion,
+            AdvertisedCapabilities,
+            s_serverBuildVersion);
+        return session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len));
+    }
+
+    /// <summary>
     /// Send a server-status frame (ready/initializing) directly. Used both for
     /// fresh-client greeting and for broadcast on RealTime entry.
     /// </summary>

--- a/src/B3.Umdf.Server/SubscriptionManager.cs
+++ b/src/B3.Umdf.Server/SubscriptionManager.cs
@@ -145,8 +145,73 @@ public sealed class SubscriptionManager : IDisposable
             session.SetMarketDataManagers(managers);
         MetricsRegistry.WsConnectionsActive.Add(1);
 
+        // ServerHello MUST be the first server-initiated frame so clients can negotiate
+        // protocol version + capabilities before interpreting any other message.
+        SnapshotEmitter.SendServerHello(session);
+
         // Immediately tell the client whether the server is ready
         SnapshotEmitter.SendServerStatus(session, _ready);
+    }
+
+    /// <summary>
+    /// Terminal notification hook: deliver a <see cref="MessageType.SymbolDelisted"/>
+    /// frame to every current subscriber of <paramref name="securityId"/> and tear
+    /// down the per-symbol subscription map so the symbol stops fanning out.
+    /// <para>Today this hook has no built-in upstream trigger — integration with the
+    /// real SBE delisting code path (e.g. <c>SecurityStatus_3</c> in a terminal state)
+    /// is a follow-up. The hook is exercised by the unit test in
+    /// <c>SubscriptionManagerTests.NotifyDelisted_NotifiesOnlySubscribers</c>.</para>
+    /// <para>Thread-safety: the snapshot of subscriber ids is taken under
+    /// <c>_subLock</c>; per-subscriber <c>TryEnqueue</c> is multi-writer-safe.
+    /// Cleanup runs under the same lock to avoid racing a fresh subscribe.</para>
+    /// </summary>
+    public void NotifyDelisted(ulong securityId)
+    {
+        string[] clientIds;
+        lock (_subLock)
+        {
+            if (!_subscriptions.TryGetValue(securityId, out var subs) || subs.Count == 0)
+                return;
+            clientIds = new string[subs.Count];
+            int i = 0;
+            foreach (var k in subs.Keys) clientIds[i++] = k;
+        }
+
+        var buf = new byte[12];
+        int len = WireProtocol.WriteSymbolDelisted(buf, securityId);
+        var payload = new ReadOnlyMemory<byte>(buf, 0, len);
+
+        foreach (var clientId in clientIds)
+        {
+            if (_clients.TryGetValue(clientId, out var session))
+                session.TryEnqueue(payload);
+        }
+
+        // Tear down the per-symbol subscription map last so any concurrent
+        // broadcast that has already snapshotted the inner dict still gets
+        // through, but no future broadcast will find subscribers for it.
+        lock (_subLock)
+        {
+            foreach (var clientId in clientIds)
+                RemoveSubscriptionCore(clientId, securityId, enqueueAck: false, adjustMetric: true);
+        }
+    }
+
+    /// <summary>
+    /// Test-only seam: register a synthetic subscription without going through the
+    /// full snapshot/registry pipeline. Used by <c>SubscriptionManagerTests</c> to
+    /// exercise <see cref="NotifyDelisted"/> in isolation.
+    /// </summary>
+    internal void AddSubscriptionForTest(string clientId, ulong securityId, DataFlags flags)
+    {
+        lock (_subLock)
+        {
+            var newClients = _subscriptions.TryGetValue(securityId, out var existing)
+                ? new Dictionary<string, SubscriptionState>(existing)
+                : new Dictionary<string, SubscriptionState>();
+            newClients[clientId] = new SubscriptionState(flags, 0);
+            _subscriptions[securityId] = newClients;
+        }
     }
 
     /// <summary>Unregister a client and remove all its subscriptions.</summary>

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -65,6 +65,16 @@ public enum MessageType : ushort
     /// the last value within a packet wins.</summary>
     SymbolStaleStatus = 0x0070,
 
+    /// <summary>Server → Client: terminal notification that a previously-subscribed
+    /// security has been delisted by the venue. Carries only the securityId; clients
+    /// MUST stop expecting further data for that symbol and SHOULD remove it from
+    /// their UI. The server cleans up the per-symbol subscription map after sending,
+    /// so subsequent <c>Subscribe</c> attempts for the same symbol will fail with
+    /// <see cref="SubscribeErrorCode.UnknownSymbol"/>.
+    /// Issued via <c>SubscriptionManager.NotifyDelisted</c>; integration with the
+    /// upstream SBE delisting trigger is intentionally a follow-up.</summary>
+    SymbolDelisted = 0x0071,
+
     /// <summary>Server → Client: aggregate recovery progress.
     /// Periodic broadcast (~250ms) of total stale symbols and per-kind breakdown across
     /// all channel groups. Stops after totalStale=0 has been broadcast once so clients
@@ -89,6 +99,32 @@ public enum MessageType : ushort
     /// Lets clients release per-news buffers and surface the assembled news to
     /// the UI exactly once.</summary>
     NewsEnd = 0x0092,
+
+    /// <summary>Server → Client: protocol/version handshake. Sent as the very first
+    /// frame after a client connects (before <see cref="ServerStatus"/>) so consumers
+    /// can negotiate features and surface the server build to operators.
+    /// Payload: <c>[u32 protocolVersion][u32 capabilities][u8 buildVerLen][buildVer UTF-8]</c>.
+    /// The MessageType is purely additive — older clients that don't recognise it MUST
+    /// skip the frame (length-prefixed) and continue parsing the next message.</summary>
+    ServerHello = 0x00A0,
+}
+
+/// <summary>
+/// Bitfield of optional server-side features advertised in <see cref="MessageType.ServerHello"/>.
+/// Clients MUST treat unknown bits as reserved (ignore + log). New flags are appended
+/// only — bits MUST NOT be reused or repurposed once shipped.
+/// </summary>
+[Flags]
+public enum ServerCapabilities : uint
+{
+    None = 0,
+    /// <summary>Server pushes initial book/info/MBP snapshot frames immediately on
+    /// successful Subscribe. Always set today; documented as a flag so clients can
+    /// branch cleanly once a future server might allow snapshot opt-out.</summary>
+    SnapshotOnSubscribe = 0x0001,
+    /// <summary>Server emits <see cref="MessageType.SymbolDelisted"/> as the terminal
+    /// notification when a subscribed security is delisted mid-session.</summary>
+    SymbolDelistedNotification = 0x0002,
 }
 
 public enum SubscribeErrorCode : byte
@@ -366,6 +402,78 @@ public static class WireProtocol
         WriteFramingHeader(dest, totalLen, MessageType.BookCleared);
         BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
         dest[12] = clearSide;
+        return totalLen;
+    }
+
+    /// <summary>
+    /// Current server-side wire protocol version. Bumped only on a breaking change to
+    /// the framing or to the semantics of an existing <see cref="MessageType"/>.
+    /// Additive new MessageTypes do NOT bump this field.
+    /// </summary>
+    public const uint ProtocolVersion = 1;
+
+    /// <summary>
+    /// Maximum buffer needed for a <see cref="MessageType.ServerHello"/> frame:
+    /// header(4) + protocolVersion(4) + capabilities(4) + buildVerLen(1) + 255 UTF-8 bytes.
+    /// </summary>
+    public const int ServerHelloMaxSize = FramingHeaderSize + 4 + 4 + 1 + 255;
+
+    /// <summary>
+    /// Write a <see cref="MessageType.ServerHello"/> frame. <paramref name="buildVersion"/>
+    /// is truncated to 255 UTF-8 bytes (the on-wire length prefix is a single byte) so
+    /// callers may safely pass an assembly version, semver string, or git SHA without
+    /// pre-validation. Returns the total number of bytes written.
+    /// </summary>
+    public static int WriteServerHello(
+        Span<byte> dest,
+        uint protocolVersion,
+        ServerCapabilities capabilities,
+        string buildVersion)
+    {
+        // UTF-8-encode into a scratch buffer first so we can clamp to 255 bytes
+        // without truncating mid-codepoint awkwardness — buildVersion is short
+        // (assembly version / sha) so the alloc is negligible.
+        var encoded = Encoding.UTF8.GetBytes(buildVersion ?? string.Empty);
+        if (encoded.Length > 255)
+        {
+            // Defensive: drop trailing bytes; build strings should never exceed 255.
+            var trimmed = new byte[255];
+            Array.Copy(encoded, trimmed, 255);
+            encoded = trimmed;
+        }
+        ushort totalLen = (ushort)(FramingHeaderSize + 4 + 4 + 1 + encoded.Length);
+        WriteFramingHeader(dest, totalLen, MessageType.ServerHello);
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[4..], protocolVersion);
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[8..], (uint)capabilities);
+        dest[12] = (byte)encoded.Length;
+        encoded.CopyTo(dest[13..]);
+        return totalLen;
+    }
+
+    /// <summary>
+    /// Parse a <see cref="MessageType.ServerHello"/> payload (everything after the
+    /// 4-byte framing header). Returns the negotiated tuple. Used by the C# client
+    /// SDK and useful to round-trip in tests.
+    /// </summary>
+    public static (uint ProtocolVersion, ServerCapabilities Capabilities, string BuildVersion) ReadServerHello(
+        ReadOnlySpan<byte> payload)
+    {
+        uint version = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+        var caps = (ServerCapabilities)BinaryPrimitives.ReadUInt32LittleEndian(payload[4..]);
+        byte buildLen = payload[8];
+        string build = Encoding.UTF8.GetString(payload.Slice(9, buildLen));
+        return (version, caps, build);
+    }
+
+    /// <summary>
+    /// Write a <see cref="MessageType.SymbolDelisted"/> frame: <c>[securityId u64]</c>.
+    /// Total: 12 bytes. Sent once per subscriber when a security is delisted.
+    /// </summary>
+    public static int WriteSymbolDelisted(Span<byte> dest, ulong securityId)
+    {
+        const ushort totalLen = FramingHeaderSize + 8; // 12
+        WriteFramingHeader(dest, totalLen, MessageType.SymbolDelisted);
+        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
         return totalLen;
     }
 

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -138,6 +138,46 @@ public class MarketDataClientIntegrationTests
         Assert.True(subscribesSeen >= 2, $"expected ≥ 2 subscribes after reconnect, saw {subscribesSeen}");
     }
 
+    [Fact]
+    public async Task ServerHello_IsParsed_AndExposedOnLastServerHello()
+    {
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            // Push a ServerHello as the first frame, then idle. Mirrors what the
+            // real server's RegisterClient does on connect.
+            await TestWsServer.SendServerHelloAsync(
+                ws,
+                protocolVersion: 1,
+                capabilities: 0x03, // SnapshotOnSubscribe | SymbolDelistedNotification
+                buildVersion: "1.2.3-test",
+                ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        var helloReceived = new TaskCompletionSource<ServerHelloEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.ServerHello += h => helloReceived.TrySetResult(h);
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+
+        var hello = await helloReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1U, hello.ProtocolVersion);
+        Assert.Equal(ServerCapabilities.SnapshotOnSubscribe | ServerCapabilities.SymbolDelistedNotification, hello.Capabilities);
+        Assert.Equal("1.2.3-test", hello.BuildVersion);
+
+        // LastServerHello property snapshots the most-recently-received hello so
+        // late subscribers can still inspect the negotiation result.
+        var snap = client.LastServerHello;
+        Assert.NotNull(snap);
+        Assert.Equal(1U, snap!.Value.ProtocolVersion);
+        Assert.Equal("1.2.3-test", snap.Value.BuildVersion);
+    }
+
     private static async Task WaitUntil(Func<bool> pred, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -251,6 +291,21 @@ internal sealed class TestWsServer : IAsyncDisposable
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(12), price);
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(20), qty);
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(28), tradeId);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendServerHelloAsync(WebSocket ws, uint protocolVersion, uint capabilities, string buildVersion, CancellationToken ct)
+    {
+        // [len u16][type u16=0x00A0][protocolVersion u32][capabilities u32][buildVerLen u8][buildVer UTF-8…]
+        var buildBytes = Encoding.UTF8.GetBytes(buildVersion);
+        ushort total = (ushort)(4 + 4 + 4 + 1 + buildBytes.Length);
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x00A0);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), protocolVersion);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(8), capabilities);
+        buf[12] = (byte)buildBytes.Length;
+        buildBytes.CopyTo(buf, 13);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 }

--- a/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
+++ b/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
@@ -217,6 +217,45 @@ public class SubscriptionManagerTests
     }
 
     [Fact]
+    public void NotifyDelisted_NotifiesOnlySubscribers_AndCleansUpSubscriptionMap()
+    {
+        using var sm = new SubscriptionManager();
+
+        var subscriber = new ClientSession(new FakeWebSocket(), channelCapacity: 16);
+        var bystander = new ClientSession(new FakeWebSocket(), channelCapacity: 16);
+        sm.RegisterClient(subscriber);
+        sm.RegisterClient(bystander);
+
+        // Both sessions received ServerHello + ServerStatus on register (2 frames each).
+        Assert.Equal(2, subscriber.QueueDepth);
+        Assert.Equal(2, bystander.QueueDepth);
+
+        const ulong securityId = 9999UL;
+        sm.AddSubscriptionForTest(subscriber.Id, securityId, DataFlags.Book);
+        Assert.Equal(1, sm.ActiveSymbolCount);
+
+        int subscriberBefore = subscriber.QueueDepth;
+        int bystanderBefore = bystander.QueueDepth;
+        sm.NotifyDelisted(securityId);
+
+        // Subscriber gains the SymbolDelisted frame (and any internal cleanup deltas
+        // routed through the outbound ring); bystander's queue is untouched.
+        Assert.True(subscriber.QueueDepth > subscriberBefore,
+            $"subscriber should receive SymbolDelisted (depth {subscriberBefore} -> {subscriber.QueueDepth})");
+        Assert.Equal(bystanderBefore, bystander.QueueDepth);
+
+        // Server-side subscription map for the symbol is cleared so future events
+        // for the same securityId no longer fan out anywhere.
+        Assert.Equal(0, sm.ActiveSymbolCount);
+
+        // Idempotent: re-calling on a symbol with no subscribers is a no-op.
+        int subscriberAfter = subscriber.QueueDepth;
+        sm.NotifyDelisted(securityId);
+        Assert.Equal(subscriberAfter, subscriber.QueueDepth);
+        Assert.Equal(bystanderBefore, bystander.QueueDepth);
+    }
+
+    [Fact]
     public void AppSettings_DefaultValues()
     {
         var settings = new AppSettings();

--- a/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
@@ -229,6 +229,54 @@ public class WebSocketHostIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task WebSocket_ServerHello_IsFirstFrame_AndCarriesProtocolVersion()
+    {
+        var (host, sm, port, cts) = await StartHostAsync();
+        using var ws = new ClientWebSocket();
+        try
+        {
+            await ws.ConnectAsync(new Uri($"ws://127.0.0.1:{port}/ws"), CancellationToken.None);
+
+            // Read the first WebSocket frame: it MUST be the binary ServerHello,
+            // emitted by RegisterClient before ServerStatus.
+            var buffer = new byte[1024];
+            using var receiveCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            int filled = 0;
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer, filled, buffer.Length - filled), receiveCts.Token);
+                filled += result.Count;
+            } while (!result.EndOfMessage);
+
+            Assert.Equal(WebSocketMessageType.Binary, result.MessageType);
+
+            // Frame 0: ServerHello (length-prefixed, type at offset 2).
+            ushort len = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+            ushort type = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(2));
+            Assert.Equal((ushort)MessageType.ServerHello, type);
+            Assert.True(filled >= len, $"frame should be at least {len} bytes (got {filled})");
+
+            var (protocolVersion, capabilities, buildVersion) =
+                WireProtocol.ReadServerHello(buffer.AsSpan(WireProtocol.FramingHeaderSize, len - WireProtocol.FramingHeaderSize));
+
+            Assert.Equal(WireProtocol.ProtocolVersion, protocolVersion);
+            Assert.False(string.IsNullOrEmpty(buildVersion), "ServerHello.buildVersion must be non-empty");
+            Assert.True(capabilities.HasFlag(ServerCapabilities.SnapshotOnSubscribe));
+            Assert.True(capabilities.HasFlag(ServerCapabilities.SymbolDelistedNotification));
+
+            await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+        }
+        finally
+        {
+            cts.Cancel();
+            await host.StopAsync();
+            await host.DisposeAsync();
+            sm.Dispose();
+        }
+    }
+
     private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;


### PR DESCRIPTION
Closes the two quick-win audit findings on issue #17 by adding two purely additive WebSocket `MessageType` values plus first-class client surfaces for both.

## What's in the box

### ServerHello — `MessageType.ServerHello = 0x00A0`
- Sent as the **very first** server-initiated frame from `SubscriptionManager.RegisterClient`, **before** `ServerStatus`.
- Payload: `[u32 protocolVersion][u32 capabilities][u8 buildVerLen][buildVer UTF-8…]`.
- `WireProtocol.ProtocolVersion = 1` — bumped only on a breaking change to framing or to existing message semantics. Adding new MessageTypes does **not** bump it.
- `serverBuildVersion` is read once from the executing assembly's version (no per-connection reflection cost).

### ServerCapabilities bitfield (append-only, both server + client)
| Bit | Name | Meaning |
|---|---|---|
| 0x01 | `SnapshotOnSubscribe` | Server pushes initial snapshot frames immediately on Subscribe (always set today; flagged so a future server can opt out cleanly). |
| 0x02 | `SymbolDelistedNotification` | Server emits `SymbolDelisted` as the terminal notification when a subscribed security is delisted mid-session. |

Pattern for future capabilities: append a new bit, document it in the enum XML doc on both sides, and **never** reuse or repurpose an existing bit. Clients MUST treat unknown bits as reserved (ignore + log) — never gate behaviour on the absence of a known bit.

### SymbolDelisted — `MessageType.SymbolDelisted = 0x0071`
- Payload: `[u64 securityId]` (12 bytes total).
- `SubscriptionManager.NotifyDelisted(securityId)`: snapshots subscribers under `_subLock`, fans out the frame via existing per-subscriber `TryEnqueue`, then tears down the per-symbol subscription map so subsequent ticks for the symbol no longer fan out to anyone.
- **Hook only — no upstream trigger today.** Per the issue's edge-case guidance, the hook is shipped so wiring it to the real SBE delisting code path (e.g. a terminal `SecurityStatus_3`) is a clean follow-up. The hook is exercised by a unit test in isolation; the call-site itself is documented in the XML doc on `NotifyDelisted`.

## Client surfaces

### C# SDK (`B3.MarketData.WebSocketClient`)
- New public events: `MarketDataClient.ServerHello`, `MarketDataClient.SymbolDelisted`.
- New snapshot property: `MarketDataClient.LastServerHello` (cached under `_stateLock`, reset to `null` at the top of every reconnect attempt so late subscribers get the most recent negotiation result).
- New public types: `ServerHelloEvent`, `SymbolDelistedEvent`, `ServerCapabilities` enum (mirrors the server's enum).
- Default no-op branch in `DecodeAndEnqueue` was already present, so older SDK builds skip the new types gracefully.

### Frontend (`frontend/js/protocol.js`, `frontend/js/worker.js`)
- `MSG.SERVER_HELLO`, `MSG.SYMBOL_DELISTED`, plus a `SERVER_CAPABILITIES` table.
- `parseMessage` returns `{ type: 'ServerHello', protocolVersion, capabilities, buildVersion }` and `{ type: 'SymbolDelisted', securityId }`.
- Worker logs the hello (with build version + capability bits in hex) and posts a `serverHello` message for any future status bar; `SymbolDelisted` drops the local subscription entry and triggers a UI re-render. Stays minimal — no UI redesign.

## Back-compat story
- **No existing message bytes change.** Only new `MessageType` values were appended to the enum.
- Frontend `parseMessage` already returns `null` for unknown types — older HTML clients running against this server skip the two new frames cleanly.
- C# client `DecodeAndEnqueue` has a default no-op branch — older SDK builds against this server skip them.
- A newer client connecting to an older server simply won't observe the new frames; nothing throws.
- `ProtocolVersion` stays at **1** (handshake is purely additive).

## Tests
- Baseline before this PR: **492** tests passing (post-#24 merge baseline of 486 + 6 from intervening merges).
- New tests (+3): now **495 tests, 0 failures**.
  1. `WebSocketHostIntegrationTests.WebSocket_ServerHello_IsFirstFrame_AndCarriesProtocolVersion` — spins up Kestrel on a loopback port, connects with `ClientWebSocket`, and asserts the first binary frame is `ServerHello` with `ProtocolVersion == 1`, non-empty `buildVersion`, and both capability flags set.
  2. `SubscriptionManagerTests.NotifyDelisted_NotifiesOnlySubscribers_AndCleansUpSubscriptionMap` — registers two sessions, subscribes only one (via a new internal `AddSubscriptionForTest` seam), calls `NotifyDelisted`, asserts the subscriber's outbound queue grew while the bystander's didn't, asserts `ActiveSymbolCount` cleared, asserts idempotency on a second call.
  3. `MarketDataClientIntegrationTests.ServerHello_IsParsed_AndExposedOnLastServerHello` — drives the SDK against the existing in-process `TestWsServer` (with a new `SendServerHelloAsync` helper), asserts the typed event and the `LastServerHello` snapshot.

## Verification
```
dotnet build -c Release --nologo   →  0 Warning(s), 0 Error(s)
dotnet test  -c Release --nologo --no-build  →  495 passed, 0 failed
```

## Out of scope (not touched)
- Transport-level concerns (WS framing, ping/pong, close codes) — that's #18 territory.
- Real upstream SBE → `NotifyDelisted` wiring — explicit follow-up.
- Existing `MessageType` values, payloads, or enum positions — append-only.