### PR TITLE
P1 book: TradeBust reverses ring + candle state

### DIFF
--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -30,6 +30,34 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     private long _marketOrderTransitionsToPriced;
     private long _marketOrderTransitionsToMarket;
 
+    // ── Trade-bust reversal state (P1 — TradeBust_57 §10) ────────────────────
+
+    /// <summary>
+    /// Capacity of the per-symbol recent-trade index used for bust reversal.
+    /// Mirrors the ring buffer used downstream by the server (50 entries) but
+    /// gives a little extra headroom for late busts.
+    /// </summary>
+    internal const int TradeBustRingCapacity = 64;
+
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<ulong, SymbolTradeState> _tradeStates = new();
+    private long _tradeBustsReceived;
+    private long _tradeBustsApplied;
+    private long _unknownTradeBusts;
+    private long _outOfRetentionTradeBusts;
+
+    /// <summary>Total <c>TradeBust_57</c> messages dispatched to <see cref="HandleTradeBust"/>.</summary>
+    public long TradeBustsReceived => Volatile.Read(ref _tradeBustsReceived);
+    /// <summary>Trade busts that resulted in real internal-state mutation (ring + candle).</summary>
+    public long TradeBustsApplied => Volatile.Read(ref _tradeBustsApplied);
+    /// <summary>Busts whose tradeId was not found in the per-symbol recent-trade index.</summary>
+    public long UnknownTradeBusts => Volatile.Read(ref _unknownTradeBusts);
+    /// <summary>Busts whose original trade fell outside the candle retention window — counted, not reversed.</summary>
+    public long OutOfRetentionTradeBusts => Volatile.Read(ref _outOfRetentionTradeBusts);
+
+    /// <summary>Per-symbol trade-state lookup. Used by tests to inspect ring/candles after a bust.</summary>
+    internal bool TryGetTradeState(ulong securityId, out SymbolTradeState? state)
+        => _tradeStates.TryGetValue(securityId, out state);
+
     /// <summary>
     /// Packet-level SendingTime (nanoseconds since epoch) for the message currently being processed.
     /// Set at the start of OnPacket, consumed by Handle* methods.
@@ -866,6 +894,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         }
 
         _eventHandler?.OnTrade(securityId, price, quantity, tradeId, tradeTimeNs);
+        RecordTrade(securityId, price, quantity, tradeId, tradeTimeNs);
         TrackMatchEvent(securityId, msg.MatchEventIndicator);
     }
 
@@ -922,6 +951,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         }
 
         _eventHandler?.OnForwardTrade(securityId, price, quantity, tradeId, tradeTimeNs);
+        RecordTrade(securityId, price, quantity, tradeId, tradeTimeNs);
         TrackMatchEvent(securityId, msg.MatchEventIndicator);
     }
 
@@ -949,6 +979,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
 
     private void HandleTradeBust(in TradeBust_57DataReader reader)
     {
+        Interlocked.Increment(ref _tradeBustsReceived);
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
 
@@ -966,8 +997,144 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
                 TrackMboRptSeq(book, (uint)rptSeq);
         }
 
-        _eventHandler?.OnTradeBust(securityId, price, quantity, tradeId);
+        DispatchTradeBust(securityId, price, quantity, tradeId);
         TrackMatchEvent(securityId, msg.MatchEventIndicator);
