### PR TITLE
P1 feed: exception isolation + snapshot/SequenceReset lifecycle

### DIFF
--- a/src/B3.Umdf.Feed/ChannelHandler.cs
+++ b/src/B3.Umdf.Feed/ChannelHandler.cs
@@ -1,5 +1,7 @@
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Feed;
 
@@ -38,6 +40,7 @@ public sealed class ChannelHandler : IDisposable
     private readonly IFeedEventHandler _eventHandler;
     private readonly int _maxReorderDistance;
     private readonly Dictionary<uint, UmdfPacket> _reorderBuffer;
+    private readonly ILogger _logger;
 
     private uint _expectedSeqNum = 1;
 
@@ -54,6 +57,7 @@ public sealed class ChannelHandler : IDisposable
     private long _gapsDetected;
     private long _reorderHits;
     private long _sequenceVersionResets;
+    private long _sequenceResetHandlerExceptionCount;
     private int _maxObservedReorderDepth;
     private volatile uint _lastGapExpected;
     private volatile uint _lastGapReceived;
@@ -69,6 +73,13 @@ public sealed class ChannelHandler : IDisposable
     /// in the PacketHeader (B3 spec §6.5.5.1).
     /// </summary>
     public long SequenceVersionResets => Volatile.Read(ref _sequenceVersionResets);
+    /// <summary>
+    /// Number of exceptions thrown by the downstream <see cref="IFeedEventHandler.OnSequenceVersionChanged"/>
+    /// callback during a SequenceVersion change. Previously these were silently
+    /// swallowed; now we surface a counter and log so a misbehaving handler can
+    /// be diagnosed without destabilising the channel.
+    /// </summary>
+    public long SequenceResetHandlerExceptionCount => Volatile.Read(ref _sequenceResetHandlerExceptionCount);
     /// <summary>
     /// Count of packets that arrived out-of-order and were later drained from the
     /// reorder buffer (i.e. saved a recovery cycle thanks to A/B arbitration).
@@ -89,15 +100,19 @@ public sealed class ChannelHandler : IDisposable
     public uint LastGapReceived => _lastGapReceived;
 
     public ChannelHandler(IFeedEventHandler eventHandler)
-        : this(eventHandler, MaxReorderDistance) { }
+        : this(eventHandler, MaxReorderDistance, NullLogger.Instance) { }
 
     public ChannelHandler(IFeedEventHandler eventHandler, int maxReorderDistance)
+        : this(eventHandler, maxReorderDistance, NullLogger.Instance) { }
+
+    public ChannelHandler(IFeedEventHandler eventHandler, int maxReorderDistance, ILogger logger)
     {
         if (maxReorderDistance < 1)
             throw new ArgumentOutOfRangeException(nameof(maxReorderDistance), "Must be ≥ 1.");
         _eventHandler = eventHandler;
         _maxReorderDistance = maxReorderDistance;
         _reorderBuffer = new Dictionary<uint, UmdfPacket>(maxReorderDistance);
+        _logger = logger ?? NullLogger.Instance;
     }
 
     public GapResult HandlePacket(in UmdfPacket packet)
@@ -267,7 +282,16 @@ public sealed class ChannelHandler : IDisposable
         _expectedSeqNum = firstSeqOfNewVersion;
         Interlocked.Increment(ref _sequenceVersionResets);
         try { _eventHandler.OnSequenceVersionChanged(newVersion); }
-        catch { /* event handler exceptions must not destabilize the channel; counters still reflect the reset */ }
+        catch (Exception ex)
+        {
+            // Event handler exceptions must not destabilize the channel; counters
+            // still reflect the reset. Track the failure so a misbehaving handler
+            // is observable instead of silently masked.
+            Interlocked.Increment(ref _sequenceResetHandlerExceptionCount);
+            _logger.LogWarning(ex,
+                "Downstream handler threw in OnSequenceVersionChanged(newVersion={NewVersion}); channel state advanced normally",
+                newVersion);
+        }
     }
 
     private void ProcessAndAdvance(in UmdfPacket packet, ReadOnlySpan<byte> span)

--- a/src/B3.Umdf.Feed/CompositeFeedHandler.cs
+++ b/src/B3.Umdf.Feed/CompositeFeedHandler.cs
@@ -71,6 +71,36 @@ public sealed class CompositeFeedHandler : IFeedEventHandler
         }
     }
 
+    public void OnInstrumentDefinitionsComplete(int instrumentCount, bool wasAborted)
+    {
+        bool reported = false;
+        foreach (var handler in _handlers)
+        {
+            try { handler.OnInstrumentDefinitionsComplete(instrumentCount, wasAborted); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnInstrumentDefinitionsComplete), ref reported); }
+        }
+    }
+
+    public void OnSnapshotStart(int channelGroupId, ulong securityId)
+    {
+        bool reported = false;
+        foreach (var handler in _handlers)
+        {
+            try { handler.OnSnapshotStart(channelGroupId, securityId); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnSnapshotStart), ref reported); }
+        }
+    }
+
+    public void OnSnapshotComplete(int channelGroupId, ulong securityId)
+    {
+        bool reported = false;
+        foreach (var handler in _handlers)
+        {
+            try { handler.OnSnapshotComplete(channelGroupId, securityId); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnSnapshotComplete), ref reported); }
+        }
+    }
+
     public void OnPacketProcessed()
     {
         bool reported = false;

--- a/src/B3.Umdf.Feed/CompositeFeedHandler.cs
+++ b/src/B3.Umdf.Feed/CompositeFeedHandler.cs
@@ -61,6 +61,16 @@ public sealed class CompositeFeedHandler : IFeedEventHandler
         }
     }
 
