### PR TITLE
Make CandleAggregator and NewsReassembler caps configurable (p2-candle-news-config)

### DIFF
--- a/src/B3.Umdf.Book/CandleAggregator.cs
+++ b/src/B3.Umdf.Book/CandleAggregator.cs
@@ -19,20 +19,26 @@ namespace B3.Umdf.Book;
 /// </summary>
 internal sealed class CandleAggregator
 {
-    private const int MaxGapFill = 60; // max gap-fill candles per trade gap
+    /// <summary>Default value of <see cref="CandleAggregatorOptions.RetentionWindow"/>; preserved as a const for back-compat with existing callers/tests.</summary>
     internal const int MaxRetainedCandles = 10 * 60 * 60; // 10h @ 1s resolution
     /// <summary>
     /// 512 candles × 56 bytes = 28,672 bytes per chunk — comfortably below the .NET LOH
     /// threshold (85,000 bytes), so chunk allocations stay on the SOH and are cheap to GC.
     /// </summary>
     internal const int ChunkSize = 512;
+    /// <summary>Number of chunk slots required for the default retention. Instance retention may differ; see <see cref="_maxChunks"/>.</summary>
     internal static readonly int MaxChunks = (MaxRetainedCandles + ChunkSize - 1) / ChunkSize;
+
+    private readonly int _maxGapFill;
+    private readonly int _maxRetainedCandles;
+    private readonly int _bucketSize;
+    private readonly int _maxChunks;
 
     /// <summary>
     /// Fixed-length array of chunk references. Allocated once at construction (small: ~MaxChunks
     /// pointers ≈ 568 bytes per security). Individual chunks are allocated lazily on first write.
     /// </summary>
-    private readonly Candle[]?[] _chunks = new Candle[MaxChunks][];
+    private readonly Candle[]?[] _chunks;
     private long _lastClose;
     /// <summary>Logical index of the oldest candle (0..MaxRetainedCandles-1).</summary>
     private volatile int _head;
@@ -46,8 +52,14 @@ internal sealed class CandleAggregator
     // as "stat-quality-degraded" without distorting OHLC.
     private Dictionary<long, int>? _bustedCounts;
 
-    /// <summary>Resolution is always 1 second.</summary>
-    public int Resolution => 1;
+    /// <summary>Resolution in seconds — equals the configured bucket size.</summary>
+    public int Resolution => _bucketSize;
+
+    /// <summary>Maximum number of candles this instance will retain (configurable).</summary>
+    public int RetentionWindow => _maxRetainedCandles;
+
+    /// <summary>Maximum gap-fill candles inserted between consecutive trades (configurable).</summary>
+    public int MaxGapFill => _maxGapFill;
 
     /// <summary>Number of candles stored.</summary>
     public int Count => _count;
@@ -57,6 +69,21 @@ internal sealed class CandleAggregator
 
     /// <summary>Most recent close price written to the aggregator, or 0 if empty.</summary>
     public long LastClose => _lastClose;
+
+    /// <summary>Construct with default options (matches legacy behavior: 60s gap-fill cap, 10h retention, 1s buckets).</summary>
+    public CandleAggregator() : this(CandleAggregatorOptions.Default) { }
+
+    /// <summary>Construct with explicit options.</summary>
+    public CandleAggregator(CandleAggregatorOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        options.Validate();
+        _maxGapFill = options.MaxGapFill;
+        _maxRetainedCandles = options.RetentionWindow;
+        _bucketSize = options.BucketSize;
+        _maxChunks = (_maxRetainedCandles + ChunkSize - 1) / ChunkSize;
+        _chunks = new Candle[_maxChunks][];
+    }
 
     /// <summary>
     /// Locate the candle whose <see cref="Candle.Time"/> equals
@@ -73,9 +100,12 @@ internal sealed class CandleAggregator
         var oldestChunk = _chunks[oldestPos / ChunkSize];
         if (oldestChunk is null) return -1;
         long oldestTime = oldestChunk[oldestPos % ChunkSize].Time;
-        long delta = timestampSeconds - oldestTime;
-        if (delta < 0 || delta >= count) return -1;
-        return (int)delta;
+        long bucket = BucketFloor(timestampSeconds);
+        long delta = bucket - oldestTime;
+        if (delta < 0) return -1;
+        long step = delta / _bucketSize;
+        if (step >= count) return -1;
+        return (int)step;
     }
 
     /// <summary>Read the candle at logical index <paramref name="logicalIndex"/>.</summary>
@@ -83,7 +113,7 @@ internal sealed class CandleAggregator
     {
         if ((uint)logicalIndex >= (uint)_count)
             throw new ArgumentOutOfRangeException(nameof(logicalIndex));
-        int pos = (_head + logicalIndex) % MaxRetainedCandles;
+        int pos = (_head + logicalIndex) % _maxRetainedCandles;
         return _chunks[pos / ChunkSize]![pos % ChunkSize];
     }
 
