### PR TITLE
P2 server: decompose WebSocketHost + split AppSettings

### DIFF
--- a/src/B3.Umdf.Server/AppSettings.cs
+++ b/src/B3.Umdf.Server/AppSettings.cs
@@ -9,7 +9,7 @@ namespace B3.Umdf.Server;
 /// Application settings that can be loaded from appsettings.json, 
 /// environment variables, or overridden via CLI arguments.
 /// </summary>
-public sealed class AppSettings
+public sealed partial class AppSettings
 {
     /// <summary>WebSocket server port. CLI: --ws-port</summary>
     public int? WsPort { get; set; }

--- a/src/B3.Umdf.Server/Configuration/AppSettings.Projections.cs
+++ b/src/B3.Umdf.Server/Configuration/AppSettings.Projections.cs
@@ -1,0 +1,71 @@
+using B3.Umdf.Server.Configuration;
+
+namespace B3.Umdf.Server;
+
+/// <summary>
+/// Cohesive option projections over <see cref="AppSettings"/>. The class keeps
+/// its flat property bag (preserved for the JSON-source-gen contract,
+/// environment-variable overrides, and existing tests/consumers) and exposes
+/// these helpers so downstream components can take dependencies on a small,
+/// purpose-built record instead of the whole bag.
+/// </summary>
+public sealed partial class AppSettings
+{
+    /// <summary>
+    /// Snapshot the connection / per-client backpressure knobs into an
+    /// immutable record suitable for passing to the WebSocket host or the
+    /// outlier sweeper.
+    /// </summary>
+    public ConnectionLimitsOptions GetConnectionLimits() => new(
+        MaxConnections: MaxConnections,
+        ClientChannelCapacity: ClientChannelCapacity,
+        SlowClientThreshold: SlowClientThreshold,
+        SlowClientMaxTicks: SlowClientMaxTicks,
+        ClientMaxPendingBytes: ClientMaxPendingBytes,
+        ClientOutlierMultiplier: ClientOutlierMultiplier,
+        ClientOutlierMinBytes: ClientOutlierMinBytes,
+        ClientOutlierPressurePct: ClientOutlierPressurePct,
+        ClientOutlierIntervalMs: ClientOutlierIntervalMs,
+        ClientCoalesceWindowMs: ClientCoalesceWindowMs);
+
+    /// <summary>
+    /// Snapshot the /health staleness gate plus shutdown drain budget.
+    /// </summary>
+    public RecoveryHealthOptions GetRecoveryHealthOptions() => new(
+        HealthMaxStaleSeconds: HealthMaxStaleSeconds,
+        HealthFailOnRecovery: HealthFailOnRecovery,
+        ShutdownDrainSeconds: ShutdownDrainSeconds);
+
+    /// <summary>
+    /// Snapshot the buffering / dispatch knobs (feed/group rings, conflation
+    /// window, stale-MBO ladder, per-symbol fanout suppression watermarks).
+    /// </summary>
+    public BufferingOptions GetBufferingOptions() => new(
+        FeedChannelCapacity: FeedChannelCapacity,
+        GroupRingCapacity: GroupRingCapacity,
+        MulticastMergeCapacity: MulticastMergeCapacity,
+        ServerFlushWindowMs: ServerFlushWindowMs,
+        MaxSnapshotRequestsPerBatch: MaxSnapshotRequestsPerBatch,
+        StaleBufferGlobalMib: StaleBufferGlobalMib,
+        StaleBufferCapLevels: StaleBufferCapLevels,
+        StaleEscapeTimeoutMs: StaleEscapeTimeoutMs,
+        PerSymbolFanoutSuppressHighPct: PerSymbolFanoutSuppressHighPct,
+        PerSymbolFanoutSuppressLowPct: PerSymbolFanoutSuppressLowPct);
+
+    /// <summary>
+    /// Snapshot the replay-driver knobs (speed, multicast republish target,
+    /// PCAP inputs, loss-injection profile).
+    /// </summary>
+    public ReplayOptions GetReplayOptions() => new(
+        Speed: Speed,
+        ReplayToMulticast: ReplayToMulticast,
+        PcapPrefixes: PcapPrefixes.AsReadOnly(),
+        PcapDirectory: PcapDirectory,
+        MulticastConfig: MulticastConfig,
+        LossTargets: LossTargets,
+        LossRate: LossRate,
+        LossMode: LossMode,
+        LossBurstSize: LossBurstSize,
+        LossCorrelated: LossCorrelated,
+        LossSeed: LossSeed);
+}

--- a/src/B3.Umdf.Server/Configuration/AppSettingsOptions.cs
+++ b/src/B3.Umdf.Server/Configuration/AppSettingsOptions.cs
@@ -1,0 +1,65 @@
+namespace B3.Umdf.Server.Configuration;
+
+/// <summary>
+/// Connection / per-client backpressure tuning projected from
+/// <see cref="AppSettings"/>. These values shape the WebSocket host's
+/// admission control (<c>MaxConnections</c>) and the per-client outbound
+/// pipeline (channel capacity, slow-client detection, byte cap, coalescing
+/// window). Built via <see cref="AppSettings.GetConnectionLimits"/>.
+/// </summary>
+public sealed record ConnectionLimitsOptions(
+    int MaxConnections,
+    int ClientChannelCapacity,
+    double SlowClientThreshold,
+    int SlowClientMaxTicks,
+    long ClientMaxPendingBytes,
+    double ClientOutlierMultiplier,
+    long ClientOutlierMinBytes,
+    double ClientOutlierPressurePct,
+    int ClientOutlierIntervalMs,
+    int ClientCoalesceWindowMs);
+
+/// <summary>
+/// /health staleness gate + graceful-drain budget. Built via
+/// <see cref="AppSettings.GetRecoveryHealthOptions"/>.
+/// </summary>
+public sealed record RecoveryHealthOptions(
+    int HealthMaxStaleSeconds,
+    bool HealthFailOnRecovery,
+    int ShutdownDrainSeconds);
+
+/// <summary>
+/// Buffering knobs governing the dispatch path: per-group MPSC ring,
+/// downstream channel capacity, server-side conflation flush window,
+/// per-batch snapshot dispatch cap, and stale-MBO buffer caps. Built via
+/// <see cref="AppSettings.GetBufferingOptions"/>.
+/// </summary>
+public sealed record BufferingOptions(
+    int FeedChannelCapacity,
+    int GroupRingCapacity,
+    int MulticastMergeCapacity,
+    int ServerFlushWindowMs,
+    int MaxSnapshotRequestsPerBatch,
+    int StaleBufferGlobalMib,
+    int[] StaleBufferCapLevels,
+    long StaleEscapeTimeoutMs,
+    double PerSymbolFanoutSuppressHighPct,
+    double PerSymbolFanoutSuppressLowPct);
+
+/// <summary>
+/// Replay / loss-injection switches consumed by the ConsoleApp's PCAP
+/// driver and <c>LossPolicyFactory</c>. Built via
+/// <see cref="AppSettings.GetReplayOptions"/>.
+/// </summary>
+public sealed record ReplayOptions(
+    double Speed,
+    bool ReplayToMulticast,
+    IReadOnlyList<string> PcapPrefixes,
+    string PcapDirectory,
+    string? MulticastConfig,
+    string? LossTargets,
+    double LossRate,
+    string LossMode,
+    int LossBurstSize,
+    bool LossCorrelated,
+    int LossSeed);

--- a/src/B3.Umdf.Server/Hosting/ClientSessionOptions.cs
+++ b/src/B3.Umdf.Server/Hosting/ClientSessionOptions.cs
@@ -1,0 +1,14 @@
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Per-WebSocket-connection tuning surface consumed by
+/// <see cref="WebSocketConnectionHandler"/> when constructing a
+/// <see cref="ClientSession"/>. Grouped so the WebSocketHost ctor doesn't
+/// need to re-thread six independent primitives every time the surface grows.
+/// </summary>
+public sealed record ClientSessionOptions(
+    int ChannelCapacity = 4096,
+    double SlowClientThreshold = 0.75,
+    int SlowClientMaxTicks = 100,
+    long MaxPendingBytes = 16L * 1024 * 1024,
+    int CoalesceWindowMs = 0);

--- a/src/B3.Umdf.Server/Hosting/CorsMiddleware.cs
+++ b/src/B3.Umdf.Server/Hosting/CorsMiddleware.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Permissive CORS middleware shared across the read-only public endpoints
+/// (dashboard scrape + health probes). Tighten via reverse proxy if exposed
+/// externally.
+/// </summary>
+internal static class CorsMiddleware
+{
+    public static void UsePermissiveCors(this WebApplication app)
+    {
+        app.Use(async (context, next) =>
+        {
+            context.Response.Headers["Access-Control-Allow-Origin"] = "*";
+            context.Response.Headers["Access-Control-Allow-Methods"] = "GET, OPTIONS";
+            context.Response.Headers["Access-Control-Allow-Headers"] = "Content-Type";
+            if (context.Request.Method == "OPTIONS")
+            {
+                context.Response.StatusCode = 204;
+                return;
+            }
+            await next();
+        });
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/HealthEndpointMapper.cs
+++ b/src/B3.Umdf.Server/Hosting/HealthEndpointMapper.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Maps the orchestration-facing probes (<c>/health</c>, <c>/ready</c>,
+/// <c>/live</c>). Carries no logic of its own; the staleness gate lives in
+/// <see cref="HealthEvaluator"/> so it can be unit-tested in isolation.
+/// </summary>
+internal sealed class HealthEndpointMapper
+{
+    private readonly SubscriptionManager _subscriptionManager;
+    private readonly Stopwatch _uptime;
+    private readonly Func<int> _maxStaleSeconds;
+    private readonly Func<bool> _failOnRecovery;
+    private readonly Func<Func<IReadOnlyDictionary<string, string>>?> _feedStateProvider;
+    private readonly Func<Func<IReadOnlyDictionary<string, long>>?> _lastPacketProvider;
+
+    public HealthEndpointMapper(
+        SubscriptionManager subscriptionManager,
+        Stopwatch uptime,
+        Func<int> maxStaleSeconds,
+        Func<bool> failOnRecovery,
+        Func<Func<IReadOnlyDictionary<string, string>>?> feedStateProvider,
+        Func<Func<IReadOnlyDictionary<string, long>>?> lastPacketProvider)
+    {
+        _subscriptionManager = subscriptionManager;
+        _uptime = uptime;
+        _maxStaleSeconds = maxStaleSeconds;
+        _failOnRecovery = failOnRecovery;
+        _feedStateProvider = feedStateProvider;
+        _lastPacketProvider = lastPacketProvider;
+    }
+
+    public void Map(WebApplication app)
+    {
+        app.MapGet("/health", () =>
+        {
+            var result = new HealthResponse
+            {
+                Status = _subscriptionManager.IsReady ? "ready" : "initializing",
+                Uptime = _uptime.Elapsed.ToString(@"hh\:mm\:ss"),
+            };
+
+            IReadOnlyDictionary<string, string>? states = null;
+            var stateProvider = _feedStateProvider();
+            if (stateProvider is not null)
+            {
+                states = stateProvider();
+                result.FeedGroups = new Dictionary<string, string>(states);
+            }
+
+            IReadOnlyDictionary<string, long>? lastPackets = null;
+            var lpProvider = _lastPacketProvider();
+            if (lpProvider is not null)
+            {
+                lastPackets = lpProvider();
+                var seconds = new Dictionary<string, double>(lastPackets.Count);
+                long now = Environment.TickCount64;
+                foreach (var (k, v) in lastPackets)
+                    seconds[k] = v > 0 ? (now - v) / 1000.0 : -1.0;
+                result.SecondsSinceLastPacket = seconds;
+            }
+
+            var unhealthy = HealthEvaluator.FindUnhealthyGroups(
+                states,
+                lastPackets,
+                Environment.TickCount64,
+                _uptime.Elapsed.TotalSeconds,
+                _maxStaleSeconds(),
+                _failOnRecovery());
+
+            if (unhealthy is not null)
+            {
+                result.Reason = "Stale recovery: " + string.Join(", ", unhealthy);
+                return Results.Json(result, AppJsonContext.Default.HealthResponse, statusCode: 503);
+            }
+
+            return Results.Json(result, AppJsonContext.Default.HealthResponse);
+        });
+
+        app.MapGet("/ready", () =>
+            _subscriptionManager.IsReady ? Results.Ok("ready") : Results.StatusCode(503));
+
+        app.MapGet("/live", () => Results.Ok("alive"));
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/HealthEvaluator.cs
+++ b/src/B3.Umdf.Server/Hosting/HealthEvaluator.cs
@@ -1,0 +1,67 @@
+using B3.Umdf.Feed;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Pure (no IO, no time-source dependency once <c>nowTicks</c> is supplied)
+/// staleness evaluator backing the <c>/health</c> endpoint. Extracted from
+/// <see cref="WebSocketHost"/> so the rule set ("a non-Streaming group whose
+/// last packet is older than the threshold flips the response to 503") can
+/// be unit-tested without spinning up Kestrel.
+/// </summary>
+public static class HealthEvaluator
+{
+    /// <summary>
+    /// Returns the "<c>group=state for Ns</c>" descriptors for every group
+    /// that is considered unhealthy under the stale-recovery rule, or
+    /// <c>null</c> when the response should remain 200 (either because the
+    /// gate is disabled, no per-group state was provided, or every group is
+    /// either Streaming or fresh enough).
+    /// </summary>
+    /// <param name="states">Per-group feed state map (e.g. "Streaming",
+    /// "WaitInstrumentDefinition"). When <c>null</c>, returns <c>null</c>.</param>
+    /// <param name="lastPacketTicks">Per-group last-observed-packet timestamp
+    /// (<see cref="Environment.TickCount64"/> units). May be <c>null</c>; for
+    /// groups absent from the map the staleness window falls back to
+    /// <paramref name="uptimeSeconds"/> (cold-start semantics).</param>
+    /// <param name="nowTicks"><see cref="Environment.TickCount64"/> at the
+    /// moment of evaluation.</param>
+    /// <param name="uptimeSeconds">Process uptime in seconds (used as the
+    /// fallback staleness window for groups with no recorded packet).</param>
+    /// <param name="maxStaleSeconds">Threshold beyond which a non-Streaming
+    /// group is considered unhealthy. Negative values disable the gate.</param>
+    /// <param name="failOnRecovery">Master switch matching
+    /// <c>AppSettings.HealthFailOnRecovery</c>. When <c>false</c>, the
+    /// evaluator unconditionally returns <c>null</c>.</param>
+    public static List<string>? FindUnhealthyGroups(
+        IReadOnlyDictionary<string, string>? states,
+        IReadOnlyDictionary<string, long>? lastPacketTicks,
+        long nowTicks,
+        double uptimeSeconds,
+        int maxStaleSeconds,
+        bool failOnRecovery)
+    {
+        if (!failOnRecovery || states is null || maxStaleSeconds < 0)
+            return null;
+
+        List<string>? unhealthy = null;
+        foreach (var (group, state) in states)
+        {
+            if (string.Equals(state, nameof(FeedState.Streaming), StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            double staleSec;
+            if (lastPacketTicks is not null && lastPacketTicks.TryGetValue(group, out var ticks) && ticks > 0)
+                staleSec = (nowTicks - ticks) / 1000.0;
+            else
+                staleSec = uptimeSeconds;
+
+            if (staleSec > maxStaleSeconds)
+            {
+                unhealthy ??= new List<string>();
+                unhealthy.Add($"{group}={state} for {staleSec:F0}s");
+            }
+        }
+        return unhealthy;
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/InstrumentEndpointMapper.cs
+++ b/src/B3.Umdf.Server/Hosting/InstrumentEndpointMapper.cs
@@ -1,0 +1,110 @@
+using B3.Umdf.Book;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace B3.Umdf.Server.Hosting;
+
+internal sealed class InstrumentEndpointMapper
+{
+    private readonly SubscriptionManager _subscriptionManager;
+
+    public InstrumentEndpointMapper(SubscriptionManager subscriptionManager)
+    {
+        _subscriptionManager = subscriptionManager;
+    }
+
+    public void Map(WebApplication app)
+    {
+        app.MapGet("/instrument/{symbol}", (string symbol) =>
+        {
+            var registry = _subscriptionManager.SymbolRegistry;
+            if (registry is null)
+                return Results.StatusCode(503);
+
+            symbol = symbol.Trim().ToUpperInvariant();
+            if (!registry.TryResolve(symbol, out var securityId))
+                return Results.NotFound();
+            var info = _subscriptionManager.FindInstrumentInfo(securityId);
+            if (info is null)
+                return Results.NotFound();
+
+            var resp = BuildInstrumentInfoResponse(securityId, info);
+            return Results.Json(resp, AppJsonContext.Default.InstrumentInfoResponse);
+        });
+    }
+
+    /// <summary>
+    /// Pure mapping helper: copy every field from the internal <see cref="InstrumentInfo"/>
+    /// snapshot into the public DTO. Mechanical and large by necessity (~50 fields covering
+    /// reference data + statistics + collections); kept separate so the endpoint registration
+    /// stays scannable.
+    /// </summary>
+    internal static InstrumentInfoResponse BuildInstrumentInfoResponse(ulong securityId, InstrumentInfo info)
+    {
+        return new InstrumentInfoResponse
+        {
+            SecurityId = securityId,
+            Symbol = info.Symbol,
+            Asset = info.Asset,
+            IsinNumber = info.IsinNumber,
+            Currency = info.Currency,
+            CfiCode = info.CfiCode,
+            SecurityGroup = info.SecurityGroup,
+            SecurityDescription = info.SecurityDescription,
+            SecurityType = info.SecurityType,
+            SecuritySubType = info.SecuritySubType,
+            Product = info.Product,
+            MinPriceIncrement = info.MinPriceIncrement,
+            PriceDivisor = info.PriceDivisor,
+            ContractMultiplier = info.ContractMultiplier,
+            StrikePrice = info.StrikePrice,
+            MaturityDate = info.MaturityDate,
+            PutOrCall = info.PutOrCall,
+            ExerciseStyle = info.ExerciseStyle,
+            MarketSegmentID = info.MarketSegmentID,
+            TickSizeDenominator = info.TickSizeDenominator,
+            TradingStatus = info.TradingStatus,
+            TradingEvent = info.TradingEvent,
+            OpeningPrice = info.OpeningPrice,
+            ClosingPrice = info.ClosingPrice,
+            HighPrice = info.HighPrice,
+            LowPrice = info.LowPrice,
+            LastTradePrice = info.LastTradePrice,
+            LastTradeSize = info.LastTradeSize,
+            SettlementPrice = info.SettlementPrice,
+            TheoreticalOpeningPrice = info.TheoreticalOpeningPrice,
+            TheoreticalOpeningSize = info.TheoreticalOpeningSize,
+            AuctionImbalanceSize = info.AuctionImbalanceSize,
+            PriceBandLow = info.PriceBandLow,
+            PriceBandHigh = info.PriceBandHigh,
+            PriceLimitType = info.PriceLimitType,
+            TradingReferencePrice = info.TradingReferencePrice,
+            AvgDailyTradedQty = info.AvgDailyTradedQty,
+            MaxTradeVol = info.MaxTradeVol,
+            TradeVolume = info.TradeVolume,
+            VwapPrice = info.VwapPrice,
+            NetChangeFromPrevDay = info.NetChangeFromPrevDay,
+            NumberOfTrades = info.NumberOfTrades,
+            OpenInterest = info.OpenInterest,
+            LastUpdateTimestamp = info.LastUpdateTimestamp,
+            Underlyings = info.Underlyings?.Select(u => new UnderlyingResponse
+            {
+                SecurityId = u.SecurityId,
+                Symbol = u.Symbol,
+            }).ToList(),
+            Legs = info.Legs?.Select(l => new LegResponse
+            {
+                SecurityId = l.SecurityId,
+                Symbol = l.Symbol,
+                RatioQty = l.RatioQty,
+                SecurityType = l.SecurityType,
+                Side = l.Side,
+            }).ToList(),
+            InstrAttribs = info.InstrAttribs?.Select(a => new InstrAttribResponse
+            {
+                Type = a.Type,
+                Value = a.Value,
+            }).ToList(),
+        };
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/MetricsEndpointMapper.cs
+++ b/src/B3.Umdf.Server/Hosting/MetricsEndpointMapper.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Owns the OpenTelemetry meter registration plus the Prometheus scrape
+/// endpoint mapping. Always exposes the <c>"B3.Umdf"</c> meter (defined by
+/// <see cref="MetricsRegistry"/>); callers may pass extra meter names to
+/// surface (e.g. <c>"B3.Umdf.Consumer"</c> from the ConsoleApp's
+/// <c>MetricsBinder</c>) on the same scrape endpoint.
+/// </summary>
+internal static class MetricsEndpointMapper
+{
+    public static void AddOpenTelemetryWithMeters(IServiceCollection services, IReadOnlyList<string> additionalMeterNames)
+    {
+        services
+            .AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddMeter(MetricsRegistry.Meter.Name);
+                foreach (var name in additionalMeterNames)
+                {
+                    if (!string.IsNullOrWhiteSpace(name))
+                        metrics.AddMeter(name);
+                }
+                metrics.AddPrometheusExporter();
+            });
+    }
+
+    public static void MapPrometheus(WebApplication app)
+    {
+        // Prometheus scrape endpoint. Lives on the same port as /health for
+        // ops-stack convenience.
+        app.MapPrometheusScrapingEndpoint();
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/RecoveryEndpointMapper.cs
+++ b/src/B3.Umdf.Server/Hosting/RecoveryEndpointMapper.cs
@@ -1,0 +1,54 @@
+using B3.Umdf.Book;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace B3.Umdf.Server.Hosting;
+
+internal sealed class RecoveryEndpointMapper
+{
+    private readonly Func<Func<int, IReadOnlyList<RecoveryEvent>>?> _eventProvider;
+    private readonly Func<Func<long>?> _eventTotalProvider;
+
+    public RecoveryEndpointMapper(
+        Func<Func<int, IReadOnlyList<RecoveryEvent>>?> eventProvider,
+        Func<Func<long>?> eventTotalProvider)
+    {
+        _eventProvider = eventProvider;
+        _eventTotalProvider = eventTotalProvider;
+    }
+
+    public void Map(WebApplication app)
+    {
+        // /api/recovery/recent surfaces the in-memory ring buffer of recent
+        // recovery audit events for ops triage. When no provider is wired
+        // (tests, embedded scenarios) the endpoint returns an empty list
+        // rather than 404 so the contract stays stable.
+        app.MapGet("/api/recovery/recent", (int? limit) =>
+        {
+            var capped = Math.Clamp(limit ?? 50, 1, 1000);
+            var events = _eventProvider()?.Invoke(capped) ?? Array.Empty<RecoveryEvent>();
+            var dto = new RecoveryEventLogResponse
+            {
+                TotalRecorded = _eventTotalProvider()?.Invoke() ?? 0,
+                Returned = events.Count,
+                Events = new RecoveryEventDto[events.Count],
+            };
+            for (int i = 0; i < events.Count; i++)
+            {
+                var e = events[i];
+                dto.Events[i] = new RecoveryEventDto
+                {
+                    TimestampUnixMs = e.TimestampUnixMs,
+                    Kind = (int)e.Kind,
+                    KindName = e.Kind.ToString(),
+                    GroupId = e.GroupId,
+                    SecurityId = e.SecurityId,
+                    SnapshotRptSeq = e.SnapshotRptSeq,
+                    PriorRptSeq = e.PriorRptSeq,
+                    Detail = e.Detail,
+                };
+            }
+            return Results.Json(dto, AppJsonContext.Default.RecoveryEventLogResponse);
+        });
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/ShutdownCoordinator.cs
+++ b/src/B3.Umdf.Server/Hosting/ShutdownCoordinator.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Owns the graceful-drain phase: send a clean WebSocket close frame
+/// (1001 / EndpointUnavailable) to every active client so they observe an
+/// orderly shutdown rather than a connection reset. The per-client close
+/// handshake is bounded by the supplied budget so a misbehaving peer cannot
+/// hold the shutdown open indefinitely.
+/// </summary>
+internal sealed class ShutdownCoordinator
+{
+    private readonly SubscriptionManager _subscriptionManager;
+    private readonly ILogger _logger;
+
+    public ShutdownCoordinator(SubscriptionManager subscriptionManager, ILogger logger)
+    {
+        _subscriptionManager = subscriptionManager;
+        _logger = logger;
+    }
+
+    public async Task DrainClientsAsync(TimeSpan closeHandshakeBudget)
+    {
+        if (closeHandshakeBudget <= TimeSpan.Zero)
+            closeHandshakeBudget = TimeSpan.FromSeconds(5);
+
+        var sessions = _subscriptionManager.EnumerateAllClients()
+            .Select(kv => kv.Value)
+            .ToList();
+        if (sessions.Count == 0)
+            return;
+
+        using var cts = new CancellationTokenSource(closeHandshakeBudget);
+        var tasks = new Task[sessions.Count];
+        for (int i = 0; i < sessions.Count; i++)
+            tasks[i] = sessions[i].RequestGracefulCloseAsync("server shutting down", cts.Token);
+
+        try { await Task.WhenAll(tasks).ConfigureAwait(false); }
+        catch { /* per-client failures already logged inside RequestGracefulCloseAsync */ }
+
+        _logger.LogInformation(
+            "Sent WebSocket close (1001) to {Count} active client(s) before stopping Kestrel",
+            sessions.Count);
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/SymbolEndpointMapper.cs
+++ b/src/B3.Umdf.Server/Hosting/SymbolEndpointMapper.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace B3.Umdf.Server.Hosting;
+
+internal sealed class SymbolEndpointMapper
+{
+    private readonly SubscriptionManager _subscriptionManager;
+
+    public SymbolEndpointMapper(SubscriptionManager subscriptionManager)
+    {
+        _subscriptionManager = subscriptionManager;
+    }
+
+    public void Map(WebApplication app)
+    {
+        app.MapGet("/symbols", (string? q, int? limit) =>
+        {
+            var registry = _subscriptionManager.SymbolRegistry;
+            if (registry is null)
+                return Results.Json(new SymbolsResponse(), AppJsonContext.Default.SymbolsResponse);
+            IEnumerable<string> symbols = registry.BySymbol.Keys.Order();
+            if (!string.IsNullOrEmpty(q))
+                symbols = symbols.Where(s => s.Contains(q, StringComparison.OrdinalIgnoreCase));
+            var max = Math.Clamp(limit ?? 20, 1, 100);
+            var list = symbols.Take(max).ToArray();
+            return Results.Json(new SymbolsResponse { Count = registry.Count, Matched = list.Length, Symbols = list },
+                AppJsonContext.Default.SymbolsResponse);
+        });
+    }
+}

--- a/src/B3.Umdf.Server/Hosting/WebSocketConnectionHandler.cs
+++ b/src/B3.Umdf.Server/Hosting/WebSocketConnectionHandler.cs
@@ -1,0 +1,153 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Umdf.Server.Hosting;
+
+/// <summary>
+/// Owns the <c>/ws</c> endpoint: shutdown gating, connection-cap enforcement,
+/// session construction, and the read/write loop pair per accepted client.
+/// Extracted from <see cref="WebSocketHost"/> so the lifecycle logic is no
+/// longer tangled with hosting setup, and so future protocol additions land
+/// in one place.
+/// </summary>
+internal sealed class WebSocketConnectionHandler
+{
+    private readonly SubscriptionManager _subscriptionManager;
+    private readonly ILogger _logger;
+    private readonly ClientSessionOptions _sessionOptions;
+    private readonly int _maxConnections;
+    private readonly Func<bool> _isShuttingDown;
+
+    public WebSocketConnectionHandler(
+        SubscriptionManager subscriptionManager,
+        ILogger logger,
+        ClientSessionOptions sessionOptions,
+        int maxConnections,
+        Func<bool> isShuttingDown)
+    {
+        _subscriptionManager = subscriptionManager;
+        _logger = logger;
+        _sessionOptions = sessionOptions;
+        _maxConnections = maxConnections;
+        _isShuttingDown = isShuttingDown;
+    }
+
+    public void Map(WebApplication app, CancellationToken ct)
+    {
+        app.Map("/ws", async context => await HandleAsync(context, ct).ConfigureAwait(false));
+    }
+
+    private async Task HandleAsync(HttpContext context, CancellationToken ct)
+    {
+        // Once shutdown has been signaled, refuse new connections immediately so the
+        // drain phase does not have to wait on freshly-accepted clients (and so we
+        // don't keep logging the connect/disconnect churn from clients that retry).
+        if (_isShuttingDown() || ct.IsCancellationRequested)
+        {
+            _logger.LogInformation("Connection rejected: server is shutting down");
+            context.Response.StatusCode = 503;
+            context.Response.Headers["Connection"] = "close";
+            return;
+        }
+
+        if (!context.WebSockets.IsWebSocketRequest)
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        // Soft connection limit: this check is intentionally racy (TOCTOU vs
+        // RegisterClient below) — under heavy concurrent connect bursts we may
+        // briefly exceed _maxConnections by a handful, which is acceptable.
+        // Tightening would require a CAS-counter in SubscriptionManager and is
+        // not worth the contention for a soft cap.
+        if (_maxConnections > 0 && _subscriptionManager.ClientCount >= _maxConnections)
+        {
+            _logger.LogWarning("Connection rejected: limit {Max} reached", _maxConnections);
+            context.Response.StatusCode = 503;
+            return;
+        }
+
+        var ws = await context.WebSockets.AcceptWebSocketAsync();
+        var session = new ClientSession(
+            ws,
+            channelCapacity: _sessionOptions.ChannelCapacity,
+            slowClientThreshold: _sessionOptions.SlowClientThreshold,
+            slowClientMaxTicks: _sessionOptions.SlowClientMaxTicks,
+            maxPendingBytes: _sessionOptions.MaxPendingBytes,
+            coalesceWindowMs: _sessionOptions.CoalesceWindowMs,
+            logger: _logger);
+        _subscriptionManager.RegisterClient(session);
+
+        _logger.LogInformation("Client {ClientId} connected", session.Id);
+
+        var writeTask = Task.Run(() => session.RunWriteLoopAsync());
+
+        try
+        {
+            await foreach (var (type, payload) in session.ReadMessagesAsync(ct))
+            {
+                switch (type)
+                {
+                    case MessageType.ClientHello:
+                    {
+                        // Optional negotiation: clients that never send ClientHello are
+                        // assumed to speak the current ProtocolVersion. If sent and
+                        // incompatible, close with WS 1003 (unsupported data).
+                        if (payload.Length < 4) break;
+                        uint clientVer = WireProtocol.ReadClientHello(payload.Span);
+                        if (clientVer < WireProtocol.SupportedProtocolVersionMin ||
+                            clientVer > WireProtocol.SupportedProtocolVersionMax)
+                        {
+                            var reason =
+                                $"protocol_version_unsupported: client {clientVer}, " +
+                                $"server min {WireProtocol.SupportedProtocolVersionMin} " +
+                                $"max {WireProtocol.SupportedProtocolVersionMax}";
+                            _logger.LogWarning(
+                                "Client {ClientId} sent unsupported ClientHello version {Version}; closing",
+                                session.Id, clientVer);
+                            try
+                            {
+                                await ws.CloseAsync(
+                                    System.Net.WebSockets.WebSocketCloseStatus.InvalidMessageType,
+                                    reason,
+                                    CancellationToken.None).ConfigureAwait(false);
+                            }
+                            catch { /* best effort */ }
+                            return;
+                        }
+                        break;
+                    }
+
+                    case MessageType.Subscribe:
+                    {
+                        var (symbol, flags) = WireProtocol.ReadSubscribe(payload.Span);
+                        _subscriptionManager.RequestSubscribe(session.Id, symbol, flags);
+                        break;
+                    }
+
+                    case MessageType.Get:
+                    {
+                        var (symbol, flags) = WireProtocol.ReadSubscribe(payload.Span);
+                        _subscriptionManager.RequestGet(session.Id, symbol, flags);
+                        break;
+                    }
+
+                    case MessageType.Unsubscribe:
+                        var securityId = WireProtocol.ReadUnsubscribe(payload.Span);
+                        _subscriptionManager.RequestUnsubscribe(session.Id, securityId);
+                        break;
+                }
+            }
+        }
+        finally
+        {
+            _logger.LogInformation("Client {ClientId} disconnected", session.Id);
+            _subscriptionManager.UnregisterClient(session.Id);
+            session.Cancel();
+            await writeTask;
+            session.Dispose();
+        }
+    }
+}

--- a/src/B3.Umdf.Server/WebSocketHost.cs
+++ b/src/B3.Umdf.Server/WebSocketHost.cs
@@ -1,12 +1,12 @@
 using System.Diagnostics;
 using B3.Umdf.Book;
 using B3.Umdf.Feed;
+using B3.Umdf.Server.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Metrics;
 
 namespace B3.Umdf.Server;
 
@@ -14,21 +14,23 @@ namespace B3.Umdf.Server;
 /// Kestrel-based WebSocket server for market data subscriptions.
 /// Includes health/readiness endpoints for orchestration compatibility.
 /// AOT-compatible: uses CreateSlimBuilder and source-generated JSON.
+///
+/// This type orchestrates the host lifecycle and owns the providers wired
+/// in by the ConsoleApp. The actual endpoint logic, CORS, health staleness
+/// evaluation, WebSocket connection handling, and shutdown drain live in
+/// dedicated classes under <see cref="Hosting"/> so each concern is
+/// independently testable.
 /// </summary>
 public sealed class WebSocketHost : IAsyncDisposable
 {
     private readonly SubscriptionManager _subscriptionManager;
     private readonly ILogger<WebSocketHost> _logger;
     private readonly Stopwatch _uptime = Stopwatch.StartNew();
+    private readonly ClientSessionOptions _sessionOptions;
+    private readonly int _maxConnections;
     private WebApplication? _app;
     private volatile bool _isShuttingDown;
     private CancellationTokenRegistration _shutdownRegistration;
-    private readonly int _maxConnections;
-    private readonly int _clientChannelCapacity;
-    private readonly double _slowClientThreshold;
-    private readonly int _slowClientMaxTicks;
-    private readonly long _clientMaxPendingBytes;
-    private readonly int _clientCoalesceWindowMs;
 
     /// <summary>Optional provider for feed group states (set before StartAsync).</summary>
     public Func<IReadOnlyDictionary<string, string>>? FeedStateProvider { get; set; }
@@ -89,11 +91,12 @@ public sealed class WebSocketHost : IAsyncDisposable
         _subscriptionManager = subscriptionManager;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<WebSocketHost>.Instance;
         _maxConnections = maxConnections;
-        _clientChannelCapacity = clientChannelCapacity;
-        _slowClientThreshold = slowClientThreshold;
-        _slowClientMaxTicks = slowClientMaxTicks;
-        _clientMaxPendingBytes = clientMaxPendingBytes;
-        _clientCoalesceWindowMs = clientCoalesceWindowMs;
+        _sessionOptions = new ClientSessionOptions(
+            ChannelCapacity: clientChannelCapacity,
+            SlowClientThreshold: slowClientThreshold,
+            SlowClientMaxTicks: slowClientMaxTicks,
+            MaxPendingBytes: clientMaxPendingBytes,
+            CoalesceWindowMs: clientCoalesceWindowMs);
     }
 
     public async Task StartAsync(int port, CancellationToken ct = default)
@@ -115,18 +118,7 @@ public sealed class WebSocketHost : IAsyncDisposable
         builder.Services.ConfigureHttpJsonOptions(options =>
             options.SerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonContext.Default));
 
-        builder.Services
-            .AddOpenTelemetry()
-            .WithMetrics(metrics =>
-            {
-                metrics.AddMeter(MetricsRegistry.Meter.Name);
-                foreach (var name in AdditionalMeterNames)
-                {
-                    if (!string.IsNullOrWhiteSpace(name))
-                        metrics.AddMeter(name);
-                }
-                metrics.AddPrometheusExporter();
-            });
+        MetricsEndpointMapper.AddOpenTelemetryWithMeters(builder.Services, AdditionalMeterNames);
 
         _app = builder.Build();
         _app.UseWebSockets(new WebSocketOptions
@@ -134,376 +126,35 @@ public sealed class WebSocketHost : IAsyncDisposable
             KeepAliveInterval = TimeSpan.FromSeconds(30),
         });
 
-        UseCorsHeaders(_app);
-        MapHealthEndpoints(_app);
-        MapMetricsEndpoint(_app);
-        MapSymbolEndpoints(_app);
-        MapInstrumentEndpoint(_app);
-        MapRecoveryEndpoint(_app);
-        MapWebSocketEndpoint(_app, ct);
+        _app.UsePermissiveCors();
+
+        var healthMapper = new HealthEndpointMapper(
+            _subscriptionManager,
+            _uptime,
+            () => HealthMaxStaleSeconds,
+            () => HealthFailOnRecovery,
+            () => FeedStateProvider,
+            () => LastPacketTimestampProvider);
+        healthMapper.Map(_app);
+
+        MetricsEndpointMapper.MapPrometheus(_app);
+
+        new SymbolEndpointMapper(_subscriptionManager).Map(_app);
+        new InstrumentEndpointMapper(_subscriptionManager).Map(_app);
+        new RecoveryEndpointMapper(
+            () => RecoveryEventProvider,
+            () => RecoveryEventTotalProvider).Map(_app);
+
+        var wsHandler = new WebSocketConnectionHandler(
+            _subscriptionManager,
+            _logger,
+            _sessionOptions,
+            _maxConnections,
+            () => _isShuttingDown);
+        wsHandler.Map(_app, ct);
 
         await _app.StartAsync(ct);
         _logger.LogInformation("WebSocket server listening on port {Port}", port);
-    }
-
-    private static void UseCorsHeaders(WebApplication app)
-    {
-        // CORS for cross-origin frontend access. Permissive by design — this
-        // service is intentionally read-only / public-by-default for the
-        // dashboard. Tighten via reverse proxy if exposed externally.
-        app.Use(async (context, next) =>
-        {
-            context.Response.Headers["Access-Control-Allow-Origin"] = "*";
-            context.Response.Headers["Access-Control-Allow-Methods"] = "GET, OPTIONS";
-            context.Response.Headers["Access-Control-Allow-Headers"] = "Content-Type";
-            if (context.Request.Method == "OPTIONS")
-            {
-                context.Response.StatusCode = 204;
-                return;
-            }
-            await next();
-        });
-    }
-
-    private void MapHealthEndpoints(WebApplication app)
-    {
-        app.MapGet("/health", () =>
-        {
-            var result = new HealthResponse
-            {
-                Status = _subscriptionManager.IsReady ? "ready" : "initializing",
-                Uptime = _uptime.Elapsed.ToString(@"hh\:mm\:ss"),
-            };
-            IReadOnlyDictionary<string, string>? states = null;
-            if (FeedStateProvider is not null)
-            {
-                states = FeedStateProvider();
-                result.FeedGroups = new Dictionary<string, string>(states);
-            }
-            IReadOnlyDictionary<string, long>? lastPackets = null;
-            if (LastPacketTimestampProvider is not null)
-            {
-                lastPackets = LastPacketTimestampProvider();
-                var seconds = new Dictionary<string, double>(lastPackets.Count);
-                long now = Environment.TickCount64;
-                foreach (var (k, v) in lastPackets)
-                    seconds[k] = v > 0 ? (now - v) / 1000.0 : -1.0;
-                result.SecondsSinceLastPacket = seconds;
-            }
-
-            // Stale-recovery gate: a group reported as non-Streaming for longer
-            // than HealthMaxStaleSeconds flips the response to 503 so that
-            // orchestrators can fail readiness on stuck groups. Cold-start
-            // semantics: when no packet has yet been seen for a group we
-            // measure staleness against process uptime, so /health stays 200
-            // until the threshold elapses (matches existing /ready behavior).
-            if (HealthFailOnRecovery && states is not null && HealthMaxStaleSeconds >= 0)
-            {
-                long now = Environment.TickCount64;
-                double uptimeSec = _uptime.Elapsed.TotalSeconds;
-                List<string>? unhealthy = null;
-                foreach (var (group, state) in states)
-                {
-                    if (string.Equals(state, nameof(FeedState.Streaming), StringComparison.OrdinalIgnoreCase))
-                        continue;
-                    double staleSec;
-                    if (lastPackets is not null && lastPackets.TryGetValue(group, out var ticks) && ticks > 0)
-                        staleSec = (now - ticks) / 1000.0;
-                    else
-                        staleSec = uptimeSec;
-                    if (staleSec > HealthMaxStaleSeconds)
-                    {
-                        unhealthy ??= new List<string>();
-                        unhealthy.Add($"{group}={state} for {staleSec:F0}s");
-                    }
-                }
-                if (unhealthy is not null)
-                {
-                    result.Reason = "Stale recovery: " + string.Join(", ", unhealthy);
-                    return Results.Json(result, AppJsonContext.Default.HealthResponse, statusCode: 503);
-                }
-            }
-
-            return Results.Json(result, AppJsonContext.Default.HealthResponse);
-        });
-
-        app.MapGet("/ready", () =>
-            _subscriptionManager.IsReady ? Results.Ok("ready") : Results.StatusCode(503));
-
-        app.MapGet("/live", () => Results.Ok("alive"));
-    }
-
-    private static void MapMetricsEndpoint(WebApplication app)
-    {
-        // Prometheus scrape endpoint. Exposes every meter registered in the
-        // OpenTelemetry pipeline (always B3.Umdf, plus AdditionalMeterNames).
-        // Lives on the same port as /health for ops-stack convenience.
-        app.MapPrometheusScrapingEndpoint();
-    }
-
-    private void MapSymbolEndpoints(WebApplication app)
-    {
-        app.MapGet("/symbols", (string? q, int? limit) =>
-        {
-            var registry = _subscriptionManager.SymbolRegistry;
-            if (registry is null)
-                return Results.Json(new SymbolsResponse(), AppJsonContext.Default.SymbolsResponse);
-            IEnumerable<string> symbols = registry.BySymbol.Keys.Order();
-            if (!string.IsNullOrEmpty(q))
-                symbols = symbols.Where(s => s.Contains(q, StringComparison.OrdinalIgnoreCase));
-            var max = Math.Clamp(limit ?? 20, 1, 100);
-            var list = symbols.Take(max).ToArray();
-            return Results.Json(new SymbolsResponse { Count = registry.Count, Matched = list.Length, Symbols = list },
-                AppJsonContext.Default.SymbolsResponse);
-        });
-    }
-
-    private void MapRecoveryEndpoint(WebApplication app)
-    {
-        // /api/recovery/recent surfaces the in-memory ring buffer of recent
-        // recovery audit events for ops triage. When no provider is wired
-        // (tests, embedded scenarios) the endpoint returns an empty list
-        // rather than 404 so the contract stays stable.
-        app.MapGet("/api/recovery/recent", (int? limit) =>
-        {
-            var capped = Math.Clamp(limit ?? 50, 1, 1000);
-            var events = RecoveryEventProvider?.Invoke(capped) ?? Array.Empty<RecoveryEvent>();
-            var dto = new RecoveryEventLogResponse
-            {
-                TotalRecorded = RecoveryEventTotalProvider?.Invoke() ?? 0,
-                Returned = events.Count,
-                Events = new RecoveryEventDto[events.Count],
-            };
-            for (int i = 0; i < events.Count; i++)
-            {
-                var e = events[i];
-                dto.Events[i] = new RecoveryEventDto
-                {
-                    TimestampUnixMs = e.TimestampUnixMs,
-                    Kind = (int)e.Kind,
-                    KindName = e.Kind.ToString(),
-                    GroupId = e.GroupId,
-                    SecurityId = e.SecurityId,
-                    SnapshotRptSeq = e.SnapshotRptSeq,
-                    PriorRptSeq = e.PriorRptSeq,
-                    Detail = e.Detail,
-                };
-            }
-            return Results.Json(dto, AppJsonContext.Default.RecoveryEventLogResponse);
-        });
-    }
-
-    private void MapInstrumentEndpoint(WebApplication app)
-    {
-        app.MapGet("/instrument/{symbol}", (string symbol) =>
-        {
-            var registry = _subscriptionManager.SymbolRegistry;
-            if (registry is null)
-                return Results.StatusCode(503);
-
-            symbol = symbol.Trim().ToUpperInvariant();
-            if (!registry.TryResolve(symbol, out var securityId))
-                return Results.NotFound();
-            var info = _subscriptionManager.FindInstrumentInfo(securityId);
-            if (info is null)
-                return Results.NotFound();
-
-            var resp = BuildInstrumentInfoResponse(securityId, info);
-            return Results.Json(resp, AppJsonContext.Default.InstrumentInfoResponse);
-        });
-    }
-
-    /// <summary>
-    /// Pure mapping helper: copy every field from the internal <see cref="InstrumentInfo"/>
-    /// snapshot into the public DTO. Mechanical and large by necessity (~50 fields covering
-    /// reference data + statistics + collections); kept separate so the endpoint registration
-    /// stays scannable.
-    /// </summary>
-    private static InstrumentInfoResponse BuildInstrumentInfoResponse(ulong securityId, InstrumentInfo info)
-    {
-        return new InstrumentInfoResponse
-        {
-            SecurityId = securityId,
-            Symbol = info.Symbol,
-            Asset = info.Asset,
-            IsinNumber = info.IsinNumber,
-            Currency = info.Currency,
-            CfiCode = info.CfiCode,
-            SecurityGroup = info.SecurityGroup,
-            SecurityDescription = info.SecurityDescription,
-            SecurityType = info.SecurityType,
-            SecuritySubType = info.SecuritySubType,
-            Product = info.Product,
-            MinPriceIncrement = info.MinPriceIncrement,
-            PriceDivisor = info.PriceDivisor,
-            ContractMultiplier = info.ContractMultiplier,
-            StrikePrice = info.StrikePrice,
-            MaturityDate = info.MaturityDate,
-            PutOrCall = info.PutOrCall,
-            ExerciseStyle = info.ExerciseStyle,
-            MarketSegmentID = info.MarketSegmentID,
-            TickSizeDenominator = info.TickSizeDenominator,
-            TradingStatus = info.TradingStatus,
-            TradingEvent = info.TradingEvent,
-            OpeningPrice = info.OpeningPrice,
-            ClosingPrice = info.ClosingPrice,
-            HighPrice = info.HighPrice,
-            LowPrice = info.LowPrice,
-            LastTradePrice = info.LastTradePrice,
-            LastTradeSize = info.LastTradeSize,
-            SettlementPrice = info.SettlementPrice,
-            TheoreticalOpeningPrice = info.TheoreticalOpeningPrice,
-            TheoreticalOpeningSize = info.TheoreticalOpeningSize,
-            AuctionImbalanceSize = info.AuctionImbalanceSize,
-            PriceBandLow = info.PriceBandLow,
-            PriceBandHigh = info.PriceBandHigh,
-            PriceLimitType = info.PriceLimitType,
-            TradingReferencePrice = info.TradingReferencePrice,
-            AvgDailyTradedQty = info.AvgDailyTradedQty,
-            MaxTradeVol = info.MaxTradeVol,
-            TradeVolume = info.TradeVolume,
-            VwapPrice = info.VwapPrice,
-            NetChangeFromPrevDay = info.NetChangeFromPrevDay,
-            NumberOfTrades = info.NumberOfTrades,
-            OpenInterest = info.OpenInterest,
-            LastUpdateTimestamp = info.LastUpdateTimestamp,
-            Underlyings = info.Underlyings?.Select(u => new UnderlyingResponse
-            {
-                SecurityId = u.SecurityId,
-                Symbol = u.Symbol,
-            }).ToList(),
-            Legs = info.Legs?.Select(l => new LegResponse
-            {
-                SecurityId = l.SecurityId,
-                Symbol = l.Symbol,
-                RatioQty = l.RatioQty,
-                SecurityType = l.SecurityType,
-                Side = l.Side,
-            }).ToList(),
-            InstrAttribs = info.InstrAttribs?.Select(a => new InstrAttribResponse
-            {
-                Type = a.Type,
-                Value = a.Value,
-            }).ToList(),
-        };
-    }
-
-    private void MapWebSocketEndpoint(WebApplication app, CancellationToken ct)
-    {
-        app.Map("/ws", async context =>
-        {
-            // Once shutdown has been signaled, refuse new connections immediately so the
-            // drain phase does not have to wait on freshly-accepted clients (and so we
-            // don't keep logging the connect/disconnect churn from clients that retry).
-            if (_isShuttingDown || ct.IsCancellationRequested)
-            {
-                _logger.LogInformation("Connection rejected: server is shutting down");
-                context.Response.StatusCode = 503;
-                context.Response.Headers["Connection"] = "close";
-                return;
-            }
-
-            if (!context.WebSockets.IsWebSocketRequest)
-            {
-                context.Response.StatusCode = 400;
-                return;
-            }
-
-            // Soft connection limit: this check is intentionally racy (TOCTOU vs
-            // RegisterClient below) — under heavy concurrent connect bursts we may
-            // briefly exceed _maxConnections by a handful, which is acceptable.
-            // Tightening would require a CAS-counter in SubscriptionManager and is
-            // not worth the contention for a soft cap.
-            if (_maxConnections > 0 && _subscriptionManager.ClientCount >= _maxConnections)
-            {
-                _logger.LogWarning("Connection rejected: limit {Max} reached", _maxConnections);
-                context.Response.StatusCode = 503;
-                return;
-            }
-
-            var ws = await context.WebSockets.AcceptWebSocketAsync();
-            var session = new ClientSession(
-                ws,
-                channelCapacity: _clientChannelCapacity,
-                slowClientThreshold: _slowClientThreshold,
-                slowClientMaxTicks: _slowClientMaxTicks,
-                maxPendingBytes: _clientMaxPendingBytes,
-                coalesceWindowMs: _clientCoalesceWindowMs,
-                logger: _logger);
-            _subscriptionManager.RegisterClient(session);
-
-            _logger.LogInformation("Client {ClientId} connected", session.Id);
-
-            // Start write loop
-            var writeTask = Task.Run(() => session.RunWriteLoopAsync());
-
-            // Read loop
-            try
-            {
-                await foreach (var (type, payload) in session.ReadMessagesAsync(ct))
-                {
-                    switch (type)
-                    {
-                        case MessageType.ClientHello:
-                        {
-                            // Optional negotiation: clients that never send ClientHello are
-                            // assumed to speak the current ProtocolVersion. If sent and
-                            // incompatible, close with WS 1003 (unsupported data).
-                            if (payload.Length < 4) break;
-                            uint clientVer = WireProtocol.ReadClientHello(payload.Span);
-                            if (clientVer < WireProtocol.SupportedProtocolVersionMin ||
-                                clientVer > WireProtocol.SupportedProtocolVersionMax)
-                            {
-                                var reason =
-                                    $"protocol_version_unsupported: client {clientVer}, " +
-                                    $"server min {WireProtocol.SupportedProtocolVersionMin} " +
-                                    $"max {WireProtocol.SupportedProtocolVersionMax}";
-                                _logger.LogWarning(
-                                    "Client {ClientId} sent unsupported ClientHello version {Version}; closing",
-                                    session.Id, clientVer);
-                                try
-                                {
-                                    await ws.CloseAsync(
-                                        System.Net.WebSockets.WebSocketCloseStatus.InvalidMessageType,
-                                        reason,
-                                        CancellationToken.None).ConfigureAwait(false);
-                                }
-                                catch { /* best effort */ }
-                                return;
-                            }
-                            break;
-                        }
-
-                        case MessageType.Subscribe:
-                        {
-                            var (symbol, flags) = WireProtocol.ReadSubscribe(payload.Span);
-                            _subscriptionManager.RequestSubscribe(session.Id, symbol, flags);
-                            break;
-                        }
-
-                        case MessageType.Get:
-                        {
-                            var (symbol, flags) = WireProtocol.ReadSubscribe(payload.Span);
-                            _subscriptionManager.RequestGet(session.Id, symbol, flags);
-                            break;
-                        }
-
-                        case MessageType.Unsubscribe:
-                            var securityId = WireProtocol.ReadUnsubscribe(payload.Span);
-                            _subscriptionManager.RequestUnsubscribe(session.Id, securityId);
-                            break;
-                    }
-                }
-            }
-            finally
-            {
-                _logger.LogInformation("Client {ClientId} disconnected", session.Id);
-                _subscriptionManager.UnregisterClient(session.Id);
-                session.Cancel();   // signal write loop to stop before awaiting
-                await writeTask;    // wait for clean exit before disposing CTS
-                session.Dispose();
-            }
-        });
     }
 
     /// <summary>
@@ -518,24 +169,8 @@ public sealed class WebSocketHost : IAsyncDisposable
     {
         if (_app is null) return;
 
-        if (closeHandshakeBudget <= TimeSpan.Zero)
-            closeHandshakeBudget = TimeSpan.FromSeconds(5);
-
-        var sessions = _subscriptionManager.EnumerateAllClients()
-            .Select(kv => kv.Value)
-            .ToList();
-        if (sessions.Count > 0)
-        {
-            using var cts = new CancellationTokenSource(closeHandshakeBudget);
-            var tasks = new Task[sessions.Count];
-            for (int i = 0; i < sessions.Count; i++)
-                tasks[i] = sessions[i].RequestGracefulCloseAsync("server shutting down", cts.Token);
-            try { await Task.WhenAll(tasks).ConfigureAwait(false); }
-            catch { /* per-client failures already logged inside RequestGracefulCloseAsync */ }
-            _logger.LogInformation(
-                "Sent WebSocket close (1001) to {Count} active client(s) before stopping Kestrel",
-                sessions.Count);
-        }
+        var coordinator = new ShutdownCoordinator(_subscriptionManager, _logger);
+        await coordinator.DrainClientsAsync(closeHandshakeBudget);
 
         await _app.StopAsync();
     }

--- a/tests/B3.Umdf.Server.Tests/AppSettingsProjectionsTests.cs
+++ b/tests/B3.Umdf.Server.Tests/AppSettingsProjectionsTests.cs
@@ -1,0 +1,84 @@
+using B3.Umdf.Server.Configuration;
+using Xunit;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Verifies the read-only option-record projections layered on top of
+/// <see cref="AppSettings"/>: each helper must surface the same defaults
+/// the flat property bag exposes, and must reflect overrides applied to
+/// the source <see cref="AppSettings"/> instance.
+/// </summary>
+public class AppSettingsProjectionsTests
+{
+    [Fact]
+    public void GetConnectionLimits_mirrors_defaults_and_overrides()
+    {
+        var s = new AppSettings();
+        var defaults = s.GetConnectionLimits();
+        Assert.Equal(s.MaxConnections, defaults.MaxConnections);
+        Assert.Equal(s.ClientChannelCapacity, defaults.ClientChannelCapacity);
+        Assert.Equal(s.SlowClientThreshold, defaults.SlowClientThreshold);
+        Assert.Equal(s.ClientMaxPendingBytes, defaults.ClientMaxPendingBytes);
+        Assert.Equal(s.ClientCoalesceWindowMs, defaults.ClientCoalesceWindowMs);
+
+        s.MaxConnections = 1234;
+        s.ClientCoalesceWindowMs = 25;
+        var updated = s.GetConnectionLimits();
+        Assert.Equal(1234, updated.MaxConnections);
+        Assert.Equal(25, updated.ClientCoalesceWindowMs);
+    }
+
+    [Fact]
+    public void GetRecoveryHealthOptions_carries_health_gate_and_drain_budget()
+    {
+        var s = new AppSettings
+        {
+            HealthMaxStaleSeconds = 90,
+            HealthFailOnRecovery = false,
+            ShutdownDrainSeconds = 12,
+        };
+        var opts = s.GetRecoveryHealthOptions();
+        Assert.Equal(90, opts.HealthMaxStaleSeconds);
+        Assert.False(opts.HealthFailOnRecovery);
+        Assert.Equal(12, opts.ShutdownDrainSeconds);
+    }
+
+    [Fact]
+    public void GetBufferingOptions_carries_stale_buffer_ladder_and_window()
+    {
+        var s = new AppSettings();
+        var opts = s.GetBufferingOptions();
+        Assert.Equal(s.StaleBufferGlobalMib, opts.StaleBufferGlobalMib);
+        Assert.Equal(s.StaleBufferCapLevels, opts.StaleBufferCapLevels);
+        Assert.Equal(s.ServerFlushWindowMs, opts.ServerFlushWindowMs);
+        Assert.Equal(s.PerSymbolFanoutSuppressHighPct, opts.PerSymbolFanoutSuppressHighPct);
+    }
+
+    [Fact]
+    public void GetReplayOptions_exposes_loss_profile_and_pcap_inputs()
+    {
+        var s = new AppSettings
+        {
+            Speed = 2.5,
+            ReplayToMulticast = true,
+            LossTargets = "AB",
+            LossRate = 0.01,
+            LossMode = "burst",
+            LossBurstSize = 5,
+            LossCorrelated = true,
+            LossSeed = 42,
+        };
+        s.PcapPrefixes.Add("/data/foo");
+        var opts = s.GetReplayOptions();
+        Assert.Equal(2.5, opts.Speed);
+        Assert.True(opts.ReplayToMulticast);
+        Assert.Equal("AB", opts.LossTargets);
+        Assert.Equal("burst", opts.LossMode);
+        Assert.Equal(5, opts.LossBurstSize);
+        Assert.True(opts.LossCorrelated);
+        Assert.Equal(42, opts.LossSeed);
+        Assert.Single(opts.PcapPrefixes);
+        Assert.Equal("/data/foo", opts.PcapPrefixes[0]);
+    }
+}

--- a/tests/B3.Umdf.Server.Tests/ClientSessionOptionsTests.cs
+++ b/tests/B3.Umdf.Server.Tests/ClientSessionOptionsTests.cs
@@ -1,0 +1,33 @@
+using B3.Umdf.Server.Hosting;
+using Xunit;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Defaults snapshot for the <see cref="ClientSessionOptions"/> record that
+/// groups the per-WebSocket-connection tuning surface. The defaults must
+/// match the WebSocketHost ctor defaults so existing call sites can
+/// continue to omit the parameters and inherit the same behavior.
+/// </summary>
+public class ClientSessionOptionsTests
+{
+    [Fact]
+    public void Defaults_match_WebSocketHost_ctor_defaults()
+    {
+        var opts = new ClientSessionOptions();
+        Assert.Equal(4096, opts.ChannelCapacity);
+        Assert.Equal(0.75, opts.SlowClientThreshold);
+        Assert.Equal(100, opts.SlowClientMaxTicks);
+        Assert.Equal(16L * 1024 * 1024, opts.MaxPendingBytes);
+        Assert.Equal(0, opts.CoalesceWindowMs);
+    }
+
+    [Fact]
+    public void Record_with_expression_supports_partial_overrides()
+    {
+        var opts = new ClientSessionOptions() with { CoalesceWindowMs = 10, MaxPendingBytes = 32L * 1024 * 1024 };
+        Assert.Equal(10, opts.CoalesceWindowMs);
+        Assert.Equal(32L * 1024 * 1024, opts.MaxPendingBytes);
+        Assert.Equal(4096, opts.ChannelCapacity);
+    }
+}

--- a/tests/B3.Umdf.Server.Tests/HealthEvaluatorTests.cs
+++ b/tests/B3.Umdf.Server.Tests/HealthEvaluatorTests.cs
@@ -1,0 +1,88 @@
+using B3.Umdf.Server.Hosting;
+using Xunit;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Pure-logic unit tests for the staleness gate behind <c>GET /health</c>.
+/// The full HTTP-level contract is exercised by <see cref="HealthEndpointTests"/>;
+/// these tests cover the rule matrix without spinning up Kestrel so future
+/// edge cases (cold start, never-seen group, gate disabled) can be added
+/// cheaply.
+/// </summary>
+public class HealthEvaluatorTests
+{
+    [Fact]
+    public void Returns_null_when_failOnRecovery_disabled()
+    {
+        var states = new Dictionary<string, string> { ["g1"] = "WaitInstrumentDefinition" };
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states, lastPacketTicks: null,
+            nowTicks: 1_000_000, uptimeSeconds: 600,
+            maxStaleSeconds: 60, failOnRecovery: false);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Returns_null_when_no_states_provided()
+    {
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states: null, lastPacketTicks: null,
+            nowTicks: 1_000_000, uptimeSeconds: 600,
+            maxStaleSeconds: 60, failOnRecovery: true);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Streaming_groups_are_never_unhealthy()
+    {
+        var states = new Dictionary<string, string>
+        {
+            ["g1"] = "Streaming",
+            ["g2"] = "Streaming",
+        };
+        var lastPackets = new Dictionary<string, long> { ["g1"] = 0, ["g2"] = 0 };
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states, lastPackets,
+            nowTicks: 1_000_000, uptimeSeconds: 99_999,
+            maxStaleSeconds: 60, failOnRecovery: true);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Cold_start_uses_uptime_below_threshold_and_stays_healthy()
+    {
+        var states = new Dictionary<string, string> { ["g1"] = "WaitInstrumentDefinition" };
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states, lastPacketTicks: null,
+            nowTicks: 1_000_000, uptimeSeconds: 30,
+            maxStaleSeconds: 60, failOnRecovery: true);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Non_streaming_group_past_threshold_via_lastPacket_is_unhealthy()
+    {
+        var states = new Dictionary<string, string> { ["g1"] = "WaitInstrumentDefinition" };
+        // Last packet 90 seconds ago (90_000 ms in TickCount64 units).
+        var lastPackets = new Dictionary<string, long> { ["g1"] = 1_000_000 - 90_000 };
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states, lastPackets,
+            nowTicks: 1_000_000, uptimeSeconds: 9999,
+            maxStaleSeconds: 60, failOnRecovery: true);
+        Assert.NotNull(result);
+        Assert.Single(result!);
+        Assert.Contains("g1=WaitInstrumentDefinition", result![0]);
+    }
+
+    [Fact]
+    public void Negative_threshold_disables_gate()
+    {
+        var states = new Dictionary<string, string> { ["g1"] = "WaitInstrumentDefinition" };
+        var result = HealthEvaluator.FindUnhealthyGroups(
+            states, lastPacketTicks: null,
+            nowTicks: 1_000_000, uptimeSeconds: 99_999,
+            maxStaleSeconds: -1, failOnRecovery: true);
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
Implements P2 todo `p2-server-decompose`.

## Problem

- `src/B3.Umdf.Server/WebSocketHost.cs` (~550 lines) was a god class owning hosting setup, CORS, readiness, metrics endpoint, recovery audit, WS lifecycle, instrument DTO mapping and shutdown orchestration.
- `src/B3.Umdf.Server/AppSettings.cs` (~440 lines) was a single monolithic property bag.

## Changes

### 1. Decompose `WebSocketHost` (commit 2caecd4)

New `src/B3.Umdf.Server/Hosting/` folder:

| File | Responsibility |
|------|----------------|
| `HealthEvaluator.cs`            | **Pure** stale-recovery rule (no IO, no time source) — now unit-testable |
| `HealthEndpointMapper.cs`       | Maps `/health`, `/ready`, `/live` |
| `MetricsEndpointMapper.cs`      | OTel meter registration + `/metrics` scrape |
| `SymbolEndpointMapper.cs`       | `/symbols` |
| `InstrumentEndpointMapper.cs`   | `/instrument/{symbol}` + DTO mapping |
| `RecoveryEndpointMapper.cs`     | `/api/recovery/recent` |
| `WebSocketConnectionHandler.cs` | `/ws` lifecycle (shutdown gate, conn cap, hello negotiation, sub/unsub, drain) |
| `ShutdownCoordinator.cs`        | Graceful 1001 close-handshake fan-out |
| `CorsMiddleware.cs`             | Permissive CORS extension method |
| `ClientSessionOptions.cs`       | Grouped per-connection tuning record |

`WebSocketHost` keeps its public ctor + property surface (no consumer changes) and now only orchestrates: build the Kestrel app, hand each concern to its mapper, and expose the providers wired in by the ConsoleApp.

### 2. Split `AppSettings` (commit 811435f)

New `src/B3.Umdf.Server/Configuration/`:

- `AppSettingsOptions.cs` — four immutable record projections:
  - `ConnectionLimitsOptions` (max connections, channel capacity, slow-client + outlier sweep)
  - `RecoveryHealthOptions` (`/health` stale gate + shutdown drain budget)
  - `BufferingOptions` (feed/group rings, conflation window, stale-MBO ladder, fanout watermarks)
  - `ReplayOptions` (speed, multicast republish, PCAP inputs, loss-injection profile)
- `AppSettings.Projections.cs` — partial extension exposing `GetConnectionLimits() / GetRecoveryHealthOptions() / GetBufferingOptions() / GetReplayOptions()`.

**Scaled-down decision:** the flat property bag on `AppSettings` is intentionally preserved. The JSON source generator, the env-var override block (`ApplyEnvironment`), the existing 150 Server tests, and the ConsoleApp's wiring all consume the flat shape, and the on-disk `appsettings.json` contract must stay flat. Nesting the JSON would have been a breaking change well outside the P2 scope. The new records are pure read-side projections that downstream code can take dependencies on instead of the whole bag.

### 3. Tests (commit 9ecd4ff)

- `HealthEvaluatorTests` (6 cases): gate disabled, no states, all-Streaming, cold-start uptime fallback, past-threshold via lastPacket, negative-threshold disable.
- `AppSettingsProjectionsTests` (4 cases): each projection mirrors flat defaults + overrides.
- `ClientSessionOptionsTests` (2 cases): defaults match the WebSocketHost ctor defaults; `with` partial overrides.

## Verification

- Baseline: 150 Server tests passing.
- After: **162 passing, 0 failing** (+12 new), no existing test modified.
- Full `dotnet build`: 0 warnings, 0 errors.
- No new NuGet deps. No public API breakage in `WebSocketHost` or `AppSettings`. ConsoleApp / Program.cs unmodified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>