### PR TITLE
P2 feed: extract shared SBE framing helper

### DIFF
--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
@@ -362,7 +361,7 @@ public sealed class FeedHandler : IDisposable
             _instrDefFirstSeenTicks = packet.ReceivedTimestampTicks;
 
         int offset = PacketHeader.MESSAGE_SIZE;
-        while (TryReadNextSbe(span, ref offset, out var sbeSlice, out var templateId))
+        while (SbeFrameWalker.TryReadNext(span, ref offset, out var sbeSlice, out var templateId))
         {
             _eventHandler.OnPacket(in packet, sbeSlice, templateId);
             if (templateId == SecurityDefinition_12Data.MESSAGE_ID)
@@ -439,7 +438,7 @@ public sealed class FeedHandler : IDisposable
         bool snapshotStarted = false;
         ulong lastSecurityId = 0;
         int channelGroupId = packet.ChannelGroup;
-        while (TryReadNextSbe(span, ref offset, out var sbeSlice, out var templateId))
+        while (SbeFrameWalker.TryReadNext(span, ref offset, out var sbeSlice, out var templateId))
         {
             if (templateId == SnapshotFullRefresh_Header_30Data.MESSAGE_ID
                 && TryReadSnapshotHeaderSecurityId(sbeSlice[MessageDispatcher.SbeHeaderSize..], out var securityId))
@@ -462,35 +461,6 @@ public sealed class FeedHandler : IDisposable
         if (!SnapshotFullRefresh_Header_30Data.TryParse(body, out var reader))
             return false;
         securityId = reader.Data.SecurityID.Value;
-        return true;
-    }
-
-    /// <summary>
-    /// Advance <paramref name="offset"/> past one framed SBE message. Centralizes
-    /// the framing validation (length checks + bounds) shared by the snapshot and
-    /// instrument-definition dispatch loops. Returns false at end-of-packet or on
-    /// any malformed frame (matching the pre-existing "best-effort, never throw"
-    /// contract — partial packets are silently truncated).
-    /// </summary>
-    private static bool TryReadNextSbe(
-        ReadOnlySpan<byte> packetSpan, ref int offset,
-        out ReadOnlySpan<byte> sbeSlice, out ushort templateId)
-    {
-        sbeSlice = default;
-        templateId = 0;
-        if (offset + FramingHeader.MESSAGE_SIZE + MessageDispatcher.SbeHeaderSize > packetSpan.Length)
-            return false;
-        var framingSlice = packetSpan[offset..];
-        if (!FramingHeader.TryParse(framingSlice, out var framing, out _))
-            return false;
-        if (framing.MessageLength < FramingHeader.MESSAGE_SIZE + MessageDispatcher.SbeHeaderSize)
-            return false;
-        if (offset + framing.MessageLength > packetSpan.Length)
-            return false;
-
-        sbeSlice = packetSpan[(offset + FramingHeader.MESSAGE_SIZE)..];
-        templateId = MemoryMarshal.Read<ushort>(sbeSlice[2..]);
-        offset += framing.MessageLength;
         return true;
     }
 

--- a/src/B3.Umdf.Feed/MessageDispatcher.cs
+++ b/src/B3.Umdf.Feed/MessageDispatcher.cs
@@ -5,7 +5,7 @@ namespace B3.Umdf.Feed;
 
 public static class MessageDispatcher
 {
-    public const int SbeHeaderSize = MessageHeader.MESSAGE_SIZE;
+    public const int SbeHeaderSize = SbeFrameWalker.SbeHeaderSize;
 
     public static void Dispatch(in UmdfPacket packet, IFeedEventHandler handler)
     {
@@ -18,6 +18,10 @@ public static class MessageDispatcher
     /// when the decoded template is one of the UMDF reset templates
     /// (<c>SequenceReset_1</c>, <c>ChannelReset_11</c>) so downstream consumers
     /// can react to mid-session resets without re-decoding the SBE body.
+    ///
+    /// Per-frame walking (framing parse, length validation, SBE slice/template
+    /// extraction) is delegated to <see cref="SbeFrameWalker"/>; this method
+    /// owns only the dispatcher-specific fan-out.
     /// </summary>
     public static void Dispatch(in UmdfPacket packet, ReadOnlySpan<byte> span, IFeedEventHandler handler)
     {
@@ -26,23 +30,8 @@ public static class MessageDispatcher
 
         int offset = UmdfPacketHeader.Size;
 
-        while (offset + FramingHeader.MESSAGE_SIZE + SbeHeaderSize <= span.Length)
+        while (SbeFrameWalker.TryReadNext(span, ref offset, out var sbeSlice, out var templateId))
         {
-            var framingSlice = span[offset..];
-            if (!FramingHeader.TryParse(framingSlice, out var framing, out _))
-                break;
-
-            if (framing.MessageLength < FramingHeader.MESSAGE_SIZE + SbeHeaderSize)
-                break;
-
-            if (offset + framing.MessageLength > span.Length)
-                break;
-
-            // SBE message starts right after the FramingHeader
-            var sbeSlice = span[(offset + FramingHeader.MESSAGE_SIZE)..];
-            if (!MessageHeader.TryReadTemplateId(sbeSlice, out var templateId))
-                break;
-
             handler.OnPacket(in packet, sbeSlice, templateId);
 
             // SequenceReset fan-out: SBE template ids 1 and 11 are mid-session
@@ -54,8 +43,6 @@ public static class MessageDispatcher
                 handler.OnSequenceReset(packet.ChannelGroup, SequenceResetReason.SequenceReset);
             else if (templateId == ChannelReset_11Data.MESSAGE_ID)
                 handler.OnSequenceReset(packet.ChannelGroup, SequenceResetReason.ChannelReset);
-
-            offset += framing.MessageLength;
         }
     }
 }

--- a/src/B3.Umdf.Feed/SbeFrameWalker.cs
+++ b/src/B3.Umdf.Feed/SbeFrameWalker.cs
@@ -1,0 +1,72 @@
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed;
+
+/// <summary>
+/// Single source of truth for walking the SBE-framed body of a UMDF packet.
+///
+/// A UMDF packet body (after the 16-byte <see cref="PacketHeader"/>) is a
+/// concatenation of <c>[FramingHeader 4B][SBE MessageHeader 8B][SBE body]</c>
+/// triples where <c>FramingHeader.MessageLength</c> covers the framing header
+/// itself. This helper centralizes the per-frame validation that used to be
+/// duplicated between <see cref="MessageDispatcher"/> (live incremental path)
+/// and <c>FeedHandler</c> (snapshot / instrument-definition paths):
+///
+///   * minimum-length check (framing + SBE header must fit)
+///   * <c>FramingHeader.TryParse</c>
+///   * claimed-length sanity (must cover at least framing + SBE header)
+///   * bounds check against the outer span (truncated trailing frame ⇒ stop)
+///   * extraction of the SBE slice and template id
+///
+/// The contract is deliberately "best-effort, never throw": malformed or
+/// truncated frames silently terminate the walk so callers do not need
+/// try/catch on the hot path. Path-specific behavior (sequence-reset
+/// fan-out, snapshot lifecycle hooks, instr-def tracking) stays at the call
+/// site.
+///
+/// Implemented as a static method over <see cref="ReadOnlySpan{T}"/> with an
+/// <c>out</c> slice + <c>ref int</c> offset to preserve the existing zero-
+/// allocation, no-closure dispatch style.
+/// </summary>
+internal static class SbeFrameWalker
+{
+    /// <summary>Size in bytes of the SBE <see cref="MessageHeader"/>.</summary>
+    public const int SbeHeaderSize = MessageHeader.MESSAGE_SIZE;
+
+    /// <summary>
+    /// Advance <paramref name="offset"/> past one framed SBE message in
+    /// <paramref name="packetSpan"/>, returning the SBE slice (header + body)
+    /// and the decoded template id. Returns <c>false</c> at end-of-packet or
+    /// on any malformed/truncated frame.
+    /// </summary>
+    public static bool TryReadNext(
+        ReadOnlySpan<byte> packetSpan,
+        ref int offset,
+        out ReadOnlySpan<byte> sbeSlice,
+        out ushort templateId)
+    {
+        sbeSlice = default;
+        templateId = 0;
+
+        if (offset + FramingHeader.MESSAGE_SIZE + SbeHeaderSize > packetSpan.Length)
+            return false;
+
+        var framingSlice = packetSpan[offset..];
+        if (!FramingHeader.TryParse(framingSlice, out var framing, out _))
+            return false;
+
+        if (framing.MessageLength < FramingHeader.MESSAGE_SIZE + SbeHeaderSize)
+            return false;
+
+        if (offset + framing.MessageLength > packetSpan.Length)
+            return false;
+
+        sbeSlice = packetSpan[(offset + FramingHeader.MESSAGE_SIZE)..];
+        if (!MessageHeader.TryReadTemplateId(sbeSlice, out templateId))
+            return false;
+
+        offset += framing.MessageLength;
+        return true;
+    }
+}

--- a/tests/B3.Umdf.Feed.Tests/SbeFrameWalkerTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/SbeFrameWalkerTests.cs
@@ -1,0 +1,108 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed.Tests;
+
+/// <summary>
+/// Direct tests for <see cref="SbeFrameWalker"/>, the shared SBE-frame walker
+/// extracted from <see cref="MessageDispatcher"/> and <c>FeedHandler</c>.
+///
+/// The walker contract: malformed / truncated frames silently terminate the
+/// walk (callers must not catch). These tests pin the corner cases that were
+/// previously implicit in two diverging copies of the framing logic.
+/// </summary>
+public class SbeFrameWalkerTests
+{
+    private const int FramingSize = FramingHeader.MESSAGE_SIZE; // 4
+    private const int SbeHeaderSize = SbeFrameWalker.SbeHeaderSize; // 8
+
+    [Fact]
+    public void MinimumLengthFrame_IsWalkedAndAdvancesOffset()
+    {
+        // Single frame with FramingHeader covering exactly framing + SBE header
+        // (no body). This is the smallest valid SBE frame on the UMDF wire.
+        const ushort templateId = 30;
+        var buf = new byte[FramingSize + SbeHeaderSize];
+        WriteFrame(buf, 0, totalLen: (ushort)(FramingSize + SbeHeaderSize), templateId);
+
+        int offset = 0;
+        bool ok = SbeFrameWalker.TryReadNext(buf, ref offset, out var sbeSlice, out var tid);
+
+        Assert.True(ok);
+        Assert.Equal(templateId, tid);
+        Assert.Equal(FramingSize + SbeHeaderSize, offset);
+        Assert.True(sbeSlice.Length >= SbeHeaderSize);
+
+        // Second call past the only frame returns false and does not advance.
+        bool again = SbeFrameWalker.TryReadNext(buf, ref offset, out _, out _);
+        Assert.False(again);
+        Assert.Equal(FramingSize + SbeHeaderSize, offset);
+    }
+
+    [Fact]
+    public void OversizedClaimedLength_TerminatesWalkWithoutAdvancing()
+    {
+        // FramingHeader claims more bytes than the buffer actually contains.
+        // The walker MUST refuse to dispatch (no partial / out-of-bounds read)
+        // and leave offset unchanged so callers know the walk ended cleanly.
+        var buf = new byte[FramingSize + SbeHeaderSize];
+        // Claim 4 extra bytes that don't exist in the buffer.
+        WriteFrame(buf, 0, totalLen: (ushort)(FramingSize + SbeHeaderSize + 4), templateId: 30);
+
+        int offset = 0;
+        bool ok = SbeFrameWalker.TryReadNext(buf, ref offset, out _, out _);
+
+        Assert.False(ok);
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void UnknownTemplateId_StillAdvancesPastFrame()
+    {
+        // The walker is template-agnostic: an unrecognized template id is
+        // surfaced to the caller (which may ignore it) and the offset advances
+        // so subsequent valid frames in the same packet remain reachable.
+        const ushort unknownTid = 0xBEEF;
+        const ushort knownTid = 30;
+        var buf = new byte[2 * (FramingSize + SbeHeaderSize)];
+        WriteFrame(buf, 0, totalLen: (ushort)(FramingSize + SbeHeaderSize), unknownTid);
+        WriteFrame(buf, FramingSize + SbeHeaderSize,
+            totalLen: (ushort)(FramingSize + SbeHeaderSize), knownTid);
+
+        int offset = 0;
+        Assert.True(SbeFrameWalker.TryReadNext(buf, ref offset, out _, out var tid1));
+        Assert.Equal(unknownTid, tid1);
+        Assert.Equal(FramingSize + SbeHeaderSize, offset);
+
+        Assert.True(SbeFrameWalker.TryReadNext(buf, ref offset, out _, out var tid2));
+        Assert.Equal(knownTid, tid2);
+        Assert.Equal(2 * (FramingSize + SbeHeaderSize), offset);
+
+        Assert.False(SbeFrameWalker.TryReadNext(buf, ref offset, out _, out _));
+    }
+
+    [Fact]
+    public void FrameLengthBelowMinimum_TerminatesWalk()
+    {
+        // FramingHeader.MessageLength must cover at least framing + SBE header.
+        // A claimed length smaller than that is malformed; the walker stops
+        // rather than dispatching a sub-header SBE slice.
+        var buf = new byte[FramingSize + SbeHeaderSize];
+        WriteFrame(buf, 0, totalLen: (ushort)(FramingSize + SbeHeaderSize - 1), templateId: 30);
+
+        int offset = 0;
+        Assert.False(SbeFrameWalker.TryReadNext(buf, ref offset, out _, out _));
+        Assert.Equal(0, offset);
+    }
+
+    private static void WriteFrame(Span<byte> buf, int offset, ushort totalLen, ushort templateId)
+    {
+        // FramingHeader: u16 messageLength (LE) + u16 encodingType
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(offset), totalLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(offset + 2), 0);
+        // SBE MessageHeader layout (B3 UMDF): blockLength(u16), templateId(u16) at +2
+        // Match the layout used by MessageDispatcherSequenceResetTests.
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(offset + FramingSize + 2), templateId);
+    }
+}


### PR DESCRIPTION
## Summary
Extracts the duplicated SBE per-frame walking logic from `MessageDispatcher` (live incremental path) and `FeedHandler.TryReadNextSbe` (snapshot / instrument-definition paths) into a single internal helper `SbeFrameWalker.TryReadNext` under `src/B3.Umdf.Feed/`.

Motivation: corner-case fixes (e.g. the recent `OnSequenceReset` propagation work in #?) had to be threaded through two near-identical copies of the framing logic and were easy to apply in one path and forget in the other.

## What is shared (now in `SbeFrameWalker`)
- minimum-length check (framing + SBE header must fit)
- `FramingHeader.TryParse`
- claimed-length sanity (`MessageLength >= framing + SBE header`)
- packet-bounds check (truncated trailing frame ⇒ stop)
- SBE slice extraction + `MessageHeader.TryReadTemplateId`
- offset advancement by `framing.MessageLength`

## What stays path-specific
- **`MessageDispatcher.Dispatch`** — `SequenceReset_1` / `ChannelReset_11` fan-out via `IFeedEventHandler.OnSequenceReset(channelGroup, reason)`.
- **`FeedHandler.DispatchAndTrackInstrDef`** — `SecurityDefinition_12` dedupe + `TotNoRelatedSym` completion bookkeeping.
- **`FeedHandler.DispatchSnapshotMessages`** — per-symbol `OnSnapshotStart` / `OnSnapshotComplete` lifecycle hooks driven by `Header_30`.

## Hot-path / allocation profile
Implemented as a static method over `ReadOnlySpan<byte>` with `out` slice + `ref int` offset — no closures, no boxing, zero allocations. Matches the pre-existing dispatch style; benchmarks unchanged.

## Tests
- Baseline Feed tests: **66 → 70**, all green.
- Existing 66 tests untouched (no modifications).
- 4 new direct tests in `SbeFrameWalkerTests` pin previously-implicit corner cases:
  - minimum-length frame is walked and offset advances
  - oversized claimed `MessageLength` terminates without advancing offset (no OOB read)
  - unknown template id is surfaced and the walk continues to subsequent frames
  - sub-minimum claimed `MessageLength` terminates the walk

## Scope
Stays within `src/B3.Umdf.Feed/**` and `tests/B3.Umdf.Feed.Tests/**`. No new NuGet deps. No public API surface change beyond the new internal helper (`MessageDispatcher.SbeHeaderSize` retained for backward compat, now aliased to `SbeFrameWalker.SbeHeaderSize`).

Closes the P2 `p2-recovery-framing` todo.