### PR TITLE
P1 book: split SymbolStateRegistry policy from core

### DIFF
--- a/src/B3.Umdf.Book/SymbolStatePolicy.cs
+++ b/src/B3.Umdf.Book/SymbolStatePolicy.cs
@@ -1,0 +1,96 @@
+namespace B3.Umdf.Book;
+
+/// <summary>
+/// Immutable policy bundle consumed by <see cref="SymbolStateRegistry"/>. Splits
+/// every tunable knob (per-kind bootstrap/live-resync defaults plus the stuck-Stale
+/// escape timeout) out of the state-machine core so the registry's mutating code
+/// paths only read configuration, never own it.
+/// </summary>
+/// <remarks>
+/// <para><b>Backwards compatibility.</b> The registry's legacy parameterless
+/// constructors and its mutable <see cref="SymbolStateRegistry.StaleEscapeTimeoutMs"/>
+/// property are preserved; both delegate to <see cref="Default"/> on construction.
+/// Production wiring (CLI, server) and existing tests therefore require zero
+/// changes.</para>
+/// <para><b>Per-kind defaults.</b> Mbo uses <see cref="BootstrapPolicy.RequireSnapshot"/>
+/// + <see cref="LiveResyncPolicy.SnapshotOnly"/> (book is stateful — applying a
+/// delete or trade without a built book corrupts state silently). Every stat kind
+/// uses <see cref="BootstrapPolicy.AcceptFirst"/> + <see cref="LiveResyncPolicy.NextMessage"/>
+/// (each stat update fully replaces the field; partial loss is preferable to
+/// perpetual stale-ness).</para>
+/// </remarks>
+public sealed class SymbolStatePolicy
+{
+    private const int KindCount = (int)SymbolGapKind.SecurityStatus + 1;
+
+    private readonly (BootstrapPolicy Boot, LiveResyncPolicy Live)[] _perKind;
+
+    /// <summary>
+    /// Stuck-Stale escape valve (milliseconds). When a (secId, kind) has been
+    /// Stale longer than this AND a snapshot arrives that would be rejected as
+    /// too-old (snapshotRptSeq &lt; MinHeal), the snapshot is accepted as
+    /// authoritative reset instead. <c>0</c> disables the escape (legacy
+    /// strict-reject behavior). The default policy uses <c>0</c> to preserve
+    /// the registry's original out-of-the-box behavior; production wiring
+    /// (<c>AppSettings.StaleEscapeTimeoutMs</c>) sets <c>60_000</c>.
+    /// </summary>
+    public long StaleEscapeTimeoutMs { get; }
+
+    /// <summary>The shared default instance: stat-friendly per-kind policies, escape disabled.</summary>
+    public static SymbolStatePolicy Default { get; } = new SymbolStatePolicy();
+
+    /// <summary>Build the default policy: standard per-kind defaults, escape disabled (0 ms).</summary>
+    public SymbolStatePolicy() : this(BuildDefaultPerKind(), staleEscapeTimeoutMs: 0)
+    {
+    }
+
+    private SymbolStatePolicy(
+        (BootstrapPolicy Boot, LiveResyncPolicy Live)[] perKind,
+        long staleEscapeTimeoutMs)
+    {
+        if (perKind is null) throw new ArgumentNullException(nameof(perKind));
+        if (perKind.Length != KindCount)
+            throw new ArgumentException($"perKind length must be {KindCount}", nameof(perKind));
+        if (staleEscapeTimeoutMs < 0)
+            throw new ArgumentOutOfRangeException(nameof(staleEscapeTimeoutMs), "must be >= 0 (0 disables)");
+        _perKind = ((BootstrapPolicy, LiveResyncPolicy)[])perKind.Clone();
+        StaleEscapeTimeoutMs = staleEscapeTimeoutMs;
+    }
+
+    /// <summary>Per-kind bootstrap policy (Unknown→first message handling).</summary>
+    public BootstrapPolicy GetBootstrap(SymbolGapKind kind) => _perKind[(int)kind].Boot;
+
+    /// <summary>Per-kind live-resync policy (Stale→Healthy without snapshot).</summary>
+    public LiveResyncPolicy GetLiveResync(SymbolGapKind kind) => _perKind[(int)kind].Live;
+
+    /// <summary>Returns a new policy with the bootstrap policy of <paramref name="kind"/> overridden.</summary>
+    public SymbolStatePolicy WithBootstrap(SymbolGapKind kind, BootstrapPolicy bootstrap)
+    {
+        var copy = ((BootstrapPolicy, LiveResyncPolicy)[])_perKind.Clone();
+        copy[(int)kind] = (bootstrap, _perKind[(int)kind].Live);
+        return new SymbolStatePolicy(copy, StaleEscapeTimeoutMs);
+    }
+
+    /// <summary>Returns a new policy with the live-resync policy of <paramref name="kind"/> overridden.</summary>
+    public SymbolStatePolicy WithLiveResync(SymbolGapKind kind, LiveResyncPolicy live)
+    {
+        var copy = ((BootstrapPolicy, LiveResyncPolicy)[])_perKind.Clone();
+        copy[(int)kind] = (_perKind[(int)kind].Boot, live);
+        return new SymbolStatePolicy(copy, StaleEscapeTimeoutMs);
+    }
+
+    /// <summary>Returns a new policy with <see cref="StaleEscapeTimeoutMs"/> overridden.</summary>
+    public SymbolStatePolicy WithStaleEscapeTimeoutMs(long staleEscapeTimeoutMs)
+        => new SymbolStatePolicy(_perKind, staleEscapeTimeoutMs);
+
+    private static (BootstrapPolicy Boot, LiveResyncPolicy Live)[] BuildDefaultPerKind()
+    {
+        var p = new (BootstrapPolicy, LiveResyncPolicy)[KindCount];
+        // Stats: self-contained, accept first, resync on next message.
+        for (int i = 0; i < KindCount; i++)
+            p[i] = (BootstrapPolicy.AcceptFirst, LiveResyncPolicy.NextMessage);
+        // MBO is the only stateful kind that requires snapshot for both bootstrap and recovery.
+        p[(int)SymbolGapKind.Mbo] = (BootstrapPolicy.RequireSnapshot, LiveResyncPolicy.SnapshotOnly);
+        return p;
+    }
+}

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -66,7 +66,7 @@ public enum LiveResyncPolicy : byte
 /// <see cref="LiveResyncPolicy.SnapshotOnly"/> because the book is stateful.
 /// Stats use <see cref="BootstrapPolicy.AcceptFirst"/> +
 /// <see cref="LiveResyncPolicy.NextMessage"/> because each message fully