+    }
+
+    /// <summary>
+    /// Apply a TradeBust_57 to per-symbol state and fan out
+    /// <see cref="IBookEventHandler.OnTradeBust"/>. Single source of truth
+    /// for the post-routing bust path — invoked by both the SBE wire
+    /// handler and tests that drive the contract directly.
+    /// </summary>
+    internal void DispatchTradeBust(ulong securityId, long price, long quantity, long tradeId)
+    {
+        ApplyTradeBustToState(securityId, tradeId);
+        _eventHandler?.OnTradeBust(securityId, price, quantity, tradeId);
+    }
+
+    /// <summary>
+    /// Append a trade to the per-symbol bust-reversal state (recent-trades ring,
+    /// 1-second candle aggregator, id→record index). Called from
+    /// <see cref="HandleTrade"/> / <see cref="HandleForwardTrade"/> after the
+    /// reportable-trade filter.
+    /// </summary>
+    internal void RecordTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+    {
+        long ts = sendingTimeNs > 0 ? sendingTimeNs / 1_000_000_000 : 0;
+        var state = _tradeStates.GetOrAdd(securityId,
+            static _ => new SymbolTradeState(TradeBustRingCapacity));
+        state.AddTrade(price, quantity, tradeId, ts);
+    }
+
+    /// <summary>
+    /// Apply a TradeBust_57 to the per-symbol state: mark the ring slot
+    /// busted, recompute (or remove) the affected 1-second candle bucket,
+    /// and refresh the cached last-trade price. Returns silently and
+    /// counts <see cref="UnknownTradeBusts"/> when the trade id isn't in
+    /// the recent-trade index, or <see cref="OutOfRetentionTradeBusts"/>
+    /// when the trade pre-dates the candle retention window. Successful
+    /// reversals increment <see cref="TradeBustsApplied"/>.
+    /// </summary>
+    internal void ApplyTradeBustToState(ulong securityId, long tradeId)
+    {
+        if (!_tradeStates.TryGetValue(securityId, out var state))
+        {
+            Interlocked.Increment(ref _unknownTradeBusts);
+            return;
+        }
+
+        if (!state.TryGetTrade(tradeId, out var rec))
+        {
+            // Trade id evicted from the bounded id-index. Best-effort:
+            // mark the ring (so snapshot history skips it) and count
+            // out-of-retention; OHLCV cannot be exactly recomputed.
+            if (!state.Ring.MarkBust(tradeId))
+            {
+                Interlocked.Increment(ref _unknownTradeBusts);
+                return;
+            }
+            Interlocked.Increment(ref _outOfRetentionTradeBusts);
+            state.RefreshLastTradeFromRing();
+            Interlocked.Increment(ref _tradeBustsApplied);
+            return;
+        }
+
+        state.Ring.MarkBust(tradeId);
+        state.RemoveTradeFromIndex(tradeId);
+
+        int bucketIdx = state.Candles.FindBucketIndex(rec.TimestampSeconds);
+        if (bucketIdx < 0)
+        {
+            // Bucket has rolled out of the 10-hour retention window. Ring
+            // entry is still flagged so future snapshots skip the busted
+            // print, but candles cannot be recomputed.
+            Interlocked.Increment(ref _outOfRetentionTradeBusts);
+            state.RefreshLastTradeFromRing();
+            Interlocked.Increment(ref _tradeBustsApplied);
+            return;
+        }
+
+        RecomputeBucket(state, bucketIdx, rec);
+        state.RefreshLastTradeFromRing();
+        Interlocked.Increment(ref _tradeBustsApplied);
+    }
+
+    /// <summary>
+    /// Rebuild the OHLCV at <paramref name="bucketIdx"/> after the trade
+    /// described by <paramref name="busted"/> is removed from contention.
+    /// Strategy:
+    /// <list type="bullet">
+    /// <item>If sibling trades from the same bucket are still in the
+    /// id-index, recompute Open (= prior bucket's close, or first remaining
+    /// price for the very first bucket), High, Low, Close, Volume from
+    /// them — exact reversal.</item>
+    /// <item>If no sibling trades remain AND the bucket is the most recent,
+    /// pop it (<see cref="CandleAggregator.RemoveLast"/>) so the next trade
+    /// starts a fresh bucket.</item>
+    /// <item>If no sibling trades remain but the bucket isn't the most
+    /// recent (i.e., gap-fill or follow-on candles came after), collapse
+    /// the bucket to a flat candle at the prior bucket's close (volume = 0)
+    /// and bump <see cref="CandleAggregator.IncrementBustedCount"/>.</item>
+    /// </list>
+    /// </summary>
+    private static void RecomputeBucket(SymbolTradeState state, int bucketIdx, in SymbolTradeState.TradeRecord busted)
+    {
+        var agg = state.Candles;
+        var original = agg.GetAt(bucketIdx);
+        long ts = original.Time;
+        var siblings = state.GetTradesInBucket(ts);
+
+        long priorClose = bucketIdx > 0 ? agg.GetAt(bucketIdx - 1).Close : 0;
+
+        if (siblings.Count > 0)
+        {
+            long open = bucketIdx > 0 ? priorClose : siblings[0].Price;
+            long high = open;
+            long low = open;
+            long volume = 0;
+            long close = open;
+            foreach (var t in siblings)
+            {
+                if (t.Price > high) high = t.Price;
+                if (t.Price < low) low = t.Price;
+                volume += t.Qty;
+                close = t.Price;
+            }
+            agg.ReplaceAt(bucketIdx, new Candle(ts, open, high, low, close, volume, original.Avg));
+            return;
+        }
+
+        bool isLast = bucketIdx == agg.Count - 1;
+        if (isLast)
+        {
+            agg.RemoveLast();
+            return;
+        }
+
+        long flat = priorClose != 0 ? priorClose : original.Close;
+        agg.ReplaceAt(bucketIdx, new Candle(ts, flat, flat, flat, flat, 0, original.Avg));
+        agg.IncrementBustedCount(ts);
     }
 
     // ── Snapshot lifecycle (delegated to SnapshotApplier) ────────────────────

