### PR TITLE
P1 cli: validate value-requiring flags to prevent silent misparsing

### DIFF
--- a/src/B3.Umdf.ConsoleApp/Bootstrap.cs
+++ b/src/B3.Umdf.ConsoleApp/Bootstrap.cs
@@ -23,18 +23,37 @@ internal static class CliArgs
     {
         var cliPrefixes = new List<string>();
 
+        // Flags that take a value as the next token. Used to detect missing
+        // values (flag at end of args, or followed by another --flag) and
+        // surface a clear validation error instead of silently consuming the
+        // next flag as the value.
+        var valueFlags = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "--ws-port", "--speed", "--pcap-prefix", "--multicast-config",
+            "--loss-targets", "--loss-rate", "--loss-mode", "--loss-burst",
+            "--loss-seed",
+        };
+
         for (int i = 0; i < args.Length; i++)
         {
-            switch (args[i])
+            var arg = args[i];
+
+            if (valueFlags.Contains(arg) && !TryReadValue(args, ref i, arg, out var readErr))
             {
-                case "--ws-port" when i + 1 < args.Length:
-                    if (!int.TryParse(args[++i], out var p) || p < 1 || p > 65535)
+                error = readErr;
+                return false;
+            }
+
+            switch (arg)
+            {
+                case "--ws-port":
+                    if (!int.TryParse(args[i], out var p) || p < 1 || p > 65535)
                     { error = "Invalid --ws-port value."; return false; }
                     settings.WsPort = p;
                     break;
 
-                case "--speed" when i + 1 < args.Length:
-                    if (!double.TryParse(args[++i],
+                case "--speed":
+                    if (!double.TryParse(args[i],
                             System.Globalization.NumberStyles.Any,
                             System.Globalization.CultureInfo.InvariantCulture,
                             out var sp) || sp < 0)
@@ -45,24 +64,24 @@ internal static class CliArgs
                     settings.Speed = sp;
                     break;
 
-                case "--pcap-prefix" when i + 1 < args.Length:
-                    cliPrefixes.Add(args[++i]);
+                case "--pcap-prefix":
+                    cliPrefixes.Add(args[i]);
                     break;
 
-                case "--multicast-config" when i + 1 < args.Length:
-                    settings.MulticastConfig = args[++i];
+                case "--multicast-config":
+                    settings.MulticastConfig = args[i];
                     break;
 
                 case "--replay-to-multicast":
                     settings.ReplayToMulticast = true;
                     break;
 
-                case "--loss-targets" when i + 1 < args.Length:
-                    settings.LossTargets = args[++i];
+                case "--loss-targets":
+                    settings.LossTargets = args[i];
                     break;
 
-                case "--loss-rate" when i + 1 < args.Length:
-                    if (!double.TryParse(args[++i],
+                case "--loss-rate":
+                    if (!double.TryParse(args[i],
                             System.Globalization.NumberStyles.Any,
                             System.Globalization.CultureInfo.InvariantCulture,
                             out var lr) || lr < 0 || lr > 1)
@@ -73,12 +92,12 @@ internal static class CliArgs
                     settings.LossRate = lr;
                     break;
 
-                case "--loss-mode" when i + 1 < args.Length:
-                    settings.LossMode = args[++i];
+                case "--loss-mode":
+                    settings.LossMode = args[i];
                     break;
 
-                case "--loss-burst" when i + 1 < args.Length:
-                    if (!int.TryParse(args[++i], out var lb) || lb < 1)
+                case "--loss-burst":
+                    if (!int.TryParse(args[i], out var lb) || lb < 1)
                     { error = "Invalid --loss-burst value. Must be >= 1."; return false; }
                     settings.LossBurstSize = lb;
                     break;
@@ -87,14 +106,14 @@ internal static class CliArgs
                     settings.LossCorrelated = true;
                     break;
 
-                case "--loss-seed" when i + 1 < args.Length:
-                    if (!int.TryParse(args[++i], out var ls))
+                case "--loss-seed":
+                    if (!int.TryParse(args[i], out var ls))
                     { error = "Invalid --loss-seed value."; return false; }
                     settings.LossSeed = ls;
                     break;
 
                 default:
-                    positionalArgs.Add(args[i]);
+                    positionalArgs.Add(arg);
                     break;
             }
         }
@@ -107,6 +126,24 @@ internal static class CliArgs
             settings.PcapPrefixes.AddRange(cliPrefixes);
         }
 
+        error = null;
+        return true;
+    }
+
+    private static bool TryReadValue(string[] args, ref int i, string flag, out string? error)
+    {
+        if (i + 1 >= args.Length)
+        {
+            error = $"{flag} requires a value (got: <EOF>)";
+            return false;
+        }
+        var next = args[i + 1];
+        if (next.StartsWith("--", StringComparison.Ordinal))
+        {
+            error = $"{flag} requires a value (got: {next})";
+            return false;
+        }
+        i++;
         error = null;
         return true;
     }

--- a/tests/B3.Umdf.ConsoleApp.Tests/CliArgsTests.cs
+++ b/tests/B3.Umdf.ConsoleApp.Tests/CliArgsTests.cs
@@ -121,4 +121,73 @@ public class CliArgsTests
         Assert.Equal(2.5, settings.Speed);
     }
 
+    [Theory]
+    [InlineData("--ws-port")]
+    [InlineData("--speed")]
+    [InlineData("--pcap-prefix")]
+    [InlineData("--multicast-config")]
+    [InlineData("--loss-targets")]
+    [InlineData("--loss-rate")]
+    [InlineData("--loss-mode")]
+    [InlineData("--loss-burst")]
+    [InlineData("--loss-seed")]
+    public void TryApply_ValueFlagAtEndOfArgs_ReturnsError(string flag)
+    {
+        var settings = new AppSettings();
+        var ok = CliArgs.TryApply(new[] { flag }, settings, new List<string>(), out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+        Assert.Contains(flag, error);
+        Assert.Contains("requires a value", error);
+        Assert.Contains("<EOF>", error);
+    }
+
+    [Fact]
+    public void TryApply_MulticastConfigFollowedByAnotherFlag_ReturnsError()
+    {
+        var settings = new AppSettings();
+        var ok = CliArgs.TryApply(
+            new[] { "--multicast-config", "--replay-to-multicast" },
+            settings, new List<string>(), out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+        Assert.Contains("--multicast-config", error);
+        Assert.Contains("requires a value", error);
+        Assert.Contains("--replay-to-multicast", error);
+        // The next flag must NOT have been silently consumed as the value.
+        Assert.Null(settings.MulticastConfig);
+        Assert.False(settings.ReplayToMulticast);
+    }
+
+    [Fact]
+    public void TryApply_SpeedFollowedByAnotherFlag_ReturnsError()
+    {
+        var settings = new AppSettings { Speed = 1.0 };
+        var ok = CliArgs.TryApply(
+            new[] { "--speed", "--multicast-config", "cfg.json" },
+            settings, new List<string>(), out var error);
+
+        Assert.False(ok);
+        Assert.NotNull(error);
+        Assert.Contains("--speed", error);
+        Assert.Contains("requires a value", error);
+        // Speed must remain untouched.
+        Assert.Equal(1.0, settings.Speed);
+    }
+
+    [Fact]
+    public void TryApply_MulticastConfigWithValue_ParsesCorrectly()
+    {
+        var settings = new AppSettings();
+        var ok = CliArgs.TryApply(
+            new[] { "--multicast-config", "/path/to/file.json" },
+            settings, new List<string>(), out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("/path/to/file.json", settings.MulticastConfig);
+    }
+
 }


### PR DESCRIPTION
Audit P1 item 13. Bootstrap.cs previously misparsed `--flag` at end-of-args or followed by another `--flag` as the value.

**Implementation:** `valueFlags` HashSet + `TryReadValue` helper that advances only after verifying the next token exists and does not start with `--`.

**Value-requiring flags:** `--ws-port`, `--speed`, `--pcap-prefix`, `--multicast-config`, `--loss-targets`, `--loss-rate`, `--loss-mode`, `--loss-burst`, `--loss-seed`.
**Boolean (unchanged):** `--replay-to-multicast`, `--loss-correlated`.
**Errors** flow through the existing `out string? error` path.

**Tests:** 30 → 42 (+12). All pre-existing tests pass (env-var precedence, etc.).

Plan ref: item 13.
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>