-/// replaces the field. Defaults are encoded in <see cref="DefaultPolicies"/>.</para>
+/// replaces the field. Defaults are encoded in <see cref="SymbolStatePolicy.Default"/>.</para>
 ///
 /// <para><b>Concurrency.</b> One <see cref="SymbolEntry"/> per security; the
 /// outer <see cref="ConcurrentDictionary{TKey,TValue}"/> handles concurrent
@@ -83,22 +83,10 @@ public sealed class SymbolStateRegistry
 {
     private const int KindCount = (int)SymbolGapKind.SecurityStatus + 1;
 
-    private static readonly (BootstrapPolicy Boot, LiveResyncPolicy Live)[] DefaultPolicies = BuildDefaultPolicies();
-
-    private static (BootstrapPolicy, LiveResyncPolicy)[] BuildDefaultPolicies()
-    {
-        var p = new (BootstrapPolicy, LiveResyncPolicy)[KindCount];
-        // Default for stats: self-contained, accept first, resync on next message.
-        for (int i = 0; i < KindCount; i++)
-            p[i] = (BootstrapPolicy.AcceptFirst, LiveResyncPolicy.NextMessage);
-        // MBO is the one stateful kind that requires snapshot for both bootstrap and recovery.
-        p[(int)SymbolGapKind.Mbo] = (BootstrapPolicy.RequireSnapshot, LiveResyncPolicy.SnapshotOnly);
-        return p;
-    }
-
     private readonly ConcurrentDictionary<ulong, SymbolEntry> _entries = new();
     private readonly ILogger _logger;
     private readonly IClock _clock;
+    private readonly SymbolStatePolicy _policy;
     private Action<ulong, bool>? _onMboStaleStatusChanged;
 
     /// <summary>
@@ -136,12 +124,24 @@ public sealed class SymbolStateRegistry
     private int _staleSymbolCount;
 
     public SymbolStateRegistry(ILogger logger)
-        : this(logger, SystemClock.Instance) { }
+        : this(logger, SystemClock.Instance, SymbolStatePolicy.Default) { }
 
     public SymbolStateRegistry(ILogger logger, IClock clock)
+        : this(logger, clock, SymbolStatePolicy.Default) { }
+
+    /// <summary>
+    /// Primary constructor. The <paramref name="policy"/> bundles every tunable
+    /// knob (per-kind bootstrap/live-resync, <see cref="SymbolStatePolicy.StaleEscapeTimeoutMs"/>)
+    /// so the registry's state-machine core only reads configuration. The
+    /// <see cref="StaleEscapeTimeoutMs"/> property is initialized from the policy
+    /// but remains settable for tests / hot-reconfig paths.
+    /// </summary>
+    public SymbolStateRegistry(ILogger logger, IClock clock, SymbolStatePolicy policy)
     {
         _logger = logger;
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _policy = policy ?? throw new ArgumentNullException(nameof(policy));
+        StaleEscapeTimeoutMs = policy.StaleEscapeTimeoutMs;
     }
 
     /// <summary>
@@ -247,7 +247,7 @@ public sealed class SymbolStateRegistry
 
         var entry = GetOrAddEntry(securityId);
         int idx = (int)kind;
-        var (bootPolicy, _) = DefaultPolicies[idx];
+        var bootPolicy = _policy.GetBootstrap(kind);
 
         ObserveResult result;
         bool fireMboStaleCallback;

--- a/tests/B3.Umdf.Book.Tests/SymbolStateRegistryBoundaryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SymbolStateRegistryBoundaryTests.cs
@@ -1,0 +1,197 @@
+using B3.Umdf.Book;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+/// <summary>
+/// Boundary-condition tests for <see cref="SymbolStateRegistry"/> covering the
+/// stuck-Stale forced-heal escape valve at the exact threshold, monotonic-clock
+/// edge cases, and per-kind bootstrap policy injection via <see cref="SymbolStatePolicy"/>.
+/// All time advances use a deterministic <see cref="FakeClock"/> — never the
+/// wall clock — so failures point unambiguously at the registry's threshold
+/// arithmetic rather than scheduler jitter.
+/// </summary>
+public class SymbolStateRegistryBoundaryTests
+{
+    /// <remarks>
+    /// Starts at 1_000_000 so <c>StaleSinceTicks</c> is non-zero on every
+    /// transition into Stale. The forced-heal escape guard requires
+    /// <c>StaleSinceTicks != 0</c> — a clock that begins at 0 silently
+    /// disables it.
+    /// </remarks>
+    private sealed class FakeClock : IClock
+    {
+        private long _ticks = 1_000_000;
+        public long NowTicks => _ticks;
+        public void Advance(long ms) => _ticks += ms;
+        public void SetTicks(long ticks) => _ticks = ticks;
+    }
+
+    private static (SymbolStateRegistry Registry, FakeClock Clock) NewRegistry(SymbolStatePolicy? policy = null)
+    {
+        var clock = new FakeClock();
+        var reg = policy is null
+            ? new SymbolStateRegistry(NullLogger.Instance, clock)
+            : new SymbolStateRegistry(NullLogger.Instance, clock, policy);
+        return (reg, clock);
+    }
+
+    /// <summary>
+    /// Pin: the escape valve is gated on <c>(now - staleSince) &gt; timeout</c>
+    /// (strictly greater). At <c>now - staleSince == timeout</c> the snapshot
+    /// must still be rejected; at <c>timeout + 1</c> it is accepted.
+    /// </summary>
+    [Fact]
+    public void ForcedHealEscape_AtExactlyTimeout_NotTriggered_Plus1Triggers()
+    {
+        const long timeout = 10_000;
+        var (reg, clock) = NewRegistry();
+        reg.StaleEscapeTimeoutMs = timeout;
+
+        // Heal Mbo at rpt=100, then create a global gap → Stale, MinHeal=199.
+        reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 200);
+        Assert.Equal(SymbolState.Stale, reg.GetState(1, SymbolGapKind.Mbo));
+
+        // Exactly at the threshold: still rejected (strict ">" guard).
+        clock.Advance(timeout);
+        var atThreshold = reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150);
+        Assert.False(atThreshold.Accepted);
+        Assert.Equal(0, reg.StaleAuthoritativeResetCount);
+        Assert.Equal(SymbolState.Stale, reg.GetState(1, SymbolGapKind.Mbo));
+
+        // One ms past the threshold: escape engages.
+        clock.Advance(1);
+        var pastThreshold = reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150);
+        Assert.True(pastThreshold.Accepted);
+        Assert.Equal(1, reg.StaleAuthoritativeResetCount);
+        Assert.Equal(SymbolState.Healthy, reg.GetState(1, SymbolGapKind.Mbo));
+    }
+
+    /// <summary>Just below threshold: never engages, no matter how close.</summary>
+    [Fact]
+    public void ForcedHealEscape_OneMsBelowTimeout_NotTriggered()
+    {
+        const long timeout = 10_000;
+        var (reg, clock) = NewRegistry();
+        reg.StaleEscapeTimeoutMs = timeout;
+
+        reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 200);
+
+        clock.Advance(timeout - 1);
+        var result = reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150);
+        Assert.False(result.Accepted);
+        Assert.Equal(0, reg.StaleAuthoritativeResetCount);
+    }
+
+    /// <summary>
+    /// Verifies policy injection: a custom shorter timeout is honored. Builds the
+    /// registry through the policy-aware constructor (no post-construction property
+    /// mutation) so the path proves <see cref="SymbolStatePolicy.StaleEscapeTimeoutMs"/>
+    /// flows into the registry's escape arithmetic.
+    /// </summary>
+    [Fact]
+    public void ForcedHealEscape_HonorsCustomShorterTimeoutFromPolicy()
+    {
+        const long shortTimeout = 250;
+        var policy = SymbolStatePolicy.Default.WithStaleEscapeTimeoutMs(shortTimeout);
+        var (reg, clock) = NewRegistry(policy);
+
+        reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 200);
+
+        // Below: rejected.
+        clock.Advance(shortTimeout);
+        Assert.False(reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150).Accepted);
+
+        // Past: accepted.
+        clock.Advance(1);
+        Assert.True(reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150).Accepted);
+        Assert.Equal(1, reg.StaleAuthoritativeResetCount);
+    }
+
+    /// <summary>
+    /// Default policy: Mbo bootstrap requires snapshot — first incremental
+    /// for an Unknown symbol is buffered, never applied. Pins the legacy
+    /// behavior the policy split must preserve.
+    /// </summary>
+    [Fact]
+    public void DefaultPolicy_MboBootstrap_RequiresSnapshot_BuffersFirstIncremental()
+    {
+        var (reg, _) = NewRegistry();
+        var result = reg.Observe(1, SymbolGapKind.Mbo, receivedRptSeq: 42);
+
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Buffer, result.Action);
+        Assert.Equal(SymbolState.Unknown, reg.GetState(1, SymbolGapKind.Mbo));
+    }
+
+    /// <summary>
+    /// Override Mbo bootstrap to <see cref="BootstrapPolicy.AcceptFirst"/> via
+    /// the policy and verify the first incremental is applied (Unknown→Healthy)
+    /// — the inverse of <see cref="DefaultPolicy_MboBootstrap_RequiresSnapshot_BuffersFirstIncremental"/>.
+    /// Concretely proves the bootstrap knob is wired through the policy.
+    /// </summary>
+    [Fact]
+    public void PolicyOverride_MboBootstrap_AcceptFirst_AppliesFirstIncremental()
+    {
+        var policy = SymbolStatePolicy.Default.WithBootstrap(SymbolGapKind.Mbo, BootstrapPolicy.AcceptFirst);
+        var (reg, _) = NewRegistry(policy);
+
+        var result = reg.Observe(1, SymbolGapKind.Mbo, receivedRptSeq: 42);
+
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Apply, result.Action);
+        Assert.Equal(SymbolState.Healthy, reg.GetState(1, SymbolGapKind.Mbo));
+    }
+
+    /// <summary>
+    /// Heavy clock skew: the injected clock jumps backwards (e.g. ntpd slewed,
+    /// or a buggy fake) AFTER a symbol enters Stale. The registry must NOT
+    /// throw and must NOT spuriously trigger the escape valve from the
+    /// resulting negative <c>(now - staleSince)</c>.
+    /// </summary>
+    [Fact]
+    public void Stale_UnderClockSkewBackwards_DoesNotThrowAndDoesNotForceHeal()
+    {
+        const long timeout = 10_000;
+        var (reg, clock) = NewRegistry();
+        reg.StaleEscapeTimeoutMs = timeout;
+
+        reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 100);
+        reg.Observe(1, SymbolGapKind.Mbo, 200);
+        Assert.Equal(SymbolState.Stale, reg.GetState(1, SymbolGapKind.Mbo));
+
+        // Wind the clock backwards by way more than the timeout. The escape
+        // guard is `(now - staleSince) > timeout` — with now < staleSince the
+        // subtraction is negative and must not engage.
+        clock.SetTicks(0);
+
+        var result = reg.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150);
+        Assert.False(result.Accepted);
+        Assert.Equal(0, reg.StaleAuthoritativeResetCount);
+        Assert.Equal(SymbolState.Stale, reg.GetState(1, SymbolGapKind.Mbo));
+
+        // Subsequent observation under skewed clock also does not throw.
+        var observe = reg.Observe(1, SymbolGapKind.Mbo, 250);
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Buffer, observe.Action);
+    }
+
+    /// <summary>
+    /// Sanity: a fresh <see cref="SymbolStatePolicy.Default"/> has the escape
+    /// disabled (0 ms). This is the contract the registry's parameterless ctor
+    /// relies on for backwards compatibility — production wiring opts in via
+    /// <c>AppSettings.StaleEscapeTimeoutMs = 60_000</c>.
+    /// </summary>
+    [Fact]
+    public void DefaultPolicy_StaleEscapeTimeoutMs_IsZeroDisabled()
+    {
+        Assert.Equal(0, SymbolStatePolicy.Default.StaleEscapeTimeoutMs);
+
+        var reg = new SymbolStateRegistry(NullLogger.Instance);
+        Assert.Equal(0, reg.StaleEscapeTimeoutMs);
+    }
+}


### PR DESCRIPTION
Audit P1 item 7. Backwards-compatible policy extraction.

**Design:** Immutable `SymbolStatePolicy` class (sealed, fluent With-style overrides). Knobs:
- `StaleEscapeTimeoutMs` (init-only)
- Per-kind `Bootstrap` (Mbo=RequireSnapshot, others=AcceptFirst)
- Per-kind `LiveResync` (Mbo=SnapshotOnly, others=NextMessage)
- `static Default`

**Backwards compat:** Both legacy ctors preserved. Mutable `StaleEscapeTimeoutMs` getter/setter retained on registry (Program.cs wiring + existing tests still work). All 193 baseline tests pass unmodified.

**New tests:** `SymbolStateRegistryBoundaryTests` covers boundary-exact, off-by-one, custom-policy, kind-policy override, backward-clock — using FakeClock at base 1_000_000.
**Tests:** 193 → 200 (+7).

Plan ref: item 7.
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>