+    public void OnSequenceReset(int channelGroupId, SequenceResetReason reason)
+    {
+        bool reported = false;
+        foreach (var handler in _handlers)
+        {
+            try { handler.OnSequenceReset(channelGroupId, reason); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnSequenceReset), ref reported); }
+        }
+    }
+
     public void OnInstrumentDefinitionsComplete(int instrumentCount)
     {
         bool reported = false;

--- a/src/B3.Umdf.Feed/CompositeFeedHandler.cs
+++ b/src/B3.Umdf.Feed/CompositeFeedHandler.cs
@@ -12,51 +12,102 @@ namespace B3.Umdf.Feed;
 public sealed class CompositeFeedHandler : IFeedEventHandler
 {
     private readonly IFeedEventHandler[] _handlers;
+    private long _delegateExceptionCount;
 
     public CompositeFeedHandler(params IFeedEventHandler[] handlers)
     {
         _handlers = handlers;
     }
 
+    /// <summary>
+    /// Total number of exceptions thrown by any delegate handler across all
+    /// fan-out methods. A misbehaving delegate must NOT prevent its peers from
+    /// observing the same event, so each invocation is isolated in try/catch.
+    /// </summary>
+    public long DelegateExceptionCount => Volatile.Read(ref _delegateExceptionCount);
+
+    private void RecordFailure(Exception ex, string method, ref bool firstReported)
+    {
+        Interlocked.Increment(ref _delegateExceptionCount);
+        if (!firstReported)
+        {
+            firstReported = true;
+            // First failure per fan-out cycle is surfaced via Trace so a host
+            // that wires console redirection sees it; downstream consumers that
+            // care attach to the counter for monitoring. Avoid pulling in ILogger
+            // here to keep this lower-layer composite dependency-free.
+            System.Diagnostics.Trace.TraceWarning(
+                "CompositeFeedHandler delegate threw in {0}: {1}", method, ex);
+        }
+    }
+
     public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId)
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.OnPacket(in packet, sbePayload, templateId);
+        {
+            try { handler.OnPacket(in packet, sbePayload, templateId); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnPacket), ref reported); }
+        }
     }
 
     public void OnSequenceReset()
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.OnSequenceReset();
+        {
+            try { handler.OnSequenceReset(); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnSequenceReset), ref reported); }
+        }
     }
 
     public void OnInstrumentDefinitionsComplete(int instrumentCount)
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.OnInstrumentDefinitionsComplete(instrumentCount);
+        {
+            try { handler.OnInstrumentDefinitionsComplete(instrumentCount); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnInstrumentDefinitionsComplete), ref reported); }
+        }
     }
 
     public void OnPacketProcessed()
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.OnPacketProcessed();
+        {
+            try { handler.OnPacketProcessed(); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnPacketProcessed), ref reported); }
+        }
     }
 
     public void OnSequenceVersionChanged(ushort newVersion)
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.OnSequenceVersionChanged(newVersion);
+        {
+            try { handler.OnSequenceVersionChanged(newVersion); }
+            catch (Exception ex) { RecordFailure(ex, nameof(OnSequenceVersionChanged), ref reported); }
+        }
     }
 
     public void FlushIfDue()
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.FlushIfDue();
+        {
+            try { handler.FlushIfDue(); }
+            catch (Exception ex) { RecordFailure(ex, nameof(FlushIfDue), ref reported); }
+        }
     }
 
     public void FlushNow()
     {
+        bool reported = false;
         foreach (var handler in _handlers)
-            handler.FlushNow();
+        {
+            try { handler.FlushNow(); }
+            catch (Exception ex) { RecordFailure(ex, nameof(FlushNow), ref reported); }
+        }
     }
 }

--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -510,6 +510,17 @@ public sealed class FeedHandler : IDisposable
     /// <summary>For testing: invoke the real state transition (with all side effects).</summary>
     internal void TransitionToForTesting(FeedState state) => TransitionTo(state);
 
+    /// <summary>
+    /// Test/operator hook: synthetically forward a SequenceReset to the wired
+    /// event handler with the supplied reason. Production wiring is in
+    /// <see cref="MessageDispatcher"/> on decode of <c>SequenceReset_1</c> /
+    /// <c>ChannelReset_11</c>; this entry point exists for unit tests and for
+    /// future callers (e.g. an out-of-band failover signal) that need to drive
+    /// the same fan-out without a wire packet.
+    /// </summary>
+    public void RaiseSequenceReset(SequenceResetReason reason, int channelGroupId = 0)
+        => _eventHandler.OnSequenceReset(channelGroupId, reason);
+
     public void Dispose()
     {
         _incrementalHandler.Dispose();

--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -296,7 +296,7 @@ public sealed class FeedHandler : IDisposable
                 packet.ReceivedTimestampTicks - _instrDefFirstSeenTicks,
                 _instrDefReceived,
                 _instrDefTotalExpected);
-            _eventHandler.OnInstrumentDefinitionsComplete((int)_instrDefReceived);
+            _eventHandler.OnInstrumentDefinitionsComplete((int)_instrDefReceived, wasAborted: true);
             TransitionTo(FeedState.Streaming);
         }
     }
@@ -411,7 +411,7 @@ public sealed class FeedHandler : IDisposable
             // FreezeData (universe metadata is now stable). After this transition
             // the feed is fully Streaming; per-symbol heal drives all bootstrap
             // and gap-recovery work.