--- a/src/B3.Umdf.Book/CandleAggregator.cs
+++ b/src/B3.Umdf.Book/CandleAggregator.cs
@@ -39,6 +39,13 @@ internal sealed class CandleAggregator
     private volatile int _count;
     private volatile int _version; // bumped on every mutation
 
+    // Per-bucket count of busted trades that fell outside the candle-reversal
+    // window (e.g. the bucket's contributing trades were already evicted from
+    // the ring, so OHLCV cannot be exactly recomputed). Exposed via
+    // <see cref="GetBustedCount"/> so dashboards can flag the affected candle
+    // as "stat-quality-degraded" without distorting OHLC.
+    private Dictionary<long, int>? _bustedCounts;
+
     /// <summary>Resolution is always 1 second.</summary>
     public int Resolution => 1;
 
@@ -47,6 +54,96 @@ internal sealed class CandleAggregator
 
     /// <summary>Version counter — incremented on every Add.</summary>
     public int Version => _version;
+
+    /// <summary>Most recent close price written to the aggregator, or 0 if empty.</summary>
+    public long LastClose => _lastClose;
+
+    /// <summary>
+    /// Locate the candle whose <see cref="Candle.Time"/> equals
+    /// <paramref name="timestampSeconds"/>. Returns the logical index
+    /// (0 = oldest retained) or -1 if no such candle exists in the
+    /// retention window. Buckets are 1-second contiguous (gap-fill
+    /// inserts placeholder candles) so the lookup is O(1).
+    /// </summary>
+    public int FindBucketIndex(long timestampSeconds)
+    {
+        int count = _count;
+        if (count == 0) return -1;
+        int oldestPos = _head;
+        var oldestChunk = _chunks[oldestPos / ChunkSize];
+        if (oldestChunk is null) return -1;
+        long oldestTime = oldestChunk[oldestPos % ChunkSize].Time;
+        long delta = timestampSeconds - oldestTime;
+        if (delta < 0 || delta >= count) return -1;
+        return (int)delta;
+    }
+
+    /// <summary>Read the candle at logical index <paramref name="logicalIndex"/>.</summary>
+    public Candle GetAt(int logicalIndex)
+    {
+        if ((uint)logicalIndex >= (uint)_count)
+            throw new ArgumentOutOfRangeException(nameof(logicalIndex));
+        int pos = (_head + logicalIndex) % MaxRetainedCandles;
+        return _chunks[pos / ChunkSize]![pos % ChunkSize];
+    }
+
+    /// <summary>
+    /// Overwrite the candle at <paramref name="logicalIndex"/>. Used by the
+    /// trade-bust reversal path to swap a recomputed OHLCV in for a
+    /// busted bucket. If the replaced candle is the most recent one,
+    /// <see cref="LastClose"/> is updated to the new close.
+    /// </summary>
+    public void ReplaceAt(int logicalIndex, in Candle candle)
+    {
+        if ((uint)logicalIndex >= (uint)_count)
+            throw new ArgumentOutOfRangeException(nameof(logicalIndex));
+        int pos = (_head + logicalIndex) % MaxRetainedCandles;
+        _chunks[pos / ChunkSize]![pos % ChunkSize] = candle;
+        if (logicalIndex == _count - 1)
+            _lastClose = candle.Close;
+        _version++;
+    }
+
+    /// <summary>
+    /// Drop the most recent candle. Used by trade-bust reversal when the
+    /// busted trade was the only contributor to the latest bucket. Falls
+    /// back <see cref="LastClose"/> to the now-last bucket's close (or 0
+    /// if the aggregator is empty).
+    /// </summary>
+    public bool RemoveLast()
+    {
+        if (_count == 0) return false;
+        _count--;
+        if (_count > 0)
+        {
+            int pos = (_head + _count - 1) % MaxRetainedCandles;
+            _lastClose = _chunks[pos / ChunkSize]![pos % ChunkSize].Close;
+        }
+        else
+        {
+            _lastClose = 0;
+        }
+        _version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Annotate a candle bucket as containing a busted trade we could not
+    /// fully reverse (typically because its sibling trades fell out of the
+    /// recent-trades retention window). OHLCV is left untouched — the
+    /// counter is purely advisory and surfaces via <see cref="GetBustedCount"/>.
+    /// </summary>
+    public void IncrementBustedCount(long timestampSeconds)
+    {
+        _bustedCounts ??= new Dictionary<long, int>();
+        _bustedCounts.TryGetValue(timestampSeconds, out var c);
+        _bustedCounts[timestampSeconds] = c + 1;
+        _version++;
+    }
+
+    /// <summary>How many busted trades fall in the bucket at <paramref name="timestampSeconds"/>.</summary>
+    public int GetBustedCount(long timestampSeconds)
+        => _bustedCounts is { } b && b.TryGetValue(timestampSeconds, out var c) ? c : 0;
 
     /// <summary>Convenience overload for tests/callers that don't have a session VWAP.
     /// Stamps the trade price as Avg (best-effort fallback).</summary>

--- a/src/B3.Umdf.Book/SymbolTradeState.cs
+++ b/src/B3.Umdf.Book/SymbolTradeState.cs
@@ -1,0 +1,112 @@
+namespace B3.Umdf.Book;
+
+/// <summary>
+/// Per-security trade-derived state owned by <see cref="BookManager"/>:
+/// the recent-trades ring used for snapshot history, a 1-second OHLCV
+/// candle aggregator, and a small (id → record) index that lets the
+/// <c>TradeBust_57</c> reversal path locate the original price/qty/timestamp
+/// of a busted trade and recompute the affected bucket.
+/// </summary>
+/// <remarks>
+/// All mutations happen on the owning BookManager's single feed thread —
+/// no locks needed. Snapshot reads (e.g., <see cref="CandleAggregator.GetCandles"/>)
+/// remain thread-safe via the aggregator's version-stamp spin-copy.
+/// </remarks>
+internal sealed class SymbolTradeState
+{
+    internal readonly struct TradeRecord
+    {
+        public readonly long Price;
+        public readonly long Qty;
+        public readonly long TimestampSeconds;
+        public TradeRecord(long price, long qty, long ts)
+        { Price = price; Qty = qty; TimestampSeconds = ts; }
+    }
+
+    public TradeRingBuffer Ring { get; }
+    public CandleAggregator Candles { get; } = new();
+
+    private readonly Dictionary<long, TradeRecord> _byId;
+    private readonly Queue<long> _idOrder;
+    private readonly int _capacity;
+
+    /// <summary>Last applied (non-busted) trade price, or null if no trade yet.</summary>
+    public long? LastTradePrice { get; private set; }
+    /// <summary>Last applied (non-busted) trade quantity, or null if no trade yet.</summary>
+    public long? LastTradeQuantity { get; private set; }
+
+    public SymbolTradeState(int capacity)
+    {
+        _capacity = capacity;
+        Ring = new TradeRingBuffer(capacity);
+        _byId = new Dictionary<long, TradeRecord>(capacity);
+        _idOrder = new Queue<long>(capacity);
+    }
+
+    public void AddTrade(long price, long qty, long tradeId, long timestampSeconds)
+    {
+        Ring.Add(price, qty, tradeId);
+        Candles.Add(price, qty, timestampSeconds);
+        LastTradePrice = price;
+        LastTradeQuantity = qty;
+
+        if (_byId.ContainsKey(tradeId))
+        {
+            _byId[tradeId] = new TradeRecord(price, qty, timestampSeconds);
+            return;
+        }
+
+        while (_byId.Count >= _capacity && _idOrder.Count > 0)
+        {
+            var oldest = _idOrder.Dequeue();
+            _byId.Remove(oldest);
+        }
+        _byId[tradeId] = new TradeRecord(price, qty, timestampSeconds);
+        _idOrder.Enqueue(tradeId);
+    }
+
+    public bool TryGetTrade(long tradeId, out TradeRecord rec)
+        => _byId.TryGetValue(tradeId, out rec);
+
+    public void RemoveTradeFromIndex(long tradeId) => _byId.Remove(tradeId);
+
+    /// <summary>
+    /// Enumerate the remaining tracked trades that fall in the given
+    /// 1-second bucket. Used by the bust-reversal path to recompute OHLCV.
+    /// </summary>
+    public List<TradeRecord> GetTradesInBucket(long timestampSeconds)
+    {
+        var list = new List<TradeRecord>();
+        foreach (var kv in _byId)
+            if (kv.Value.TimestampSeconds == timestampSeconds)
+                list.Add(kv.Value);
+        return list;
+    }
+
+    /// <summary>
+    /// After a bust mutates the ring, refresh <see cref="LastTradePrice"/>
+    /// from the most recent non-busted slot. Falls back to the previous
+    /// candle's close if every retained ring slot is now busted; nulls
+    /// out if neither is available.
+    /// </summary>
+    public void RefreshLastTradeFromRing()
+    {
+        if (Ring.TryGetLastNonBustedPrice(out var price, out var qty, out _))
+        {
+            LastTradePrice = price;
+            LastTradeQuantity = qty;
+            return;
+        }
+        var fallback = Candles.LastClose;
+        if (fallback != 0)
+        {
+            LastTradePrice = fallback;
+            LastTradeQuantity = 0;
+        }
+        else
+        {
+            LastTradePrice = null;
+            LastTradeQuantity = null;
+        }
+    }
+}

--- a/src/B3.Umdf.Book/TradeRingBuffer.cs
+++ b/src/B3.Umdf.Book/TradeRingBuffer.cs
@@ -63,6 +63,33 @@ internal sealed class TradeRingBuffer
     }
 
     /// <summary>
