### PR TITLE
P1 book: StaleMboBuffer transactional drain primitive

### DIFF
--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -299,7 +299,10 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     /// </summary>
     internal int ReplayDeferredMbo(ulong securityId, uint drainFrom, uint drainTo)
     {
-        return _staleBuffer.Drain(securityId, drainFrom, drainTo, m =>
+        // P1: use transactional drain primitive — atomic restore of buffer
+        // state AND protected floor on apply throw.
+        using var tx = _staleBuffer.BeginDrain(securityId, drainFrom, drainTo);
+        int applied = tx.Apply(m =>
         {
             _currentSendingTimeNs = m.SendingTimeNs;
             switch (m.TemplateId)
@@ -335,6 +338,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             }
             Interlocked.Increment(ref _replayedMboMessages);
         });
+        tx.Commit();
+        return applied;
     }
 
     // ── IMarketDataEventHandler ──

--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -353,9 +353,6 @@ internal sealed class SnapshotApplier
             return;
         }
 
-        // Snapshot lifecycle is ending — release the per-symbol stale-buffer floor pin.
-        _staleBuffer.ClearProtectedFloor(securityId);
-
         if (!pending.HasRptSeq)
             CompleteIlliquidSnapshot(securityId, book, pending);
         else
@@ -383,6 +380,9 @@ internal sealed class SnapshotApplier
     {
         if (pending.OrdersExpected != 0)
         {
+            // Malformed: snapshot is now rejected — release the floor pin
+            // (no Clear() will fire on this path to do it for us).
+            _staleBuffer.ClearProtectedFloor(securityId);
             Interlocked.Increment(ref _snapshotsMissingRptSeq);
             return;
         }
@@ -409,6 +409,9 @@ internal sealed class SnapshotApplier
 
         if (!heal.Accepted)
         {
+            // Snapshot rejected as too-old — release the floor pin (no Clear()
+            // fires on the rejected path; live book is left untouched).
+            _staleBuffer.ClearProtectedFloor(securityId);
             Interlocked.Increment(ref _snapshotsRejectedTooOld);
             return;
         }

--- a/src/B3.Umdf.Book/StaleMboBuffer.cs
+++ b/src/B3.Umdf.Book/StaleMboBuffer.cs
@@ -458,4 +458,200 @@ public sealed class StaleMboBuffer
     /// <summary>Current depth of a symbol's queue (for tests/metrics).</summary>
     public int DepthOf(ulong securityId) =>
         _queues.TryGetValue(securityId, out var q) ? q.Items.Count : 0;
+
+    /// <summary>
+    /// Begin a transactional drain of the per-symbol buffer for
+    /// <paramref name="securityId"/>. The returned <see cref="DrainTransaction"/>
+    /// extracts the matching window (rptSeq ∈ [drainFrom, drainTo]) and the
+    /// future tail from the queue, captures and clears the protected floor
+    /// pin, and gives the caller exclusive ownership of those entries until
+    /// <see cref="DrainTransaction.Commit"/>, <see cref="DrainTransaction.Rollback"/>,
+    /// or <see cref="DrainTransaction.Dispose"/> (which auto-rolls back if neither
+    /// Commit nor Rollback was called).
+    ///
+    /// <para><b>Atomicity guarantee:</b> if the apply callback throws or the
+    /// caller rolls back, the per-symbol queue contents, <see cref="TotalBytes"/>
+    /// accounting, and <see cref="ProtectedFloorOf"/> are restored EXACTLY to
+    /// their pre-<see cref="BeginDrain"/> values. This subsumes (and is stronger
+    /// than) the legacy <see cref="Drain"/> exception-safety contract, which
+    /// only restored the queue/byte state — not the protected floor.</para>
+    ///
+    /// <para><b>Recommended path</b> for new call sites: replaces the
+    /// <c>Drain</c> + <c>ClearProtectedFloor</c> + <c>BumpMinHeal</c>
+    /// coordination dance the caller previously had to choreograph. Old
+    /// <see cref="Drain"/>, <see cref="ClearProtectedFloor"/>, and
+    /// <see cref="SetProtectedFloor"/> remain available for callers that
+    /// have not migrated.</para>
+    ///
+    /// <para><b>Single-thread ownership:</b> per the class-level concurrency
+    /// contract, <c>BeginDrain</c> must be called from the single owner
+    /// (per-group feed) thread, and the returned transaction must not be
+    /// shared across threads.</para>
+    /// </summary>
+    public DrainTransaction BeginDrain(ulong securityId, uint drainFrom, uint drainTo) =>
+        new DrainTransaction(this, securityId, drainFrom, drainTo);
+
+    /// <summary>
+    /// Transactional drain handle returned by <see cref="BeginDrain"/>.
+    /// See that method for the full atomicity / ownership contract.
+    /// Use with <c>using</c> so an unhandled exception in the apply callback
+    /// triggers automatic <see cref="Rollback"/>.
+    /// </summary>
+    public sealed class DrainTransaction : IDisposable
+    {
+        private readonly StaleMboBuffer _buffer;
+        private readonly PerSymbolQueue? _queue;
+        private readonly List<DeferredMboMsg>? _matches;     // rptSeq ∈ [from, to], sorted asc
+        private readonly List<DeferredMboMsg>? _future;      // rptSeq > to
+        private readonly List<DeferredMboMsg>? _belowFloor;  // rptSeq < from
+        private readonly uint _originalFloor;
+        // Single-owner re-entrancy guard: BeginDrain spec is single-threaded
+        // per the class concurrency contract, but a buggy caller could nest
+        // BeginDrain inside an Apply callback. Detect and refuse.
+        private static readonly System.Threading.ThreadLocal<int> _activeTxOnThread =
+            new(() => 0, trackAllValues: false);
+
+        private int _appliedCount;
+        private bool _committed;
+        private bool _rolledBack;
+        private bool _applyThrew;
+
+        internal DrainTransaction(StaleMboBuffer buffer, ulong securityId, uint drainFrom, uint drainTo)
+        {
+            _buffer = buffer;
+            if (_activeTxOnThread.Value > 0)
+                throw new InvalidOperationException(
+                    "StaleMboBuffer.BeginDrain is single-owner: a DrainTransaction is already active on this thread. " +
+                    "Commit or Dispose the outer transaction before starting a new one.");
+            _activeTxOnThread.Value = 1;
+            try
+            {
+                if (drainTo < drainFrom || !buffer._queues.TryGetValue(securityId, out _queue))
+                    return; // empty tx — Commit/Rollback are no-ops
+                _matches = new List<DeferredMboMsg>();
+                _future = new List<DeferredMboMsg>();
+                _belowFloor = new List<DeferredMboMsg>();
+                _originalFloor = _queue.ProtectedFloor;
+                _queue.ProtectedFloor = 0; // capture & clear; restored by Rollback, left cleared by Commit
+                while (_queue.Items.TryDequeue(out var item))
+                {
+                    if (item.RptSeq < drainFrom) _belowFloor.Add(item);
+                    else if (item.RptSeq > drainTo) _future.Add(item);
+                    else _matches.Add(item);
+                }
+                _matches.Sort(static (a, b) => a.RptSeq.CompareTo(b.RptSeq));
+            }
+            catch
+            {
+                _activeTxOnThread.Value = 0;
+                throw;
+            }
+        }
+
+        /// <summary>Number of messages in the drain window that will be applied.</summary>
+        public int MatchCount => _matches?.Count ?? 0;
+
+        /// <summary>True if no messages match the drain window (Commit/Rollback are no-ops).</summary>
+        public bool IsEmpty => MatchCount == 0;
+
+        /// <summary>
+        /// Apply every match in causal (rptSeq) order via <paramref name="apply"/>.
+        /// If the callback throws, the exception propagates; the transaction is
+        /// marked failed and only <see cref="Rollback"/> (or Dispose) is permitted.
+        /// Returns the number of messages successfully applied.
+        /// </summary>
+        public int Apply(Action<DeferredMboMsg> apply)
+        {
+            EnsureNotFinalized();
+            if (_applyThrew)
+                throw new InvalidOperationException("Apply already failed; call Rollback (or Dispose) and start a new transaction.");
+            if (_matches == null) return 0;
+            try
+            {
+                for (int i = _appliedCount; i < _matches.Count; i++)
+                {
+                    apply(_matches[i]);
+                    _appliedCount++;
+                }
+            }
+            catch
+            {
+                _applyThrew = true;
+                throw;
+            }
+            return _appliedCount;
+        }
+
+        /// <summary>
+        /// Commit: release pooled buffers for matched messages, restore
+        /// future-window entries to the queue, drop snapshot-covered (below
+        /// drainFrom) entries, leave the protected floor cleared, and bump
+        /// the drained counter. Forbidden if Apply did not run to completion.
+        /// </summary>
+        public void Commit()
+        {
+            EnsureNotFinalized();
+            if (_applyThrew)
+                throw new InvalidOperationException("Cannot Commit after Apply threw; Rollback (or Dispose) instead.");
+            if (_matches != null && _appliedCount < _matches.Count)
+                throw new InvalidOperationException(
+                    $"Cannot Commit with {_matches.Count - _appliedCount} unapplied matches; call Apply first or Rollback.");
+
+            if (_queue != null && _matches != null && _future != null && _belowFloor != null)
+            {
+                long releasedBytes = 0;
+                for (int i = 0; i < _matches.Count; i++)
+                {
+                    releasedBytes += _matches[i].BodyLength;
+                    _matches[i].Release();
+                }
+                for (int i = 0; i < _belowFloor.Count; i++)
+                {
+                    releasedBytes += _belowFloor[i].BodyLength;
+                    _belowFloor[i].Release();
+                }
+                foreach (var f in _future) _queue.Items.Enqueue(f);
+                Volatile.Write(ref _buffer._totalBytes, Volatile.Read(ref _buffer._totalBytes) - releasedBytes);
+                _buffer._drained += _appliedCount;
+            }
+            _committed = true;
+            _activeTxOnThread.Value = 0;
+        }
+
+        /// <summary>
+        /// Rollback: restore EVERY entry the transaction extracted (matches +
+        /// future + below-floor) to the queue and restore the original
+        /// protected floor. Post-condition: buffer state, TotalBytes, and
+        /// ProtectedFloorOf are byte-identical to pre-<see cref="BeginDrain"/>.
+        /// Idempotent.
+        /// </summary>
+        public void Rollback()
+        {
+            if (_committed || _rolledBack) return;
+            if (_queue != null && _matches != null && _future != null && _belowFloor != null)
+            {
+                // Re-enqueue order is matches → future → below-floor. The next
+                // drain partitions by rptSeq again, so observable behavior is
+                // identical regardless of in-queue order.
+                foreach (var m in _matches) _queue.Items.Enqueue(m);
+                foreach (var f in _future) _queue.Items.Enqueue(f);
+                foreach (var b in _belowFloor) _queue.Items.Enqueue(b);
+                _queue.ProtectedFloor = _originalFloor;
+            }
+            _rolledBack = true;
+            _activeTxOnThread.Value = 0;
+        }
+
+        /// <summary>Auto-Rollback if neither Commit nor Rollback was called.</summary>
+        public void Dispose()
+        {
+            if (!_committed && !_rolledBack) Rollback();
+        }
+
+        private void EnsureNotFinalized()
+        {
+            if (_committed) throw new InvalidOperationException("DrainTransaction already committed.");
+            if (_rolledBack) throw new InvalidOperationException("DrainTransaction already rolled back.");
+        }
+    }
 }