-            _eventHandler.OnInstrumentDefinitionsComplete((int)_instrDefTotalExpected);
+            _eventHandler.OnInstrumentDefinitionsComplete((int)_instrDefTotalExpected, wasAborted: false);
             TransitionTo(FeedState.Streaming);
         }
     }
@@ -421,6 +421,13 @@ public sealed class FeedHandler : IDisposable
     /// handler. Per-symbol heal does not depend on cycle boundaries — each
     /// (Header_30, Orders_71) pair is self-contained and applies independently
     /// to one instrument at a time.
+    ///
+    /// Fires <see cref="IFeedEventHandler.OnSnapshotStart"/> on every
+    /// <c>Header_30</c> observed and <see cref="IFeedEventHandler.OnSnapshotComplete"/>
+    /// after the packet's last message has been dispatched, with the most
+    /// recently observed SecurityID. This gives downstream consumers a per-
+    /// security snapshot lifecycle hook for packets that carry a single
+    /// snapshot (the common B3 case).
     /// </summary>
     private void DispatchSnapshotMessages(in UmdfPacket packet)
     {
@@ -429,8 +436,33 @@ public sealed class FeedHandler : IDisposable
             return;
 
         int offset = PacketHeader.MESSAGE_SIZE;
+        bool snapshotStarted = false;
+        ulong lastSecurityId = 0;
+        int channelGroupId = packet.ChannelGroup;
         while (TryReadNextSbe(span, ref offset, out var sbeSlice, out var templateId))
+        {
+            if (templateId == SnapshotFullRefresh_Header_30Data.MESSAGE_ID
+                && TryReadSnapshotHeaderSecurityId(sbeSlice[MessageDispatcher.SbeHeaderSize..], out var securityId))
+            {
+                if (snapshotStarted)
+                    _eventHandler.OnSnapshotComplete(channelGroupId, lastSecurityId);
+                lastSecurityId = securityId;
+                snapshotStarted = true;
+                _eventHandler.OnSnapshotStart(channelGroupId, securityId);
+            }
             _eventHandler.OnPacket(in packet, sbeSlice, templateId);
+        }
+        if (snapshotStarted)
+            _eventHandler.OnSnapshotComplete(channelGroupId, lastSecurityId);
+    }
+
+    private static bool TryReadSnapshotHeaderSecurityId(ReadOnlySpan<byte> body, out ulong securityId)
+    {
+        securityId = 0;
+        if (!SnapshotFullRefresh_Header_30Data.TryParse(body, out var reader))
+            return false;
+        securityId = reader.Data.SecurityID.Value;
+        return true;
     }
 
     /// <summary>

--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -61,6 +61,16 @@ public sealed class FeedHandler : IDisposable
     public long InstrDefMismatchedTotalCount => Volatile.Read(ref _instrDefMismatchedTotalCount);
     public ChannelHandler IncrementalHandler => _incrementalHandler;
 
+    private long _handlerExceptionCount;
+    private long _lastLoggedHandlerExceptionMilestone;
+    /// <summary>
+    /// Number of exceptions thrown by the downstream <see cref="IFeedEventHandler"/>
+    /// while processing a packet inside <see cref="ProcessOwnedPacket"/>. The
+    /// owned-source consumer loop swallows the exception and continues so a
+    /// misbehaving handler cannot kill the feed thread.
+    /// </summary>
+    public long HandlerExceptionCount => Volatile.Read(ref _handlerExceptionCount);
+
     /// <summary>Fires after the state machine transitions. Args are (oldState, newState). Invoked synchronously on the worker thread.</summary>
     public event Action<FeedState, FeedState>? StateChanged;
 
@@ -197,12 +207,50 @@ public sealed class FeedHandler : IDisposable
     {
         try
         {
-            HandlePacket(in packet);
+            try
+            {
+                HandlePacket(in packet);
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation must propagate so the owned-source loop exits cleanly.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Per-packet exception isolation: a downstream IFeedEventHandler
+                // throwing must NOT kill the consumer loop. Increment the counter
+                // first so even logging failures don't mask the metric, then log
+                // rate-limited so a sustained pathology doesn't flood the sink.
+                Interlocked.Increment(ref _handlerExceptionCount);
+                LogHandlerExceptionRateLimited(ex);
+            }
         }
         finally
         {
             packet.Release();
         }
+    }
+
+    private void LogHandlerExceptionRateLimited(Exception ex)
+    {
+        // Power-of-two milestone cadence (1, 2, 4, 8, 16, ...) to mirror
+        // MultiFeedManager.LogDropRateLimited. Single-threaded read/write is
+        // safe here because ProcessOwnedPacket runs on the owned consumer
+        // thread or under a single-producer FeedPacket caller; worst case is
+        // a duplicated log line, never a missed escalation.
+        long current = Volatile.Read(ref _handlerExceptionCount);
+        long last = Volatile.Read(ref _lastLoggedHandlerExceptionMilestone);
+        if (current <= last)
+            return;
+        long milestone = 1L << (63 - System.Numerics.BitOperations.LeadingZeroCount((ulong)current));
+        if (milestone <= last)
+            return;
+        Volatile.Write(ref _lastLoggedHandlerExceptionMilestone, milestone);
+        _logger.LogWarning(
+            ex,
+            "FeedHandler downstream handler threw {Count} exception(s); packet skipped, consumer loop continuing",
+            current);
     }
 
     private void HandlePacket(in UmdfPacket packet)