@@ -97,7 +127,7 @@ internal sealed class CandleAggregator
     {
         if ((uint)logicalIndex >= (uint)_count)
             throw new ArgumentOutOfRangeException(nameof(logicalIndex));
-        int pos = (_head + logicalIndex) % MaxRetainedCandles;
+        int pos = (_head + logicalIndex) % _maxRetainedCandles;
         _chunks[pos / ChunkSize]![pos % ChunkSize] = candle;
         if (logicalIndex == _count - 1)
             _lastClose = candle.Close;
@@ -116,7 +146,7 @@ internal sealed class CandleAggregator
         _count--;
         if (_count > 0)
         {
-            int pos = (_head + _count - 1) % MaxRetainedCandles;
+            int pos = (_head + _count - 1) % _maxRetainedCandles;
             _lastClose = _chunks[pos / ChunkSize]![pos % ChunkSize].Close;
         }
         else
@@ -135,15 +165,16 @@ internal sealed class CandleAggregator
     /// </summary>
     public void IncrementBustedCount(long timestampSeconds)
     {
+        long bucket = BucketFloor(timestampSeconds);
         _bustedCounts ??= new Dictionary<long, int>();
-        _bustedCounts.TryGetValue(timestampSeconds, out var c);
-        _bustedCounts[timestampSeconds] = c + 1;
+        _bustedCounts.TryGetValue(bucket, out var c);
+        _bustedCounts[bucket] = c + 1;
         _version++;
     }
 
     /// <summary>How many busted trades fall in the bucket at <paramref name="timestampSeconds"/>.</summary>
     public int GetBustedCount(long timestampSeconds)
-        => _bustedCounts is { } b && b.TryGetValue(timestampSeconds, out var c) ? c : 0;
+        => _bustedCounts is { } b && b.TryGetValue(BucketFloor(timestampSeconds), out var c) ? c : 0;
 
     /// <summary>Convenience overload for tests/callers that don't have a session VWAP.
     /// Stamps the trade price as Avg (best-effort fallback).</summary>
@@ -159,16 +190,17 @@ internal sealed class CandleAggregator
     /// </summary>
     public bool Add(long price, long quantity, long timestampSeconds, long sessionVwap)
     {
+        long bucket = BucketFloor(timestampSeconds);
         if (_count > 0)
         {
-            int lastPos = (_head + _count - 1) % MaxRetainedCandles;
+            int lastPos = (_head + _count - 1) % _maxRetainedCandles;
             ref var last = ref _chunks[lastPos / ChunkSize]![lastPos % ChunkSize];
-            if (timestampSeconds < last.Time)
+            if (bucket < last.Time)
                 return false; // out-of-order trade — ignore to preserve time ordering
 
-            if (timestampSeconds == last.Time)
+            if (bucket == last.Time)
             {
-                // Same second — update in place
+                // Same bucket — update in place
                 if (price > last.High) last.High = price;
                 if (price < last.Low) last.Low = price;
                 last.Close = price;
@@ -179,29 +211,39 @@ internal sealed class CandleAggregator
                 return false;
             }
 
-            // Gap-fill: insert flat candles for empty seconds between last and current.
+            // Gap-fill: insert flat candles for empty buckets between last and current.
             // Avg = previous bucket's VWAP (no trades happened during the gap, so VWAP is unchanged).
-            long gapStart = last.Time + 1;
+            long gapStart = last.Time + _bucketSize;
             int gaps = 0;
             long gapAvg = last.Avg;
-            while (gapStart < timestampSeconds && gaps < MaxGapFill)
+            while (gapStart < bucket && gaps < _maxGapFill)
             {
                 AppendCandle(new Candle(gapStart, _lastClose, _lastClose, _lastClose, _lastClose, 0, gapAvg));
-                gapStart++;
+                gapStart += _bucketSize;
                 gaps++;
             }
 
-            AppendCandle(new Candle(timestampSeconds, _lastClose, Math.Max(price, _lastClose), Math.Min(price, _lastClose), price, quantity, sessionVwap));
+            AppendCandle(new Candle(bucket, _lastClose, Math.Max(price, _lastClose), Math.Min(price, _lastClose), price, quantity, sessionVwap));
         }
         else
         {
             // First candle ever
-            AppendCandle(new Candle(timestampSeconds, price, price, price, price, quantity, sessionVwap));
+            AppendCandle(new Candle(bucket, price, price, price, price, quantity, sessionVwap));
         }
 
         _lastClose = price;
         _version++;
         return true;
+    }
+
+    private long BucketFloor(long timestampSeconds)
+    {
+        if (_bucketSize == 1) return timestampSeconds;
+        // Floor toward negative infinity; trade timestamps are >= 0 in practice but
+        // guard for safety against synthetic test inputs.
+        long b = timestampSeconds / _bucketSize;
+        if (timestampSeconds < 0 && timestampSeconds % _bucketSize != 0) b--;
+        return b * _bucketSize;
     }
 
     /// <summary>
@@ -217,7 +259,7 @@ internal sealed class CandleAggregator
             var snapshot = new Candle[count];
             for (int i = 0; i < count; i++)
             {
-                int pos = (head + i) % MaxRetainedCandles;
+                int pos = (head + i) % _maxRetainedCandles;
                 var chunk = _chunks[pos / ChunkSize];
                 if (chunk is null)
                 {
@@ -244,7 +286,7 @@ internal sealed class CandleAggregator
             int v1 = _version;
             int count = _count;
             if (count == 0) return null;
-            int pos = (_head + count - 1) % MaxRetainedCandles;
+            int pos = (_head + count - 1) % _maxRetainedCandles;
             var chunk = _chunks[pos / ChunkSize];
             if (chunk is null)
             {
@@ -260,16 +302,16 @@ internal sealed class CandleAggregator
     private void AppendCandle(in Candle candle)
     {
         int writePos;
-        if (_count == MaxRetainedCandles)
+        if (_count == _maxRetainedCandles)
         {
             // At the retention cap: ring-buffer write; advance head.
-            writePos = (_head + _count) % MaxRetainedCandles;
+            writePos = (_head + _count) % _maxRetainedCandles;
             _chunks[writePos / ChunkSize]![writePos % ChunkSize] = candle;
-            _head = (_head + 1) % MaxRetainedCandles;
+            _head = (_head + 1) % _maxRetainedCandles;
             return;
         }
 
-        writePos = (_head + _count) % MaxRetainedCandles;
+        writePos = (_head + _count) % _maxRetainedCandles;
         int chunkIdx = writePos / ChunkSize;
         var chunk = _chunks[chunkIdx];
         if (chunk is null)

--- a/src/B3.Umdf.Book/CandleAggregatorOptions.cs
+++ b/src/B3.Umdf.Book/CandleAggregatorOptions.cs
@@ -1,0 +1,47 @@
+namespace B3.Umdf.Book;
+
+/// <summary>
+/// Immutable configuration for <see cref="CandleAggregator"/>. Exposes the previously
+/// hard-coded gap-fill cap, retention window, and bucket size so deployments and
+/// tests can tune the aggregator without recompiling.
+///
+/// <para>Defaults match the historical hard-coded values:
+/// <c>MaxGapFill=60</c>, <c>RetentionWindow=36 000</c> (10 hours of 1-second buckets),
+/// <c>BucketSize=1</c>.</para>
+/// </summary>
+internal sealed class CandleAggregatorOptions
+{
+    /// <summary>Default values matching the legacy hard-coded behavior.</summary>
+    public static CandleAggregatorOptions Default { get; } = new();
+
+    /// <summary>
+    /// Maximum number of flat gap-fill candles inserted between two trades. Trades
+    /// arriving more than <c>MaxGapFill * BucketSize</c> seconds apart skip the
+    /// flat-fill and only emit the bucket containing the new trade.
+    /// </summary>
+    public int MaxGapFill { get; init; } = 60;
+
+    /// <summary>
+    /// Maximum number of candles retained per security (ring-buffer capacity). Once
+    /// this many candles are stored, the oldest is evicted on each new append.
+    /// Default of 36 000 buckets at <c>BucketSize=1</c> covers a 10-hour session.
+    /// </summary>
+    public int RetentionWindow { get; init; } = 10 * 60 * 60;
+
+    /// <summary>
+    /// Bucket width in seconds. Trade timestamps are floored to a multiple of this
+    /// value before bucketing; gap-fill steps in increments of this value.
+    /// Defaults to 1-second buckets.
+    /// </summary>
+    public int BucketSize { get; init; } = 1;
+
+    internal void Validate()
+    {
+        if (MaxGapFill < 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxGapFill), MaxGapFill, "must be >= 0");
+        if (RetentionWindow <= 0)
+            throw new ArgumentOutOfRangeException(nameof(RetentionWindow), RetentionWindow, "must be > 0");
+        if (BucketSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(BucketSize), BucketSize, "must be > 0");
+    }
+}

--- a/src/B3.Umdf.Book/NewsReassembler.cs
+++ b/src/B3.Umdf.Book/NewsReassembler.cs
@@ -31,9 +31,13 @@ namespace B3.Umdf.Book;
 /// </summary>
 internal sealed class NewsReassembler
 {
+    /// <summary>Default value of <see cref="NewsReassemblerOptions.MaxParts"/>; preserved as a const for back-compat with existing callers/tests.</summary>
     public const int MaxPartCount = 64;
+    /// <summary>Maximum number of simultaneously in-flight news IDs (assemblies). Not currently surfaced via options — fixed for back-compat.</summary>
     public const int MaxInflight = 1024;
+    /// <summary>Default value of <see cref="NewsReassemblerOptions.MaxInflightBytes"/>; preserved as a const for back-compat with existing callers/tests.</summary>
     public const long MaxInflightBytes = 16L * 1024 * 1024;
+    /// <summary>Default value of <see cref="NewsReassemblerOptions.Ttl"/> in <see cref="System.Diagnostics.Stopwatch"/> ticks; preserved as a static for back-compat with existing callers/tests.</summary>
     public static readonly long TtlTicks = TimeSpan.FromSeconds(5).Ticks;
 
     /// <summary>Receiver of completed news. Spans are valid only during the call.</summary>
@@ -49,6 +53,10 @@ internal sealed class NewsReassembler
 
     private readonly NewsCompletedCallback _onComplete;
     private readonly Func<long> _monotonicTicks;
+    private readonly long _ttlTicks;
+    private readonly long _maxInflightBytes;
+    private readonly long _maxPartBytes;
+    private readonly int _maxParts;
     private readonly Dictionary<ulong, Assembly> _inflight = new(MaxInflight);
     // LinkedList tracks LRU order — most recently used at the tail.
     private readonly LinkedList<ulong> _lru = new();
@@ -66,9 +74,22 @@ internal sealed class NewsReassembler
     public long InflightBytes => _inflightBytes;
 
     public NewsReassembler(NewsCompletedCallback onComplete, Func<long>? monotonicTicks = null)
+        : this(onComplete, NewsReassemblerOptions.Default, monotonicTicks) { }
+
+    public NewsReassembler(NewsCompletedCallback onComplete, NewsReassemblerOptions options, Func<long>? monotonicTicks = null)
     {
         _onComplete = onComplete ?? throw new ArgumentNullException(nameof(onComplete));
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        options.Validate();
         _monotonicTicks = monotonicTicks ?? (() => Stopwatch.GetTimestamp());
+        // Convert TTL TimeSpan to ticks; matches the units of TtlTicks (TimeSpan.Ticks)
+        // and the legacy default. Custom monotonicTicks callbacks must produce values in
+        // the same unit (callers in tests typically use a synthetic counter incremented
+        // by `NewsReassembler.TtlTicks` deltas).
+        _ttlTicks = options.Ttl.Ticks;
+        _maxInflightBytes = options.MaxInflightBytes;
+        _maxPartBytes = options.MaxPartBytes;
+        _maxParts = options.MaxParts;
     }
 
     /// <summary>Submit one News_5 part. Spans are consumed synchronously; safe
@@ -89,7 +110,7 @@ internal sealed class NewsReassembler
         PartsReceived++;
 
         // Validate part bookkeeping.
-        if (partCount == 0 || partCount > MaxPartCount)
+        if (partCount == 0 || partCount > _maxParts)
         {
             DroppedInvalidPart++;
             return;
@@ -97,6 +118,19 @@ internal sealed class NewsReassembler
         if (partNumber == 0 || partNumber > partCount)
         {
             DroppedInvalidPart++;
+            return;
+        }
+
+        // Per-part byte cap. Sum of headline + text + url for this single part must
+        // fit MaxPartBytes (default 16 MiB — same as MaxInflightBytes, so legacy
+        // behavior is preserved). Drops any in-flight assembly for the same newsId
+        // since the part is unusable.
+        long partBytes = (long)headline.Length + text.Length + url.Length;
+        if (partBytes > _maxPartBytes)
+        {
+            DroppedInvalidPart++;
+            if (newsId != 0 && _inflight.TryGetValue(newsId, out var existing))
+                Remove(newsId, existing);
             return;
         }
 
@@ -112,6 +146,17 @@ internal sealed class NewsReassembler
         if (newsId == 0)
         {
             DroppedNoId++;
+            return;
+        }
+
+        // Defensive cap on the SBE-declared total text length: an oversized claim
+        // (e.g. malformed/hostile producer) would cause unbounded buffering as
+        // parts arrive. Reject up front so we never start the assembly.
+        if (totalTextLength > _maxInflightBytes)
+        {
+            DroppedInvalidPart++;
+            if (_inflight.TryGetValue(newsId, out var existing2))
+                Remove(newsId, existing2);
             return;
         }
 
@@ -216,7 +261,7 @@ internal sealed class NewsReassembler
                 node = next;
                 continue;
             }
-            if (now - asm.CreatedTicks <= TtlTicks) break;
+            if (now - asm.CreatedTicks <= _ttlTicks) break;
             DroppedTtl++;
             Remove(node.Value, asm);
             node = next;
@@ -225,7 +270,7 @@ internal sealed class NewsReassembler
 
     private void EvictIfNeeded()
     {
-        while (_inflight.Count >= MaxInflight || _inflightBytes >= MaxInflightBytes)
+        while (_inflight.Count >= MaxInflight || _inflightBytes >= _maxInflightBytes)
         {
             var oldest = _lru.First;
             if (oldest == null) break;

--- a/src/B3.Umdf.Book/NewsReassemblerOptions.cs
+++ b/src/B3.Umdf.Book/NewsReassemblerOptions.cs
@@ -1,0 +1,57 @@
+namespace B3.Umdf.Book;
+
+/// <summary>
+/// Immutable configuration for <see cref="NewsReassembler"/>. Surfaces the
+/// previously hard-coded TTL, aggregate inflight byte budget, per-part byte
+/// cap, and per-assembly part-count cap so deployments and tests can tune the
+/// reassembler without recompiling.
+///
+/// <para>Defaults match the historical hard-coded values:
+/// <c>Ttl = 5s</c>, <c>MaxInflightBytes = 16 MiB</c>,
+/// <c>MaxPartBytes = 16 MiB</c> (i.e. effectively unbounded — a single part
+/// could already fill the inflight budget under the legacy code),
+/// <c>MaxParts = 64</c>.</para>
+/// </summary>
+internal sealed class NewsReassemblerOptions
+{
+    /// <summary>Default values matching the legacy hard-coded behavior.</summary>
+    public static NewsReassemblerOptions Default { get; } = new();
+
+    /// <summary>
+    /// Maximum age of an in-flight assembly before it is dropped. Sweep happens on
+    /// each <c>Submit</c>. Default 5 s.
+    /// </summary>
+    public TimeSpan Ttl { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Aggregate buffered-bytes budget across all in-flight assemblies. New
+    /// assemblies trigger LRU eviction once the cap is exceeded. Default 16 MiB.
+    /// </summary>
+    public long MaxInflightBytes { get; init; } = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of bytes any single part may contribute (sum of headline +
+    /// text + url payload of one part). Parts exceeding this cap drop the entire
+    /// assembly. Default 16 MiB (matches <see cref="MaxInflightBytes"/> so the
+    /// historical behavior — no per-part validation — is preserved).
+    /// </summary>
+    public long MaxPartBytes { get; init; } = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of parts a single assembly may declare via the SBE
+    /// <c>PartCount</c> field. Larger declarations are dropped. Default 64.
+    /// </summary>
+    public int MaxParts { get; init; } = 64;
+
+    internal void Validate()
+    {
+        if (Ttl <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(Ttl), Ttl, "must be > 0");
+        if (MaxInflightBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxInflightBytes), MaxInflightBytes, "must be > 0");
+        if (MaxPartBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxPartBytes), MaxPartBytes, "must be > 0");
+        if (MaxParts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(MaxParts), MaxParts, "must be > 0");
+    }
+}

--- a/tests/B3.Umdf.Book.Tests/CandleAggregatorOptionsTests.cs
+++ b/tests/B3.Umdf.Book.Tests/CandleAggregatorOptionsTests.cs
@@ -1,0 +1,183 @@
+using System;
+using B3.Umdf.Book;
+using Xunit;
+
+namespace B3.Umdf.Book.Tests;
+
+/// <summary>
+/// Stress / option-coverage tests for <see cref="CandleAggregator"/> driven through
+/// <see cref="CandleAggregatorOptions"/>. Validates that gap-fill cap, retention
+/// rollover, bucket-size bucketing, and out-of-order trade handling honor the
+/// configured options and that the bust-aware APIs (<c>FindBucketIndex</c>,
+/// <c>ReplaceAt</c>, <c>IncrementBustedCount</c>) co-exist cleanly.
+/// </summary>
+public class CandleAggregatorOptionsTests
+{
+    [Fact]
+    public void Defaults_MatchLegacyConstants()
+    {
+        var opts = CandleAggregatorOptions.Default;
+        Assert.Equal(60, opts.MaxGapFill);
+        Assert.Equal(CandleAggregator.MaxRetainedCandles, opts.RetentionWindow);
+        Assert.Equal(1, opts.BucketSize);
+
+        var agg = new CandleAggregator();
+        Assert.Equal(60, agg.MaxGapFill);
+        Assert.Equal(CandleAggregator.MaxRetainedCandles, agg.RetentionWindow);
+        Assert.Equal(1, agg.Resolution);
+    }
+
+    [Fact]
+    public void GapLongerThanMaxGapFill_StopsFillingAndJumpsToTradeBucket()
+    {
+        // Custom small gap-fill cap (3) — easier to reason about than the default 60.
+        var opts = new CandleAggregatorOptions { MaxGapFill = 3, RetentionWindow = 100 };
+        var agg = new CandleAggregator(opts);
+
+        agg.Add(price: 100, quantity: 1, timestampSeconds: 1_000);
+        // Gap of 10 seconds — well past MaxGapFill=3.
+        agg.Add(price: 110, quantity: 2, timestampSeconds: 1_010);
+
+        // Expect: bucket 1000 (real), 1001/1002/1003 (3 flat fillers), 1010 (real). 5 candles total.
+        var candles = agg.GetCandles();
+        Assert.Equal(5, candles.Length);
+        Assert.Equal(1_000, candles[0].Time);
+        Assert.Equal(1_001, candles[1].Time); Assert.Equal(0, candles[1].Volume);
+        Assert.Equal(1_002, candles[2].Time); Assert.Equal(0, candles[2].Volume);
+        Assert.Equal(1_003, candles[3].Time); Assert.Equal(0, candles[3].Volume);
+        Assert.Equal(1_010, candles[4].Time); Assert.Equal(2, candles[4].Volume);
+    }
+
+    [Fact]
+    public void GapExactlyAtMaxGapFill_FillsExactlyMaxGapFillBuckets()
+    {
+        // Trade at t and trade at t + (MaxGapFill+1) → MaxGapFill flat candles between.
+        var opts = new CandleAggregatorOptions { MaxGapFill = 5, RetentionWindow = 50 };
+        var agg = new CandleAggregator(opts);
+        agg.Add(100, 1, 0);
+        agg.Add(110, 1, 6);
+        var candles = agg.GetCandles();
+        // bucket 0, 1..5 (5 fillers), 6 → 7 total
+        Assert.Equal(7, candles.Length);
+        for (int i = 1; i <= 5; i++) Assert.Equal(0, candles[i].Volume);
+    }
+
+    [Fact]
+    public void RetentionRollover_EvictsOldestBeyondConfiguredWindow()
+    {
+        const int retention = 32; // tiny window for fast assertion
+        var opts = new CandleAggregatorOptions { MaxGapFill = 0, RetentionWindow = retention };
+        var agg = new CandleAggregator(opts);
+
+        const int pushed = retention + 17;
+        for (int i = 0; i < pushed; i++)
+            agg.Add(price: 100 + i, quantity: 1, timestampSeconds: i);
+
+        Assert.Equal(retention, agg.Count);
+        var candles = agg.GetCandles();
+        Assert.Equal(retention, candles.Length);
+        // Oldest 17 candles should have been evicted; first stored candle is at t = pushed - retention.
+        Assert.Equal(pushed - retention, candles[0].Time);
+        Assert.Equal(pushed - 1, candles[^1].Time);
+    }
+
+    [Fact]
+    public void OutOfOrderBurst_LateTradesIntoCurrentBucket_AreIgnored()
+    {
+        var opts = new CandleAggregatorOptions { MaxGapFill = 5, RetentionWindow = 100 };
+        var agg = new CandleAggregator(opts);
+        agg.Add(100, 1, 1_000);
+        agg.Add(105, 1, 1_001);
+        // Burst of out-of-order trades (timestamps strictly behind last bucket).
+        for (int i = 0; i < 20; i++)
+        {
+            agg.Add(price: 50, quantity: 100, timestampSeconds: 999 - i);
+        }
+        // Aggregator should still hold exactly 2 candles.
+        Assert.Equal(2, agg.Count);
+        var candles = agg.GetCandles();
+        Assert.Equal(1_000, candles[0].Time);
+        Assert.Equal(1_001, candles[1].Time);
+        // Volumes unchanged by the late burst.
+        Assert.Equal(1, candles[0].Volume);
+        Assert.Equal(1, candles[1].Volume);
+    }
+
+    [Fact]
+    public void BucketSize_GreaterThanOne_FloorsTimestampsAndStepsGapFill()
+    {
+        var opts = new CandleAggregatorOptions { MaxGapFill = 10, RetentionWindow = 100, BucketSize = 5 };
+        var agg = new CandleAggregator(opts);
+
+        Assert.Equal(5, agg.Resolution);
+
+        // Three trades inside bucket [1000, 1005).
+        agg.Add(100, 2, 1_000);
+        agg.Add(110, 3, 1_002);
+        agg.Add(105, 1, 1_004);
+        // Gap to bucket [1015, 1020) — two empty buckets in between.
+        agg.Add(120, 1, 1_017);
+
+        var c = agg.GetCandles();
+        Assert.Equal(4, c.Length);
+        Assert.Equal(1_000, c[0].Time);
+        Assert.Equal(6, c[0].Volume);  // 2+3+1
+        Assert.Equal(110, c[0].High);
+        Assert.Equal(100, c[0].Open);
+        Assert.Equal(105, c[0].Close);
+        Assert.Equal(1_005, c[1].Time); Assert.Equal(0, c[1].Volume);
+        Assert.Equal(1_010, c[2].Time); Assert.Equal(0, c[2].Volume);
+        Assert.Equal(1_015, c[3].Time); Assert.Equal(1, c[3].Volume);
+    }
+
+    [Fact]
+    public void BustAwareApis_CoexistWithCustomOptions()
+    {
+        var opts = new CandleAggregatorOptions { MaxGapFill = 5, RetentionWindow = 50, BucketSize = 1 };
+        var agg = new CandleAggregator(opts);
+        agg.Add(100, 5, 1_000);
+        agg.Add(105, 3, 1_001);
+
+        int idx = agg.FindBucketIndex(1_000);
+        Assert.Equal(0, idx);
+        var orig = agg.GetAt(idx);
+
+        // Replace the bucket with a recomputed candle and verify it sticks.
+        agg.ReplaceAt(idx, new Candle(orig.Time, 90, 95, 85, 92, 4, orig.Avg));
+        Assert.Equal(92, agg.GetAt(idx).Close);
+
+        agg.IncrementBustedCount(1_001);
+        Assert.Equal(1, agg.GetBustedCount(1_001));
+
+        Assert.True(agg.RemoveLast());
+        Assert.Equal(1, agg.Count);
+    }
+
+    [Fact]
+    public void BustAwareApis_FindBucketIndex_RespectsBucketSize()
+    {
+        var opts = new CandleAggregatorOptions { MaxGapFill = 2, RetentionWindow = 100, BucketSize = 5 };
+        var agg = new CandleAggregator(opts);
+        agg.Add(100, 1, 1_000);
+        agg.Add(110, 1, 1_005);
+
+        // Any timestamp inside the [1000, 1005) bucket maps to logical index 0.
+        Assert.Equal(0, agg.FindBucketIndex(1_000));
+        Assert.Equal(0, agg.FindBucketIndex(1_004));
+        Assert.Equal(1, agg.FindBucketIndex(1_005));
+        Assert.Equal(1, agg.FindBucketIndex(1_009));
+        Assert.Equal(-1, agg.FindBucketIndex(1_010)); // not yet stored
+
+        agg.IncrementBustedCount(1_007); // floors to 1_005
+        Assert.Equal(1, agg.GetBustedCount(1_005));
+        Assert.Equal(1, agg.GetBustedCount(1_009));
+    }
+
+    [Fact]
+    public void Options_Validate_RejectsNonPositiveValues()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CandleAggregator(new CandleAggregatorOptions { RetentionWindow = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CandleAggregator(new CandleAggregatorOptions { BucketSize = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CandleAggregator(new CandleAggregatorOptions { MaxGapFill = -1 }));
+    }
+}

--- a/tests/B3.Umdf.Book.Tests/NewsReassemblerOptionsTests.cs
+++ b/tests/B3.Umdf.Book.Tests/NewsReassemblerOptionsTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using B3.Umdf.Book;
+using Xunit;
+
+namespace B3.Umdf.Book.Tests;
+
+/// <summary>
+/// Stress / option-coverage tests for <see cref="NewsReassembler"/> driven through
+/// <see cref="NewsReassemblerOptions"/>. Validates that the configurable TTL,
+/// inflight-byte cap, per-part byte cap, and per-assembly part-count cap behave
+/// as documented and that legacy default behavior is preserved.
+/// </summary>
+public class NewsReassemblerOptionsTests
+{
+    private sealed record CapturedNews(ulong NewsId, byte[] Headline, byte[] Text, byte[] Url);
+
+    private static (NewsReassembler, List<CapturedNews>, Action<long>) CreateWithClock(
+        NewsReassemblerOptions options, long startTicks = 0)
+    {
+        long clock = startTicks;
+        var captured = new List<CapturedNews>();
+        var reasm = new NewsReassembler(
+            (sec, id, src, lang, ts, h, t, u) =>
+                captured.Add(new CapturedNews(id, h.ToArray(), t.ToArray(), u.ToArray())),
+            options,
+            monotonicTicks: () => clock);
+        return (reasm, captured, delta => clock += delta);
+    }
+
+    private static byte[] B(int n, byte fill = (byte)'x')
+    {
+        var a = new byte[n];
+        Array.Fill(a, fill);
+        return a;
+    }
+
+    [Fact]
+    public void Defaults_MatchLegacyConstants()
+    {
+        var opts = NewsReassemblerOptions.Default;
+        Assert.Equal(TimeSpan.FromSeconds(5), opts.Ttl);
+        Assert.Equal(NewsReassembler.MaxInflightBytes, opts.MaxInflightBytes);
+        Assert.Equal(NewsReassembler.MaxInflightBytes, opts.MaxPartBytes);
+        Assert.Equal(NewsReassembler.MaxPartCount, opts.MaxParts);
+    }
+
+    [Fact]
+    public void PartExactlyAtMaxPartBytes_IsAccepted()
+    {
+        // Per-part cap of 1024 bytes; submit a single multi-part part whose total
+        // payload (headline + text + url) is exactly 1024.
+        var opts = new NewsReassemblerOptions { MaxPartBytes = 1024 };
+        var (r, captured, _) = CreateWithClock(opts);
+
+        // 2-part assembly: part 1 sized at exactly the cap (300 + 700 + 24 = 1024).
+        r.Submit(100, 7, 0, 0, partCount: 2, partNumber: 1, origTimeNanos: 1, totalTextLength: 0,
+                 B(300, (byte)'h'), B(700, (byte)'t'), B(24, (byte)'u'));
+        Assert.Equal(1, r.Inflight);
+        Assert.Equal(0, r.DroppedInvalidPart);
+
+        // Part 2 also at cap (1 + 1023 + 0 = 1024).
+        r.Submit(100, 7, 0, 0, 2, 2, 1, 0, B(1, (byte)'H'), B(1023, (byte)'T'), Array.Empty<byte>());
+        Assert.Single(captured);
+        Assert.Equal(0, r.Inflight);
+        Assert.Equal(301, captured[0].Headline.Length);
+        Assert.Equal(1723, captured[0].Text.Length);
+        Assert.Equal(24, captured[0].Url.Length);
+    }
+
+    [Fact]
+    public void PartOneByteOverMaxPartBytes_DropsAssembly()
+    {
+        var opts = new NewsReassemblerOptions { MaxPartBytes = 1024 };
+        var (r, _, _) = CreateWithClock(opts);
+
+        // Build an in-flight assembly (well-sized part 1).
+        r.Submit(100, 7, 0, 0, 2, 1, 0, 0, B(10), B(10), B(10));
+        Assert.Equal(1, r.Inflight);
+
+        // Part 2 is one byte over the cap (1024 + 1).
+        r.Submit(100, 7, 0, 0, 2, 2, 0, 0, B(513), B(512), Array.Empty<byte>());
+
+        Assert.Equal(1, r.DroppedInvalidPart);
+        Assert.Equal(0, r.Inflight); // existing assembly was also evicted
+    }
+
+    [Fact]
+    public void OversizedTotalTextLength_DropsBeforeBuffering()
+    {
+        var opts = new NewsReassemblerOptions { MaxInflightBytes = 4096 };
+        var (r, _, _) = CreateWithClock(opts);
+
+        // totalTextLength claims 1 MiB — way over the 4 KiB inflight cap.
+        r.Submit(100, 7, 0, 0, partCount: 2, partNumber: 1, origTimeNanos: 0,
+                 totalTextLength: 1_000_000u,
+                 B(8), B(8), Array.Empty<byte>());
+
+        Assert.Equal(0, r.Inflight);
+        Assert.Equal(0, r.InflightBytes);
+        Assert.Equal(1, r.DroppedInvalidPart);
+    }
+
+    [Fact]
+    public void EvictionUnderConcurrentExpiryAndCapPressure()
+    {
+        // Tiny inflight byte cap forces aggressive LRU eviction; short TTL forces
+        // expiry on the older assemblies during the same sweep cycle.
+        var opts = new NewsReassemblerOptions
+        {
+            MaxInflightBytes = 4096,
+            MaxPartBytes = 4096,
+            Ttl = TimeSpan.FromTicks(1000),
+        };
+        var (r, captured, advance) = CreateWithClock(opts, startTicks: 1_000);
+
+        // Stage four assemblies that together exceed MaxInflightBytes.
+        // Each part-1 holds 1500 bytes (headline+text+url = 500 each); after the
+        // 3rd insert in-flight is 4500 > 4096, so the 4th insert triggers eviction.
+        for (ulong id = 1; id <= 4; id++)
+        {
+            r.Submit(100, id, 0, 0, partCount: 2, partNumber: 1, origTimeNanos: 0, totalTextLength: 0,
+                     B(500, (byte)'h'), B(500, (byte)'t'), B(500, (byte)'u'));
+        }
+
+        // The 4th insert's EvictIfNeeded sweep must have evicted at least one LRU entry.
+        Assert.True(r.DroppedCap >= 1, $"Expected at least one cap eviction, got {r.DroppedCap}");
+        Assert.True(r.InflightBytes <= 4500);
+
+        // Now advance past TTL and submit another assembly to trigger SweepExpired.
+        advance(2_000);
+        r.Submit(100, 99, 0, 0, partCount: 2, partNumber: 1, origTimeNanos: 0, totalTextLength: 0,
+                 B(100), B(100), B(100));
+
+        // Anything older than now-1000 ticks should have been swept.
+        Assert.True(r.DroppedTtl >= 1, $"Expected at least one TTL eviction after clock advance, got {r.DroppedTtl}");
+        Assert.Empty(captured); // none completed
+    }
+
+    [Fact]
+    public void Ttl_CustomValue_RespectsConfiguredWindow()
+    {
+        // Custom 10-second TTL — half-second advance should not expire.
+        var opts = new NewsReassemblerOptions { Ttl = TimeSpan.FromSeconds(10) };
+        var (r, _, advance) = CreateWithClock(opts, startTicks: 1_000_000);
+
+        r.Submit(100, 7, 0, 0, 2, 1, 0, 0, B(8), B(8), Array.Empty<byte>());
+        Assert.Equal(1, r.Inflight);
+
+        advance(TimeSpan.FromSeconds(5).Ticks);
+        r.Submit(100, 8, 0, 0, 2, 1, 0, 0, B(8), B(8), Array.Empty<byte>());
+
+        Assert.Equal(0, r.DroppedTtl); // 5s < 10s TTL
+        Assert.Equal(2, r.Inflight);
+
+        advance(TimeSpan.FromSeconds(10).Ticks + 1);
+        r.Submit(100, 9, 0, 0, 2, 1, 0, 0, B(8), B(8), Array.Empty<byte>());
+        Assert.True(r.DroppedTtl >= 1);
+    }
+
+    [Fact]
+    public void MaxParts_BelowDefault_RejectsLargeAssemblies()
+    {
+        var opts = new NewsReassemblerOptions { MaxParts = 4 };
+        var (r, _, _) = CreateWithClock(opts);
+
+        r.Submit(100, 7, 0, 0, partCount: 5, partNumber: 1, 0, 0, B(2), B(2), Array.Empty<byte>());
+        Assert.Equal(1, r.DroppedInvalidPart);
+        Assert.Equal(0, r.Inflight);
+
+        // partCount == MaxParts is still accepted.
+        r.Submit(100, 8, 0, 0, partCount: 4, partNumber: 1, 0, 0, B(2), B(2), Array.Empty<byte>());
+        Assert.Equal(1, r.Inflight);
+    }
+
+    [Fact]
+    public void Options_Validate_RejectsNonPositiveValues()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsReassembler(
+            (a, b, c, d, e, f, g, h) => { }, new NewsReassemblerOptions { Ttl = TimeSpan.Zero }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsReassembler(
+            (a, b, c, d, e, f, g, h) => { }, new NewsReassemblerOptions { MaxInflightBytes = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsReassembler(
+            (a, b, c, d, e, f, g, h) => { }, new NewsReassemblerOptions { MaxPartBytes = 0 }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsReassembler(
+            (a, b, c, d, e, f, g, h) => { }, new NewsReassemblerOptions { MaxParts = 0 }));
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the hard-coded thresholds in `CandleAggregator` and `NewsReassembler` with immutable options objects so deployments and tests can tune them without recompiling. Defaults preserve current behavior exactly.

## API shape
```csharp
internal sealed class CandleAggregatorOptions {
    public int      MaxGapFill      { get; init; } = 60;
    public int      RetentionWindow { get; init; } = 36_000; // 10h @ 1s
    public int      BucketSize      { get; init; } = 1;
}

internal sealed class NewsReassemblerOptions {
    public TimeSpan Ttl              { get; init; } = TimeSpan.FromSeconds(5);
    public long     MaxInflightBytes { get; init; } = 16L * 1024 * 1024;
    public long     MaxPartBytes     { get; init; } = 16L * 1024 * 1024;
    public int      MaxParts         { get; init; } = 64;
}
```
Both classes keep their parameterless legacy constructors (delegate to `Options.Default`) and the previously public consts (`MaxRetainedCandles`, `MaxPartCount`, `MaxInflight`, `MaxInflightBytes`, `TtlTicks`) as documented defaults — back-compat with existing call sites (`GroupConflationHandler`, `MarketDataManager`) and tests is preserved.

## CandleAggregator details
- Per-instance `_maxGapFill`, `_maxRetainedCandles`, `_bucketSize`, `_maxChunks`. Chunk array is now sized from `RetentionWindow` (instead of a static const), so a small retention window allocates a correspondingly small `_chunks` skeleton.
- `BucketSize > 1` floors trade timestamps to bucket boundaries and steps gap-fill in matching increments. `FindBucketIndex`, `IncrementBustedCount`, and `GetBustedCount` bucketize internally — the bust-aware APIs added by PR #28 keep working cleanly under custom bucket sizes.
- New `Resolution`, `RetentionWindow`, `MaxGapFill` instance properties.

## NewsReassembler details
- Per-instance `_ttlTicks`, `_maxInflightBytes`, `_maxPartBytes`, `_maxParts`.
- Adds two defensive gates in `Submit` keyed off the new options:
  - Per-part byte cap (`headline+text+url > MaxPartBytes` → `DroppedInvalidPart`, evict any in-flight assembly for this newsId).
  - Oversized SBE `totalTextLength` (`> MaxInflightBytes` → `DroppedInvalidPart`, prevents unbounded buffering as later parts arrive).
  Defaults match the historical budget so no existing scenario hits the new gates.
- `MaxInflight = 1024` (in-flight assembly count) is intentionally kept as a fixed const — it isn't in the requested options shape and changing it would force the caller-allocated dictionary capacity hint to also become dynamic.

## Tests
- `CandleAggregatorOptionsTests` (8 tests): defaults parity, long-gap > MaxGapFill, exact-at-cap gap, retention rollover (`RetentionWindow + N`), out-of-order burst ignored, `BucketSize > 1` bucketing & gap-fill, bust-aware APIs co-existence (general & under `BucketSize > 1`), options validation.
- `NewsReassemblerOptionsTests` (9 tests): defaults parity, part exactly at `MaxPartBytes` accepted, +1B over-cap drops assembly, oversized `totalTextLength` rejected, eviction under concurrent expiry + cap pressure, custom TTL respected, `MaxParts < default` rejects oversized `partCount`, options validation.
- **Test count: 220 → 237 in `B3.Umdf.Book.Tests`. All other projects unchanged. No regressions.**

## Wiring
`AppSettings` was **not** extended — it currently exposes no Book-level config surface, so per the task scope we left it alone. Both options classes are available for direct DI / test use; future work can plumb them through if desired.

## Constraints honored
- All edits stay inside `src/B3.Umdf.Book/**` and `tests/B3.Umdf.Book.Tests/**`.
- No new NuGet dependencies.
- All 220 baseline Book tests continue to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>