+    /// Most recent non-busted trade's price (newest → oldest scan). Returns
+    /// false if every retained slot is busted or the ring is empty. Used by
+    /// the bust reversal path on <see cref="BookManager"/> to recompute the
+    /// effective last-trade price after a <c>TradeBust_57</c> wipes the
+    /// most recent print.
+    /// </summary>
+    public bool TryGetLastNonBustedPrice(out long price, out long quantity, out long tradeId)
+    {
+        int count = _count;
+        int head = _head;
+        int len = _buf.Length;
+        for (int i = 1; i <= count; i++)
+        {
+            int pos = (head - i + len) % len;
+            if (_buf[pos].Busted == 0)
+            {
+                price = _buf[pos].Price;
+                quantity = _buf[pos].Qty;
+                tradeId = _buf[pos].TradeId;
+                return true;
+            }
+        }
+        price = 0; quantity = 0; tradeId = 0;
+        return false;
+    }
+
+    /// <summary>
     /// Snapshot oldest → newest. Safe for concurrent reads.
     /// Re-copies the slot array if any mutation (Add or MarkBust) is detected
     /// during the copy via the <see cref="_version"/> stamp — without this, a

--- a/tests/B3.Umdf.Book.Tests/BookManagerTradeBustReversalTests.cs
+++ b/tests/B3.Umdf.Book.Tests/BookManagerTradeBustReversalTests.cs
@@ -1,0 +1,166 @@
+using B3.Umdf.Book;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+/// <summary>
+/// P1 — Trade bust state reversal (B3 BinaryUMDF v2.2.0 §10).
+///
+/// Pins the BookManager-side reversal of <c>TradeBust_57</c>: the busted
+/// trade is removed from the per-symbol recent-trades index, the
+/// 1-second OHLCV bucket containing it is recomputed (or popped when the
+/// bust was the only contributor), and the cached LastTradePrice falls
+/// back to the most recent surviving trade. Bust-fanout via
+/// <see cref="IBookEventHandler.OnTradeBust"/> is preserved.
+/// </summary>
+public class BookManagerTradeBustReversalTests
+{
+    private const ulong SecurityId = 9001;
+    private const long Ts = 1_700_000_000L * 1_000_000_000L; // ns @ 2023-11-14T22:13:20Z
+
+    private sealed class Recorder : IBookEventHandler
+    {
+        public int TradeCount;
+        public int BustCount;
+        public (ulong sec, long price, long qty, long id) LastBust;
+
+        public void OnOrderAdded(OrderBook book, in OrderBookEntry entry) { }
+        public void OnOrderUpdated(OrderBook book, in OrderBookEntry entry) { }
+        public void OnOrderDeleted(OrderBook book, ulong orderId, BookSideType side) { }
+        public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs) => TradeCount++;
+        public void OnBookCleared(ulong securityId, BookClearSide side) { }
+        public void OnTradeBust(ulong securityId, long price, long quantity, long tradeId)
+        {
+            BustCount++;
+            LastBust = (securityId, price, quantity, tradeId);
+        }
+    }
+
+    private static (BookManager bm, Recorder rec) NewBookManager()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var staleBuffer = new StaleMboBuffer(NullLogger.Instance);
+        var rec = new Recorder();
+        var bm = new BookManager(eventHandler: rec, stateRegistry: registry, staleBuffer: staleBuffer);
+        return (bm, rec);
+    }
+
+    [Fact]
+    public void Bust_RecentTrade_RestoresLastPriceToPriorTrade()
+    {
+        var (bm, _) = NewBookManager();
+
+        bm.RecordTrade(SecurityId, price: 100_0000, quantity: 10, tradeId: 1, sendingTimeNs: Ts);
+        bm.RecordTrade(SecurityId, price: 101_0000, quantity:  5, tradeId: 2, sendingTimeNs: Ts);
+
+        Assert.True(bm.TryGetTradeState(SecurityId, out var state));
+        Assert.Equal(101_0000L, state!.LastTradePrice);
+
+        bm.ApplyTradeBustToState(SecurityId, tradeId: 2);
+
+        Assert.Equal(100_0000L, state.LastTradePrice);
+        Assert.Equal(1, bm.TradeBustsApplied);
+        Assert.Equal(0, bm.UnknownTradeBusts);
+
+        // Ring entry for the busted trade is flagged so snapshot history skips it.
+        var slots = state.Ring.AsSpan();
+        Assert.Equal(2, slots.Length);
+        Assert.Equal(0, slots[0].Busted);
+        Assert.Equal(1, slots[1].Busted);
+    }
+
+    [Fact]
+    public void Bust_AdjustsCurrentMinuteCandle_OHLCV()
+    {
+        var (bm, _) = NewBookManager();
+
+        // Three trades in the same 1-second bucket: 100, 105 (high), 99 (low → busted).
+        bm.RecordTrade(SecurityId, price: 100_0000, quantity: 10, tradeId: 1, sendingTimeNs: Ts);
+        bm.RecordTrade(SecurityId, price: 105_0000, quantity:  4, tradeId: 2, sendingTimeNs: Ts);
+        bm.RecordTrade(SecurityId, price:  99_0000, quantity:  6, tradeId: 3, sendingTimeNs: Ts);
+
+        Assert.True(bm.TryGetTradeState(SecurityId, out var state));
+        var before = state!.Candles.GetLatest()!.Value;
+        Assert.Equal(20L, before.Volume);
+        Assert.Equal(105_0000L, before.High);
+        Assert.Equal( 99_0000L, before.Low);
+
+        bm.ApplyTradeBustToState(SecurityId, tradeId: 3);
+
+        var after = state.Candles.GetLatest()!.Value;
+        Assert.Equal(14L, after.Volume);             // 99-print volume removed
+        Assert.Equal(105_0000L, after.High);
+        Assert.Equal(100_0000L, after.Low);          // low rebuilt from {100, 105}
+        Assert.Equal(100_0000L, after.Open);         // first remaining trade is open (no prior bucket)
+        Assert.Equal(105_0000L, after.Close);        // last surviving trade in bucket
+        Assert.Equal(1, bm.TradeBustsApplied);
+    }
+
+    [Fact]
+    public void Bust_OfOnlyTradeInLatestBucket_PopsBucket()
+    {
+        var (bm, _) = NewBookManager();
+        long ts2 = Ts + 1_000_000_000L; // next second
+
+        bm.RecordTrade(SecurityId, price: 100_0000, quantity: 10, tradeId: 1, sendingTimeNs: Ts);
+        bm.RecordTrade(SecurityId, price: 105_0000, quantity:  4, tradeId: 2, sendingTimeNs: ts2);
+
+        Assert.True(bm.TryGetTradeState(SecurityId, out var state));
+        Assert.Equal(2, state!.Candles.Count);
+
+        bm.ApplyTradeBustToState(SecurityId, tradeId: 2);
+
+        Assert.Equal(1, state.Candles.Count);                // latest bucket popped
+        Assert.Equal(100_0000L, state.LastTradePrice);       // falls back to prior trade
+        Assert.Equal(100_0000L, state.Candles.LastClose);
+    }
+
+    [Fact]
+    public void Bust_UnknownTradeId_IncrementsCounter_AndDoesNotThrow()
+    {
+        var (bm, _) = NewBookManager();
+        bm.RecordTrade(SecurityId, price: 100_0000, quantity: 10, tradeId: 1, sendingTimeNs: Ts);
+
+        bm.ApplyTradeBustToState(SecurityId, tradeId: 9_999); // never seen
+
+        Assert.Equal(1, bm.UnknownTradeBusts);
+        Assert.Equal(0, bm.TradeBustsApplied);
+        Assert.Equal(0, bm.OutOfRetentionTradeBusts);
+
+        Assert.True(bm.TryGetTradeState(SecurityId, out var state));
+        Assert.Equal(100_0000L, state!.LastTradePrice);      // unchanged
+        Assert.Equal(0, state.Ring.AsSpan()[0].Busted);
+    }
+
+    [Fact]
+    public void Bust_UnknownSecurityId_IncrementsUnknown_AndIsNoOp()
+    {
+        var (bm, _) = NewBookManager();
+
+        bm.ApplyTradeBustToState(securityId: 4242, tradeId: 1);
+
+        Assert.Equal(1, bm.UnknownTradeBusts);
+        Assert.Equal(0, bm.TradeBustsApplied);
+        Assert.False(bm.TryGetTradeState(4242, out _));
+    }
+
+    [Fact]
+    public void Bust_StillFires_OnTradeBust_ExactlyOnce()
+    {
+        var (bm, rec) = NewBookManager();
+        bm.RecordTrade(SecurityId, price: 100_0000, quantity: 10, tradeId: 1, sendingTimeNs: Ts);
+
+        // DispatchTradeBust is the single source of truth for the
+        // post-routing bust path (applied by HandleTradeBust after wire
+        // decode + RouteMbo). Verifies the OnTradeBust fanout still fires
+        // exactly once per bust alongside the new state-reversal work.
+        bm.DispatchTradeBust(SecurityId, price: 100_0000, quantity: 10, tradeId: 1);
+
+        Assert.Equal(1, rec.BustCount);
+        Assert.Equal((SecurityId, 100_0000L, 10L, 1L), rec.LastBust);
+        Assert.Equal(1, bm.TradeBustsApplied);
+
+        Assert.True(bm.TryGetTradeState(SecurityId, out var state));
+        Assert.Equal(1, state!.Ring.AsSpan()[0].Busted);  // state was actually mutated
+    }
+}


### PR DESCRIPTION
Audit P1 item 4. `HandleTradeBust` previously only fanned out `OnTradeBust` — now reverses internal state.

**Strategy**
- Per-symbol `SymbolTradeState` (lazy ConcurrentDictionary): TradeRingBuffer + CandleAggregator + bounded id-index (cap 64) for O(1) bust lookup.
- Candle invalidation: exact OHLCV recompute when siblings remain; pop bucket if last; flat-collapse to priorClose w/ `BustedCount` for older buckets.
- Out-of-retention / unknown trade-id are counted, not errors.

**New counters:** `TradeBustsReceived`, `TradeBustsApplied`, `UnknownTradeBusts`, `OutOfRetentionTradeBusts`. `OnTradeBust` fan-out preserved.

**Tests:** 193 → 199 (+6). Server tests still 145/145.

Plan ref: item 4.
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>