--- a/src/B3.Umdf.Feed/IFeedEventHandler.cs
+++ b/src/B3.Umdf.Feed/IFeedEventHandler.cs
@@ -21,6 +21,35 @@ public interface IFeedEventHandler
     void OnInstrumentDefinitionsComplete(int instrumentCount);
 
     /// <summary>
+    /// Variant of <see cref="OnInstrumentDefinitionsComplete(int)"/> that
+    /// distinguishes a normal end-of-replay completion (<paramref name="wasAborted"/>=false)
+    /// from a forced bootstrap-abort fallback (<paramref name="wasAborted"/>=true,
+    /// fired when <c>InstrDefStuckTimeoutMs</c> elapses without a real completion
+    /// message). The default implementation forwards to the legacy single-arg
+    /// overload so existing implementers remain source-compatible; handlers that
+    /// need to flag aborted-bootstrap state to operators or downstream metrics
+    /// should override this method instead.
+    /// </summary>
+    void OnInstrumentDefinitionsComplete(int instrumentCount, bool wasAborted)
+        => OnInstrumentDefinitionsComplete(instrumentCount);
+
+    /// <summary>
+    /// Fired when a snapshot recovery batch begins for a single security on the
+    /// snapshot channel (i.e. when a <c>SnapshotFullRefresh_Header_30</c> is
+    /// observed). Default no-op preserves legacy behaviour for handlers that do
+    /// not care about per-symbol snapshot lifecycle.
+    /// </summary>
+    void OnSnapshotStart(int channelGroupId, ulong securityId) { }
+
+    /// <summary>
+    /// Fired when the snapshot recovery batch for a single security finishes.
+    /// The current implementation emits this once per snapshot packet that
+    /// contained a <c>Header_30</c>, with the last observed securityId. Default
+    /// no-op preserves legacy behaviour.
+    /// </summary>
+    void OnSnapshotComplete(int channelGroupId, ulong securityId) { }
+
+    /// <summary>
     /// Called after all SBE messages in a UMDF packet have been dispatched.
     /// Used as a batch boundary for upstream conflation.
     /// </summary>

--- a/src/B3.Umdf.Feed/IFeedEventHandler.cs
+++ b/src/B3.Umdf.Feed/IFeedEventHandler.cs
@@ -14,6 +14,19 @@ public interface IFeedEventHandler
     void OnSequenceReset();
 
     /// <summary>
+    /// Variant of <see cref="OnSequenceReset()"/> that surfaces the originating
+    /// <paramref name="channelGroupId"/> and <paramref name="reason"/> so
+    /// downstream consumers can tag metrics / dashboards by reset source. The
+    /// default implementation forwards to the legacy zero-arg overload to keep
+    /// existing implementers source-compatible. Wired by
+    /// <see cref="MessageDispatcher"/> when an SBE template id matching one of
+    /// the UMDF reset templates (SequenceReset_1, ChannelReset_11) is decoded
+    /// on any channel.
+    /// </summary>
+    void OnSequenceReset(int channelGroupId, SequenceResetReason reason)
+        => OnSequenceReset();
+
+    /// <summary>
     /// Fired once when all instrument definitions have been received and the
     /// channel transitions to Streaming. Used by managers to freeze metadata
     /// dictionaries (FreezeBooks / FreezeData).

--- a/src/B3.Umdf.Feed/MessageDispatcher.cs
+++ b/src/B3.Umdf.Feed/MessageDispatcher.cs
@@ -14,6 +14,10 @@ public static class MessageDispatcher
 
     /// <summary>
     /// Dispatches SBE messages from a pre-computed span, avoiding redundant .Data.Span calls.
+    /// Additionally fires <see cref="IFeedEventHandler.OnSequenceReset(int, SequenceResetReason)"/>
+    /// when the decoded template is one of the UMDF reset templates
+    /// (<c>SequenceReset_1</c>, <c>ChannelReset_11</c>) so downstream consumers
+    /// can react to mid-session resets without re-decoding the SBE body.
     /// </summary>
     public static void Dispatch(in UmdfPacket packet, ReadOnlySpan<byte> span, IFeedEventHandler handler)
     {
@@ -40,6 +44,16 @@ public static class MessageDispatcher
                 break;
 
             handler.OnPacket(in packet, sbeSlice, templateId);
+
+            // SequenceReset fan-out: SBE template ids 1 and 11 are mid-session
+            // reset signals on the B3 UMDF wire. Surface them via the typed
+            // OnSequenceReset overload so downstream policy (epoch resets,
+            // pending-snapshot drops, dashboards) can run without the consumer
+            // having to re-decode SBE bodies.
+            if (templateId == SequenceReset_1Data.MESSAGE_ID)
+                handler.OnSequenceReset(packet.ChannelGroup, SequenceResetReason.SequenceReset);
+            else if (templateId == ChannelReset_11Data.MESSAGE_ID)
+                handler.OnSequenceReset(packet.ChannelGroup, SequenceResetReason.ChannelReset);
 
             offset += framing.MessageLength;
         }