--- a/tests/B3.Umdf.Book.Tests/StaleMboBufferDrainTransactionTests.cs
+++ b/tests/B3.Umdf.Book.Tests/StaleMboBufferDrainTransactionTests.cs
@@ -1,0 +1,241 @@
+using B3.Umdf.Book;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+/// <summary>
+/// Pins the contract of <see cref="StaleMboBuffer.BeginDrain"/> /
+/// <see cref="StaleMboBuffer.DrainTransaction"/> (the P1 transactional drain
+/// primitive). Compared to the legacy <see cref="StaleMboBuffer.Drain"/>
+/// method, the transaction additionally guarantees:
+/// <list type="number">
+///   <item>Atomic restore of the protected floor on Rollback.</item>
+///   <item>Atomic restore of below-floor (snapshot-covered) entries on
+///   Rollback — legacy Drain dropped them irrecoverably.</item>
+///   <item>Auto-Rollback on Dispose without Commit.</item>
+///   <item>Single-thread/single-owner re-entrancy guard.</item>
+/// </list>
+/// </summary>
+public class StaleMboBufferDrainTransactionTests
+{
+    private static StaleMboBuffer NewBuffer() =>
+        new(NullLogger.Instance, perSymbolCap: 1024, globalByteCap: 64L * 1024 * 1024, hotPerSymbolCap: 65536);
+
+    [Fact]
+    public void Commit_AppliesAllEntries_ClearsFloor_BumpsDrainedCounter()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.Enqueue(1, 50, rptSeq: 11, 0, new byte[] { 11 });
+        buf.Enqueue(1, 50, rptSeq: 12, 0, new byte[] { 12 });
+        buf.Enqueue(1, 50, rptSeq: 20, 0, new byte[] { 20, 20 }); // future
+        buf.SetProtectedFloor(1, 9);
+        Assert.Equal(9u, buf.ProtectedFloorOf(1));
+        long preDrainBytes = buf.TotalBytes;
+        Assert.Equal(5, preDrainBytes);
+        long preDrained = buf.DrainedCount;
+
+        var applied = new List<uint>();
+        using (var tx = buf.BeginDrain(1, drainFrom: 10, drainTo: 12))
+        {
+            Assert.Equal(3, tx.MatchCount);
+            Assert.False(tx.IsEmpty);
+            // BeginDrain captures-and-clears the floor for the duration.
+            Assert.Equal(0u, buf.ProtectedFloorOf(1));
+            int n = tx.Apply(m => applied.Add(m.RptSeq));
+            Assert.Equal(3, n);
+            tx.Commit();
+        }
+
+        Assert.Equal(new uint[] { 10, 11, 12 }, applied);
+        Assert.Equal(0u, buf.ProtectedFloorOf(1)); // Commit leaves floor cleared
+        Assert.Equal(preDrained + 3, buf.DrainedCount);
+        // Future entry (20) survives.
+        Assert.Equal(1, buf.DepthOf(1));
+        Assert.Equal(2L, buf.TotalBytes); // only the 2-byte future remains
+    }
+
+    [Fact]
+    public void Rollback_OnApplyThrow_RestoresBufferAndFloorExactly()
+    {
+        var buf = NewBuffer();
+        // Mix of below-floor (5,9), in-window (10,11,12), future (20,21).
+        buf.Enqueue(1, 50, rptSeq: 5, 0, new byte[] { 5 });
+        buf.Enqueue(1, 50, rptSeq: 9, 0, new byte[] { 9 });
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.Enqueue(1, 50, rptSeq: 11, 0, new byte[] { 11 });
+        buf.Enqueue(1, 50, rptSeq: 12, 0, new byte[] { 12 });
+        buf.Enqueue(1, 50, rptSeq: 20, 0, new byte[] { 20, 20 });
+        buf.Enqueue(1, 50, rptSeq: 21, 0, new byte[] { 21, 21 });
+        buf.SetProtectedFloor(1, 10);
+
+        long preDrainBytes = buf.TotalBytes;
+        int preDepth = buf.DepthOf(1);
+        long preDrained = buf.DrainedCount;
+        uint preFloor = buf.ProtectedFloorOf(1);
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var tx = buf.BeginDrain(1, drainFrom: 10, drainTo: 12);
+            // Floor is captured-and-cleared while tx is open.
+            Assert.Equal(0u, buf.ProtectedFloorOf(1));
+            tx.Apply(m =>
+            {
+                if (m.RptSeq == 11) throw new InvalidOperationException("simulated");
+            });
+            tx.Commit(); // unreachable — Apply threw
+        });
+
+        // Post-rollback: EXACTLY pre-drain state.
+        Assert.Equal(preDrainBytes, buf.TotalBytes);
+        Assert.Equal(preDepth, buf.DepthOf(1));
+        Assert.Equal(preDrained, buf.DrainedCount); // no advance — drain rolled back
+        Assert.Equal(preFloor, buf.ProtectedFloorOf(1));
+
+        // Subsequent successful drain should see all in-window entries again.
+        var applied = new List<uint>();
+        using (var tx2 = buf.BeginDrain(1, drainFrom: 10, drainTo: 12))
+        {
+            tx2.Apply(m => applied.Add(m.RptSeq));
+            tx2.Commit();
+        }
+        Assert.Equal(new uint[] { 10, 11, 12 }, applied);
+        // Future entries still there too.
+        Assert.Equal(2, buf.DepthOf(1));
+    }
+
+    [Fact]
+    public void Dispose_WithoutCommit_AutoRollsBack()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.Enqueue(1, 50, rptSeq: 11, 0, new byte[] { 11 });
+        buf.SetProtectedFloor(1, 8);
+
+        long preDrainBytes = buf.TotalBytes;
+
+        // No throw, no Commit — Dispose alone must rollback.
+        var applied = new List<uint>();
+        using (var tx = buf.BeginDrain(1, drainFrom: 10, drainTo: 11))
+        {
+            tx.Apply(m => applied.Add(m.RptSeq));
+            // intentionally no tx.Commit()
+        }
+
+        // Apply did execute — but rollback restores buffer state.
+        Assert.Equal(new uint[] { 10, 11 }, applied);
+        Assert.Equal(preDrainBytes, buf.TotalBytes);
+        Assert.Equal(2, buf.DepthOf(1));
+        Assert.Equal(8u, buf.ProtectedFloorOf(1));
+    }
+
+    [Fact]
+    public void Commit_AfterApplyThrew_IsForbidden()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+
+        using var tx = buf.BeginDrain(1, 10, 10);
+        Assert.Throws<InvalidOperationException>(() =>
+            tx.Apply(_ => throw new InvalidOperationException("boom")));
+        Assert.Throws<InvalidOperationException>(() => tx.Commit());
+        // Rollback is still allowed (and Dispose will call it).
+        tx.Rollback();
+        Assert.Equal(1, buf.DepthOf(1));
+    }
+
+    [Fact]
+    public void Commit_WithUnappliedMatches_IsForbidden()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.Enqueue(1, 50, rptSeq: 11, 0, new byte[] { 11 });
+
+        using var tx = buf.BeginDrain(1, 10, 11);
+        // Caller never calls Apply — Commit must refuse to silently drop matches.
+        Assert.Throws<InvalidOperationException>(() => tx.Commit());
+    }
+
+    [Fact]
+    public void EmptyWindow_BeginDrain_IsNoop()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.SetProtectedFloor(1, 5);
+
+        // drainTo < drainFrom → empty.
+        using (var tx = buf.BeginDrain(1, drainFrom: 5, drainTo: 4))
+        {
+            Assert.Equal(0, tx.MatchCount);
+            Assert.True(tx.IsEmpty);
+            tx.Commit();
+        }
+
+        // Buffer untouched, floor untouched (no clear-and-restore happens
+        // when the tx is empty — preserves the snapshot-in-flight semantics).
+        Assert.Equal(1, buf.DepthOf(1));
+        Assert.Equal(5u, buf.ProtectedFloorOf(1));
+    }
+
+    [Fact]
+    public void NestedBeginDrain_OnSameThread_IsRefused()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        buf.Enqueue(2, 50, rptSeq: 10, 0, new byte[] { 10 });
+
+        using var outerTx = buf.BeginDrain(1, 10, 10);
+        // Even for a different securityId, the single-owner contract refuses
+        // re-entrant drain — the caller is single-threaded by class contract.
+        Assert.Throws<InvalidOperationException>(() => buf.BeginDrain(2, 10, 10));
+        outerTx.Rollback();
+
+        // After outer Rollback the guard is released — fresh tx works.
+        using var nextTx = buf.BeginDrain(2, 10, 10);
+        nextTx.Apply(_ => { });
+        nextTx.Commit();
+    }
+
+    [Fact]
+    public void Rollback_RestoresBelowFloorEntries_NotDroppedLikeLegacyDrain()
+    {
+        // This is the key behavioral upgrade vs. the legacy Drain method:
+        // entries with rptSeq < drainFrom (snapshot-covered) are released by
+        // legacy Drain immediately, irrecoverable on apply throw. The
+        // transaction MUST hold them and restore on rollback.
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 5, 0, new byte[] { 5 });
+        buf.Enqueue(1, 50, rptSeq: 6, 0, new byte[] { 6 });
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+        long preDrainBytes = buf.TotalBytes;
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var tx = buf.BeginDrain(1, drainFrom: 10, drainTo: 10);
+            tx.Apply(_ => throw new InvalidOperationException());
+            tx.Commit();
+        });
+
+        // 5 and 6 must still be enqueued (rollback restored them).
+        Assert.Equal(3, buf.DepthOf(1));
+        Assert.Equal(preDrainBytes, buf.TotalBytes);
+    }
+
+    [Fact]
+    public void Commit_DropsBelowFloorEntries()
+    {
+        var buf = NewBuffer();
+        buf.Enqueue(1, 50, rptSeq: 5, 0, new byte[] { 5 });
+        buf.Enqueue(1, 50, rptSeq: 10, 0, new byte[] { 10 });
+
+        using (var tx = buf.BeginDrain(1, drainFrom: 10, drainTo: 10))
+        {
+            tx.Apply(_ => { });
+            tx.Commit();
+        }
+
+        // Below-floor entry (5) was dropped on Commit (snapshot baseline covers it).
+        Assert.Equal(0, buf.DepthOf(1));
+        Assert.Equal(0L, buf.TotalBytes);
+    }
+}


### PR DESCRIPTION
Audit P1 item 6. Replaces caller-coordinated Drain/Release/ClearProtectedFloor/BumpMinHeal with a single transaction.

**Primitive:** `BeginDrain(secId, drainFrom, drainTo)` returns `DrainTransaction : IDisposable` with `Apply(Action<DeferredMboMsg>)`, `Commit()`, `Rollback()`. Auto-rollback on Dispose.

**Strengthened invariants vs legacy Drain:**
1. Protected floor captured-and-cleared at BeginDrain, restored on Rollback.
2. Below-floor (snapshot-covered) entries also tx-held — restored on Rollback (legacy dropped them).
3. Nested BeginDrain refused via ThreadLocal guard.
4. Commit after Apply throw or with unapplied matches → InvalidOperationException.

**Migrations:** `BookManager.ReplayDeferredMbo` and `SnapshotApplier` floor-cleanup paths.
**Tests:** 193 → 202 (+9). Solution builds 0/0.

Plan ref: item 6.
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>