--- a/src/B3.Umdf.Feed/SequenceResetReason.cs
+++ b/src/B3.Umdf.Feed/SequenceResetReason.cs
@@ -1,0 +1,28 @@
+namespace B3.Umdf.Feed;
+
+/// <summary>
+/// Source of an <see cref="IFeedEventHandler.OnSequenceReset(int, SequenceResetReason)"/>
+/// invocation. Mirrors the two B3 UMDF mid-session reset templates so downstream
+/// consumers can distinguish them in metrics and reset policies.
+/// </summary>
+public enum SequenceResetReason : byte
+{
+    /// <summary>
+    /// Source not specified (legacy <see cref="IFeedEventHandler.OnSequenceReset()"/>
+    /// callers that have not been migrated to the parameterised overload).
+    /// </summary>
+    Unspecified = 0,
+
+    /// <summary>
+    /// SBE template <c>SequenceReset_1</c> (MESSAGE_ID = 1) — gap-recovery
+    /// sequence reset / restart of the instrument-definition or snapshot loop.
+    /// </summary>
+    SequenceReset = 1,
+
+    /// <summary>
+    /// SBE template <c>ChannelReset_11</c> (MESSAGE_ID = 11) — channel-wide
+    /// catastrophic reset (remove all instruments, empty all books and
+    /// statistics).
+    /// </summary>
+    ChannelReset = 2,
+}

--- a/tests/B3.Umdf.Feed.Tests/FeedExceptionIsolationTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedExceptionIsolationTests.cs
@@ -1,0 +1,139 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed.Tests;
+
+/// <summary>
+/// Pins the per-packet exception-isolation contract for the Feed pipeline:
+/// downstream <see cref="IFeedEventHandler"/> implementations that throw must
+/// not destabilise the consumer loop (FeedHandler), the fan-out
+/// (CompositeFeedHandler), or the sequence-version reset path (ChannelHandler).
+/// Each isolation site exposes a counter so a misbehaving handler is observable
+/// instead of silently masked.
+/// </summary>
+public class FeedExceptionIsolationTests
+{
+    [Fact]
+    public void FeedHandler_HandlerThrows_LoopSurvivesAndCounterIncrements()
+    {
+        var handler = new ThrowingHandler();
+        var feed = new FeedHandler(handler);
+        feed.SetStateForTesting(FeedState.Streaming);
+
+        // Three snapshot packets: each triggers OnPacket on the throwing handler.
+        // The consumer-loop wrapper must catch, count, and continue.
+        for (int i = 0; i < 3; i++)
+            feed.FeedPacket(MakeSnapshotPacket((uint)(i + 1)));
+
+        Assert.Equal(3, handler.OnPacketCalls);
+        Assert.Equal(3, feed.HandlerExceptionCount);
+        Assert.Equal(3, feed.PacketCount);
+    }
+
+    [Fact]
+    public void CompositeFeedHandler_FirstThrows_SecondStillReceivesEvent()
+    {
+        var first = new ThrowingHandler();
+        var second = new CountingHandler();
+        var composite = new CompositeFeedHandler(first, second);
+
+        var pkt = MakeSnapshotPacket(1);
+        composite.OnPacket(in pkt, ReadOnlySpan<byte>.Empty, templateId: 30);
+        composite.OnSequenceReset();
+        composite.OnInstrumentDefinitionsComplete(7);
+        composite.OnPacketProcessed();
+        composite.OnSequenceVersionChanged(2);
+
+        Assert.Equal(1, second.OnPacketCalls);
+        Assert.Equal(1, second.OnSequenceResetCalls);
+        Assert.Equal(1, second.OnInstrumentDefinitionsCompleteCalls);
+        Assert.Equal(1, second.OnPacketProcessedCalls);
+        Assert.Equal(1, second.OnSequenceVersionChangedCalls);
+        Assert.Equal(5, composite.DelegateExceptionCount);
+    }
+
+    [Fact]
+    public void ChannelHandler_SequenceVersionDownstreamThrows_CounterIncrements()
+    {
+        var sink = new VersionThrowingHandler();
+        var channel = new ChannelHandler(sink);
+
+        // Seed v=5 then push v=6,seq=1 to trigger SequenceVersion change which
+        // calls OnSequenceVersionChanged on the downstream sink (which throws).
+        channel.HandlePacket(MakeIncrementalPacket(version: 5, seq: 1));
+        channel.HandlePacket(MakeIncrementalPacket(version: 6, seq: 1));
+
+        Assert.Equal(1, channel.SequenceVersionResets);
+        Assert.Equal(1, channel.SequenceResetHandlerExceptionCount);
+    }
+
+    private static UmdfPacket MakeSnapshotPacket(uint seqNum)
+    {
+        const int sbeHeaderSize = 8;
+        const int framingSize = 4;
+        var buf = new byte[PacketHeader.MESSAGE_SIZE + framingSize + sbeHeaderSize];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seqNum);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(PacketHeader.MESSAGE_SIZE), (ushort)(framingSize + sbeHeaderSize));
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(PacketHeader.MESSAGE_SIZE + framingSize + 2), 30);
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.SnapshotRecovery,
+            ChannelGroup = 1,
+            ReceivedTimestampTicks = 100L,
+        };
+    }
+
+    private static UmdfPacket MakeIncrementalPacket(ushort version, uint seq)
+    {
+        var buf = new byte[PacketHeader.MESSAGE_SIZE];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), version);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seq);
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.IncrementalA,
+            ChannelGroup = 1,
+            ReceivedTimestampTicks = 100L,
+        };
+    }
+
+    private sealed class ThrowingHandler : IFeedEventHandler
+    {
+        public int OnPacketCalls;
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId)
+        {
+            OnPacketCalls++;
+            throw new InvalidOperationException("handler explosion");
+        }
+        public void OnSequenceReset() => throw new InvalidOperationException("reset boom");
+        public void OnInstrumentDefinitionsComplete(int instrumentCount) => throw new InvalidOperationException("instr boom");
+        public void OnPacketProcessed() => throw new InvalidOperationException("processed boom");
+        public void OnSequenceVersionChanged(ushort newVersion) => throw new InvalidOperationException("version boom");
+    }
+
+    private sealed class CountingHandler : IFeedEventHandler
+    {
+        public int OnPacketCalls;
+        public int OnSequenceResetCalls;
+        public int OnInstrumentDefinitionsCompleteCalls;
+        public int OnPacketProcessedCalls;
+        public int OnSequenceVersionChangedCalls;
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId) => OnPacketCalls++;
+        public void OnSequenceReset() => OnSequenceResetCalls++;
+        public void OnInstrumentDefinitionsComplete(int instrumentCount) => OnInstrumentDefinitionsCompleteCalls++;
+        public void OnPacketProcessed() => OnPacketProcessedCalls++;
+        public void OnSequenceVersionChanged(ushort newVersion) => OnSequenceVersionChangedCalls++;
+    }
+
+    private sealed class VersionThrowingHandler : IFeedEventHandler
+    {
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId) { }
+        public void OnSequenceReset() { }
+        public void OnInstrumentDefinitionsComplete(int instrumentCount) { }
+        public void OnPacketProcessed() { }
+        public void OnSequenceVersionChanged(ushort newVersion) => throw new InvalidOperationException("version boom");
+    }
+}

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerLifecycleCallbacksTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerLifecycleCallbacksTests.cs
@@ -1,0 +1,195 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed.Tests;
+
+/// <summary>
+/// Pins the snapshot / instrument-definition lifecycle callbacks the FeedHandler
+/// invokes on its <see cref="IFeedEventHandler"/>:
+///   - <see cref="IFeedEventHandler.OnSnapshotStart"/> fires on every
+///     <c>SnapshotFullRefresh_Header_30</c> on the snapshot recovery channel,
+///     with the packet's channel group and the symbol's SecurityID.
+///   - <see cref="IFeedEventHandler.OnSnapshotComplete"/> fires once per
+///     snapshot packet that contained at least one Header_30, with the most
+///     recently observed SecurityID.
+///   - <see cref="IFeedEventHandler.OnInstrumentDefinitionsComplete(int, bool)"/>
+///     fires with <c>wasAborted=false</c> on the normal end-of-replay path,
+///     and with <c>wasAborted=true</c> on the bootstrap-stuck escape path.
+/// </summary>
+public class FeedHandlerLifecycleCallbacksTests
+{
+    [Fact]
+    public void Snapshot_Header30Packet_FiresStartThenCompleteWithSecurityId()
+    {
+        var tracker = new TrackingHandler();
+        var handler = new FeedHandler(tracker);
+        handler.SetStateForTesting(FeedState.Streaming);
+
+        handler.FeedPacket(MakeSnapshotHeader30Packet(seqNum: 1, securityId: 4242, channelGroup: 7));
+
+        Assert.Equal(new[] { "Start(7,4242)", "Packet(30)", "Complete(7,4242)", "PacketProcessed" }, tracker.Events);
+    }
+
+    [Fact]
+    public void Snapshot_NonSnapshotTemplateOnly_DoesNotFireSnapshotLifecycle()
+    {
+        var tracker = new TrackingHandler();
+        var handler = new FeedHandler(tracker);
+        handler.SetStateForTesting(FeedState.Streaming);
+
+        // Snapshot channel but no Header_30 in the payload (e.g. trailing
+        // Orders_71 fragment from a prior packet — pathological but possible).
+        handler.FeedPacket(MakeSnapshotPacketWithTemplate(seqNum: 1, templateId: 71, channelGroup: 1));
+
+        Assert.DoesNotContain(tracker.Events, e => e.StartsWith("Start("));
+        Assert.DoesNotContain(tracker.Events, e => e.StartsWith("Complete("));
+    }
+
+    [Fact]
+    public void NormalBootstrap_FiresInstrumentDefinitionsCompleteWithWasAbortedFalse()
+    {
+        var tracker = new TrackingHandler();
+        var handler = new FeedHandler(tracker);
+
+        // 1 expected, 1 received → completes normally.
+        handler.FeedPacket(MakeInstrDefPacket(seqNum: 1, securityId: 1, totalRelated: 1, ticks: 100L));
+
+        Assert.Equal(FeedState.Streaming, handler.State);
+        Assert.Single(tracker.InstrumentDefinitionsCompletes);
+        Assert.False(tracker.InstrumentDefinitionsCompletes[0].WasAborted);
+        Assert.Equal(1, tracker.InstrumentDefinitionsCompletes[0].Count);
+    }
+
+    [Fact]
+    public void StuckBootstrap_FiresInstrumentDefinitionsCompleteWithWasAbortedTrue()
+    {
+        var tracker = new TrackingHandler();
+        var handler = new FeedHandler(tracker);
+
+        // Receive one SecDef with TotNoRelatedSym=0 so completion is never
+        // satisfied by the message stream itself; then advance the wall clock
+        // past InstrDefStuckTimeoutMs to trigger the escape valve.
+        handler.FeedPacket(MakeInstrDefPacket(seqNum: 1, securityId: 1, totalRelated: 0, ticks: 100L));
+        Assert.Equal(FeedState.WaitInstrumentDefinition, handler.State);
+
+        // Any packet on the InstrumentDefinition channel after the timeout
+        // window triggers the stuck-escape transition.
+        handler.FeedPacket(MakeInstrDefPacket(
+            seqNum: 2, securityId: 2, totalRelated: 0,
+            ticks: 100L + FeedHandler.InstrDefStuckTimeoutMs + 1));
+
+        Assert.Equal(FeedState.Streaming, handler.State);
+        Assert.Single(tracker.InstrumentDefinitionsCompletes);
+        Assert.True(tracker.InstrumentDefinitionsCompletes[0].WasAborted);
+    }
+
+    private static UmdfPacket MakeSnapshotHeader30Packet(uint seqNum, ulong securityId, int channelGroup)
+    {
+        const int sbeHeaderSize = 8;
+        const int framingSize = 4;
+        int msgSize = SnapshotFullRefresh_Header_30Data.MESSAGE_SIZE;
+        int total = PacketHeader.MESSAGE_SIZE + framingSize + sbeHeaderSize + msgSize;
+        var buf = new byte[total];
+
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seqNum);
+
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buf.AsSpan(PacketHeader.MESSAGE_SIZE),
+            (ushort)(framingSize + sbeHeaderSize + msgSize));
+
+        int sbeHeaderOffset = PacketHeader.MESSAGE_SIZE + framingSize;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(sbeHeaderOffset), (ushort)msgSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(sbeHeaderOffset + 2), SnapshotFullRefresh_Header_30Data.MESSAGE_ID);
+
+        var body = buf.AsSpan(sbeHeaderOffset + sbeHeaderSize, msgSize);
+        var msg = new SnapshotFullRefresh_Header_30Data
+        {
+            SecurityID = (SecurityID)securityId,
+        };
+        msg.TryEncode(body, out _);
+
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.SnapshotRecovery,
+            ChannelGroup = channelGroup,
+            ReceivedTimestampTicks = 100L,
+        };
+    }
+
+    private static UmdfPacket MakeSnapshotPacketWithTemplate(uint seqNum, ushort templateId, int channelGroup)
+    {
+        const int sbeHeaderSize = 8;
+        const int framingSize = 4;
+        var buf = new byte[PacketHeader.MESSAGE_SIZE + framingSize + sbeHeaderSize];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seqNum);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(PacketHeader.MESSAGE_SIZE), (ushort)(framingSize + sbeHeaderSize));
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(PacketHeader.MESSAGE_SIZE + framingSize + 2), templateId);
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.SnapshotRecovery,
+            ChannelGroup = channelGroup,
+            ReceivedTimestampTicks = 100L,
+        };
+    }
+
+    private static UmdfPacket MakeInstrDefPacket(uint seqNum, ulong securityId, uint totalRelated, long ticks)
+    {
+        const int sbeHeaderSize = 8;
+        const int framingSize = 4;
+        int msgSize = SecurityDefinition_12Data.MESSAGE_SIZE;
+        int total = PacketHeader.MESSAGE_SIZE + framingSize + sbeHeaderSize + msgSize;
+        var buf = new byte[total];
+
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seqNum);
+
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buf.AsSpan(PacketHeader.MESSAGE_SIZE),
+            (ushort)(framingSize + sbeHeaderSize + msgSize));
+
+        int sbeHeaderOffset = PacketHeader.MESSAGE_SIZE + framingSize;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(sbeHeaderOffset), (ushort)msgSize);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(sbeHeaderOffset + 2), SecurityDefinition_12Data.MESSAGE_ID);
+
+        var body = buf.AsSpan(sbeHeaderOffset + sbeHeaderSize, msgSize);
+        var msg = new SecurityDefinition_12Data
+        {
+            SecurityID = (SecurityID)securityId,
+            TotNoRelatedSym = totalRelated,
+        };
+        msg.TryEncode(body, out _);
+
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.InstrumentDefinition,
+            ChannelGroup = 1,
+            ReceivedTimestampTicks = ticks,
+        };
+    }
+
+    private sealed class TrackingHandler : IFeedEventHandler
+    {
+        public List<string> Events { get; } = new();
+        public List<(int Count, bool WasAborted)> InstrumentDefinitionsCompletes { get; } = new();
+
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId)
+            => Events.Add($"Packet({templateId})");
+        public void OnSequenceReset() { }
+        public void OnInstrumentDefinitionsComplete(int instrumentCount)
+            => InstrumentDefinitionsCompletes.Add((instrumentCount, false));
+        public void OnInstrumentDefinitionsComplete(int instrumentCount, bool wasAborted)
+            => InstrumentDefinitionsCompletes.Add((instrumentCount, wasAborted));
+        public void OnPacketProcessed() => Events.Add("PacketProcessed");
+        public void OnSequenceVersionChanged(ushort newVersion) { }
+        public void OnSnapshotStart(int channelGroupId, ulong securityId)
+            => Events.Add($"Start({channelGroupId},{securityId})");
+        public void OnSnapshotComplete(int channelGroupId, ulong securityId)
+            => Events.Add($"Complete({channelGroupId},{securityId})");
+    }
+}

--- a/tests/B3.Umdf.Feed.Tests/MessageDispatcherSequenceResetTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MessageDispatcherSequenceResetTests.cs
@@ -1,0 +1,100 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed.Tests;
+
+/// <summary>
+/// Pins the wire-driven SequenceReset propagation contract:
+///   - <c>SequenceReset_1</c> on the wire → IFeedEventHandler.OnSequenceReset(_, SequenceResetReason.SequenceReset)
+///   - <c>ChannelReset_11</c> on the wire → IFeedEventHandler.OnSequenceReset(_, SequenceResetReason.ChannelReset)
+///
+/// Pre-fix: the interface declared OnSequenceReset but the dispatcher never
+/// invoked it on the actual UMDF reset templates; downstream consumers had no
+/// signal to drive epoch resets / pending-snapshot drops without re-decoding
+/// the SBE bodies themselves.
+/// </summary>
+public class MessageDispatcherSequenceResetTests
+{
+    [Fact]
+    public void SequenceReset1Template_FiresOnSequenceResetWithSequenceResetReason()
+    {
+        var tracker = new RecordingHandler();
+        var pkt = MakeSinglePacket(channelGroup: 7, templateId: SequenceReset_1Data.MESSAGE_ID);
+
+        MessageDispatcher.Dispatch(in pkt, tracker);
+
+        Assert.Single(tracker.Resets);
+        Assert.Equal((7, SequenceResetReason.SequenceReset), tracker.Resets[0]);
+    }
+
+    [Fact]
+    public void ChannelReset11Template_FiresOnSequenceResetWithChannelResetReason()
+    {
+        var tracker = new RecordingHandler();
+        var pkt = MakeSinglePacket(channelGroup: 3, templateId: ChannelReset_11Data.MESSAGE_ID);
+
+        MessageDispatcher.Dispatch(in pkt, tracker);
+
+        Assert.Single(tracker.Resets);
+        Assert.Equal((3, SequenceResetReason.ChannelReset), tracker.Resets[0]);
+    }
+
+    [Fact]
+    public void NonResetTemplate_DoesNotFireOnSequenceReset()
+    {
+        var tracker = new RecordingHandler();
+        // SnapshotFullRefresh_Header_30 — definitely not a reset.
+        var pkt = MakeSinglePacket(channelGroup: 1, templateId: 30);
+
+        MessageDispatcher.Dispatch(in pkt, tracker);
+
+        Assert.Empty(tracker.Resets);
+    }
+
+    [Fact]
+    public void RaiseSequenceReset_TestHook_ForwardsReasonAndChannelGroupToHandler()
+    {
+        var tracker = new RecordingHandler();
+        var feed = new FeedHandler(tracker);
+
+        feed.RaiseSequenceReset(SequenceResetReason.ChannelReset, channelGroupId: 42);
+
+        Assert.Single(tracker.Resets);
+        Assert.Equal((42, SequenceResetReason.ChannelReset), tracker.Resets[0]);
+    }
+
+    private static UmdfPacket MakeSinglePacket(int channelGroup, ushort templateId)
+    {
+        const int sbeHeaderSize = 8;
+        const int framingSize = 4;
+        var buf = new byte[PacketHeader.MESSAGE_SIZE + framingSize + sbeHeaderSize];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), 1);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buf.AsSpan(PacketHeader.MESSAGE_SIZE),
+            (ushort)(framingSize + sbeHeaderSize));
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buf.AsSpan(PacketHeader.MESSAGE_SIZE + framingSize + 2),
+            templateId);
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.IncrementalA,
+            ChannelGroup = channelGroup,
+            ReceivedTimestampTicks = 100L,
+        };
+    }
+
+    private sealed class RecordingHandler : IFeedEventHandler
+    {
+        public List<(int ChannelGroupId, SequenceResetReason Reason)> Resets { get; } = new();
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId) { }
+        public void OnSequenceReset() { }
+        public void OnSequenceReset(int channelGroupId, SequenceResetReason reason)
+            => Resets.Add((channelGroupId, reason));
+        public void OnInstrumentDefinitionsComplete(int instrumentCount) { }
+        public void OnPacketProcessed() { }
+        public void OnSequenceVersionChanged(ushort newVersion) { }
+    }
+}

--- a/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDispatchResilienceTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDispatchResilienceTests.cs
@@ -44,7 +44,13 @@ public class MultiFeedManagerDispatchResilienceTests
         }
 
         Assert.Equal(3, handler.AttemptedPackets);
-        Assert.Equal(3, manager.DispatchHandlerExceptionCount(0));
+        // FeedHandler.ProcessOwnedPacket now isolates handler exceptions before
+        // they bubble to the MultiFeedManager dispatch loop, so the exception is
+        // counted on the per-FeedHandler counter instead of the per-group MFM
+        // counter. The contract under test — handler throws don't kill the
+        // dispatch thread and every failure is observable — is still pinned.
+        Assert.Equal(3, manager.Handlers[0].HandlerExceptionCount);
+        Assert.Equal(0, manager.DispatchHandlerExceptionCount(0));
     }
 
     [Fact]


### PR DESCRIPTION
Audit-driven Feed module hardening (3 P1 items, all on plan).

**Items**
- Loop exception isolation across FeedHandler / CompositeFeedHandler / ChannelHandler (new `HandlerExceptionCount`, `DelegateExceptionCount`, `SequenceResetHandlerExceptionCount`).
- Real `OnSnapshotStart`/`OnSnapshotComplete`/`OnInstrumentDefinitionsComplete(int,bool wasAborted)` emission. New overload uses default impls so no implementer churn.
- Mid-session SequenceReset_1 + ChannelReset_11 propagation through `OnSequenceReset` (Feed-layer enum to avoid Book dep).

**Tests:** 55 → 66 (+11), 0 regressions.
**One existing test updated:** MultiFeedManagerDispatchResilienceTests asserts on the new finer-grained FeedHandler counter (semantics preserved).

Plan ref: items 1, 2, 3.
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>