### PR TITLE
WebSocketClient: full server parity (MBO/MBP/News/Candles/Rankings)

### DIFF
--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -145,3 +145,290 @@ public readonly record struct ConnectionStateChangedEvent(
     ConnectionState State,
     Exception? Error,
     DateTime ChangedUtc);
+
+/// <summary>
+/// Order book side. Matches the server's internal <c>BookSideType</c> /
+/// SBE <c>MDEntryType</c> wire byte (0 = Bid, 1 = Ask).
+/// </summary>
+public enum BookSide : byte
+{
+    Bid = 0,
+    Ask = 1,
+}
+
+/// <summary>
+/// Side(s) cleared by a <see cref="BookClearedEvent"/>. Matches the server's
+/// <c>BookClearSide</c> wire byte (0 = Both, 1 = Bid, 2 = Ask).
+/// </summary>
+public enum BookClearSide : byte
+{
+    Both = 0,
+    Bid = 1,
+    Ask = 2,
+}
+
+// ── L3 / Order-by-order book (MBO) ──────────────────────────────────
+
+/// <summary>One MBO order inside a <see cref="BookSnapshotEvent"/>.
+/// Price is scaled with the SBE 4-decimal exponent already applied.</summary>
+public readonly record struct BookSnapshotOrder(
+    ulong OrderId,
+    decimal Price,
+    long Qty);
+
+/// <summary>
+/// L3 / order-by-order snapshot phase boundary. The server currently
+/// emits this as an empty marker frame (zero entries on both sides)
+/// followed by one <see cref="OrderAddedEvent"/> per live order on the
+/// book — so consumers SHOULD clear any prior state for
+/// <see cref="SecurityId"/> when this event fires and then rebuild from
+/// the OrderAdded stream that follows in the same WebSocket packet.
+/// <para>The wire format also allows aggregated price-level entries
+/// inside the snapshot body (price/totalQty/orderCount), which are
+/// surfaced via <see cref="Bids"/> / <see cref="Asks"/> with
+/// <see cref="BookSnapshotOrder.OrderId"/> set to 0 — present for
+/// forward-compatibility but empty in production traffic today.</para>
+/// </summary>
+public sealed class BookSnapshotEvent
+{
+    public ulong SecurityId { get; init; }
+    public string Symbol { get; init; } = "";
+    /// <summary>Per-symbol RptSeq at snapshot publish time; matches the value
+    /// the next incremental will carry on the wire.</summary>
+    public uint RptSeq { get; init; }
+    public IReadOnlyList<BookSnapshotOrder> Bids { get; init; } = Array.Empty<BookSnapshotOrder>();
+    public IReadOnlyList<BookSnapshotOrder> Asks { get; init; } = Array.Empty<BookSnapshotOrder>();
+    public DateTime ReceivedUtc { get; init; }
+}
+
+/// <summary>Per-order Add. Price already scaled. Fires for both
+/// <c>OrderAdded</c> (0x0030) opcodes.</summary>
+public readonly record struct OrderAddedEvent(
+    ulong SecurityId,
+    string Symbol,
+    ulong OrderId,
+    BookSide Side,
+    decimal Price,
+    long Qty,
+    DateTime ReceivedUtc);
+
+/// <summary>Per-order Update (qty / price change). Price already scaled.</summary>
+public readonly record struct OrderUpdatedEvent(
+    ulong SecurityId,
+    string Symbol,
+    ulong OrderId,
+    BookSide Side,
+    decimal Price,
+    long Qty,
+    DateTime ReceivedUtc);
+
+/// <summary>Per-order Delete. Consumers MUST drop the matching
+/// <see cref="OrderId"/> on <see cref="Side"/> from their book.</summary>
+public readonly record struct OrderDeletedEvent(
+    ulong SecurityId,
+    string Symbol,
+    ulong OrderId,
+    BookSide Side,
+    DateTime ReceivedUtc);
+
+/// <summary>Mass-delete of one or both sides of the book. Consumers MUST
+/// drop every order on the affected side(s) — a follow-up
+/// <see cref="BookSnapshotEvent"/> is NOT guaranteed.</summary>
+public readonly record struct BookClearedEvent(
+    ulong SecurityId,
+    string Symbol,
+    BookClearSide ClearSide,
+    DateTime ReceivedUtc);
+
+/// <summary>
+/// Aggregate null-price MOA/MOC market tier for one side. Carries the
+/// total quantity and order count; deliberately separate from
+/// <see cref="OrderAddedEvent"/> so no sentinel price is needed.
+/// </summary>
+public readonly record struct MarketTierUpdateEvent(
+    ulong SecurityId,
+    string Symbol,
+    BookSide Side,
+    long TotalQty,
+    int OrderCount,
+    DateTime ReceivedUtc);
+
+// ── MBP / Aggregated price levels ───────────────────────────────────
+
+/// <summary>One aggregated level inside a <see cref="LevelSnapshotEvent"/>.
+/// Price already scaled.</summary>
+public readonly record struct PriceLevel(
+    decimal Price,
+    long TotalQty,
+    int OrderCount);
+
+/// <summary>
+/// Full MBP price-level snapshot. Emitted on initial
+/// <see cref="SubscribeFlags.Mbp"/> subscribe. Consumers SHOULD replace
+/// any prior per-symbol level map when this fires.
+/// </summary>
+public sealed class LevelSnapshotEvent
+{
+    public ulong SecurityId { get; init; }
+    public string Symbol { get; init; } = "";
+    public IReadOnlyList<PriceLevel> Bids { get; init; } = Array.Empty<PriceLevel>();
+    public IReadOnlyList<PriceLevel> Asks { get; init; } = Array.Empty<PriceLevel>();
+    public DateTime ReceivedUtc { get; init; }
+}
+
+/// <summary>Incremental MBP level (re)write. Conflated server-side per
+/// <c>(secId, side, price)</c> — at most one per packet per level.</summary>
+public readonly record struct LevelUpdateEvent(
+    ulong SecurityId,
+    string Symbol,
+    BookSide Side,
+    decimal Price,
+    long TotalQty,
+    int OrderCount,
+    DateTime ReceivedUtc);
+
+/// <summary>Incremental MBP level removal. Consumers MUST drop the
+/// matching <c>(side, price)</c> from their per-symbol map.</summary>
+public readonly record struct LevelDeletedEvent(
+    ulong SecurityId,
+    string Symbol,
+    BookSide Side,
+    decimal Price,
+    DateTime ReceivedUtc);
+
+// ── Per-symbol stale + recovery aggregate ───────────────────────────
+
+/// <summary>Per-symbol stale-status transition. Coalesced server-side
+/// (last value within a packet wins). UI consumers SHOULD dim rows
+/// when <see cref="IsStale"/> is <c>true</c>.</summary>
+public readonly record struct SymbolStaleStatusEvent(
+    ulong SecurityId,
+    string Symbol,
+    bool IsStale,
+    DateTime ReceivedUtc);
+
+/// <summary>One per-kind stale breakdown row inside
+/// <see cref="RecoveryProgressEvent"/>. <see cref="Kind"/> is the raw
+/// <c>SymbolGapKind</c> byte from the server — kept as a byte so that
+/// new kinds added server-side are forward-compatible.</summary>
+public readonly record struct RecoveryProgressKind(byte Kind, uint StaleCount);
+
+/// <summary>
+/// Aggregate recovery progress (broadcast ~250 ms). Stops after the
+/// final "all healthy" frame (<see cref="TotalStaleSymbols"/> == 0) so
+/// the UI can clear its banner.
+/// </summary>
+public sealed class RecoveryProgressEvent
+{
+    public uint TotalSymbols { get; init; }
+    public uint TotalStaleSymbols { get; init; }
+    public IReadOnlyList<RecoveryProgressKind> StaleByKind { get; init; } = Array.Empty<RecoveryProgressKind>();
+    public DateTime ReceivedUtc { get; init; }
+}
+
+// ── Candles ─────────────────────────────────────────────────────────
+
+/// <summary>
+/// One OHLCV+VWAP candle. Prices already scaled with the SBE 4-decimal
+/// exponent; <see cref="TimeNanos"/> is exchange epoch nanoseconds.
+/// </summary>
+public readonly record struct Candle(
+    long TimeNanos,
+    decimal Open,
+    decimal High,
+    decimal Low,
+    decimal Close,
+    long Volume,
+    decimal Avg);
+
+/// <summary>
+/// Historical candle batch. The server may send multiple batches per
+/// snapshot (e.g. one per resolution); each frame is self-contained.
+/// </summary>
+public sealed class CandleSnapshotEvent
+{
+    public ulong SecurityId { get; init; }
+    public string Symbol { get; init; } = "";
+    /// <summary>Candle resolution as a raw server-side identifier
+    /// (e.g. seconds-per-bucket). Kept as <c>int</c> to stay
+    /// forward-compatible with new resolutions.</summary>
+    public int Resolution { get; init; }
+    /// <summary>True on the first batch of a snapshot — consumers SHOULD
+    /// replace their cached history for <c>(SecurityId, Resolution)</c>.</summary>
+    public bool IsFirst { get; init; }
+    /// <summary>True on the final batch of a snapshot.</summary>
+    public bool IsLast { get; init; }
+    public IReadOnlyList<Candle> Candles { get; init; } = Array.Empty<Candle>();
+    public DateTime ReceivedUtc { get; init; }
+}
+
+/// <summary>Single candle change (latest candle updated or a new bucket
+/// opened). Consumers SHOULD upsert by <see cref="Candle.TimeNanos"/>.</summary>
+public readonly record struct CandleUpdateEvent(
+    ulong SecurityId,
+    string Symbol,
+    int Resolution,
+    Candle Candle,
+    DateTime ReceivedUtc);
+
+// ── Rankings ────────────────────────────────────────────────────────
+
+/// <summary>One row inside a <see cref="RankingsUpdateEvent"/>. <see cref="Value"/>
+/// is the raw server-side metric (volume in shares, gainers/losers in
+/// basis-point percentage * 100, etc.) — kept as <c>long</c> so the
+/// SDK does not have to interpret category-specific scaling.</summary>
+public readonly record struct RankingEntry(
+    ulong SecurityId,
+    string Symbol,
+    long Value);
+
+/// <summary>
+/// Three top-N rankings tables (most-traded by volume, top gainers,
+/// top losers) emitted periodically by the server. Each list is at
+/// most 10 entries on the current wire.
+/// </summary>
+public sealed class RankingsUpdateEvent
+{
+    public IReadOnlyList<RankingEntry> Volume { get; init; } = Array.Empty<RankingEntry>();
+    public IReadOnlyList<RankingEntry> Gainers { get; init; } = Array.Empty<RankingEntry>();
+    public IReadOnlyList<RankingEntry> Losers { get; init; } = Array.Empty<RankingEntry>();
+    public DateTime ReceivedUtc { get; init; }
+}
+
+// ── News ────────────────────────────────────────────────────────────
+
+/// <summary>Optional source classification for a <see cref="NewsEvent"/>.
+/// Kept as a raw byte so that new sources added server-side are
+/// forward-compatible.</summary>
+public enum NewsSource : byte
+{
+    Unknown = 0,
+}
+
+/// <summary>
+/// A fully-reassembled news delivery. The SDK buffers
+/// <c>NewsBegin/Chunk/End</c> frames internally and raises a single
+/// <see cref="MarketDataClient.News"/> event with the joined payloads.
+/// </summary>
+public sealed class NewsEvent
+{
+    /// <summary>0 = global news (no instrument scope).</summary>
+    public ulong SecurityIdOrZero { get; init; }
+    /// <summary>Resolved symbol when <see cref="SecurityIdOrZero"/> matches
+    /// a previously-subscribed security; empty otherwise.</summary>
+    public string Symbol { get; init; } = "";
+    public ulong NewsId { get; init; }
+    public byte SourceRaw { get; init; }
+    /// <summary>Source classification when known; otherwise
+    /// <see cref="NewsSource.Unknown"/>. Use <see cref="SourceRaw"/>
+    /// for the wire byte.</summary>
+    public NewsSource Source => Enum.IsDefined(typeof(NewsSource), SourceRaw) ? (NewsSource)SourceRaw : NewsSource.Unknown;
+    /// <summary>Raw language code from the wire (ISO-style or vendor-specific).</summary>
+    public ushort LanguageRaw { get; init; }
+    /// <summary>Original publish time in nanoseconds from epoch (exchange time).</summary>
+    public long OrigTimeNanos { get; init; }
+    public string Headline { get; init; } = "";
+    public string Text { get; init; } = "";
+    public string Url { get; init; } = "";
+    public DateTime ReceivedUtc { get; init; }
+}

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -75,6 +75,45 @@ public sealed class MarketDataClient : IAsyncDisposable
     public event Action<SubscribeErrorEvent>? SubscribeError;
     public event Action<ConnectionStateChangedEvent>? ConnectionStateChanged;
 
+    // ── L3 / Order-by-order (MBO) ────────────────────────────────────
+
+    /// <summary>L3 snapshot-phase marker. Consumers SHOULD clear prior book
+    /// state and rebuild from the <see cref="OrderAdded"/> stream that
+    /// follows in the same packet.</summary>
+    public event Action<BookSnapshotEvent>? BookSnapshot;
+    public event Action<OrderAddedEvent>? OrderAdded;
+    public event Action<OrderUpdatedEvent>? OrderUpdated;
+    public event Action<OrderDeletedEvent>? OrderDeleted;
+    public event Action<BookClearedEvent>? BookCleared;
+    public event Action<MarketTierUpdateEvent>? MarketTierUpdate;
+
+    // ── MBP / aggregated levels ──────────────────────────────────────
+
+    public event Action<LevelSnapshotEvent>? LevelSnapshot;
+    public event Action<LevelUpdateEvent>? LevelUpdate;
+    public event Action<LevelDeletedEvent>? LevelDeleted;
+
+    // ── Stale / recovery ─────────────────────────────────────────────
+
+    public event Action<SymbolStaleStatusEvent>? SymbolStaleStatus;
+    public event Action<RecoveryProgressEvent>? RecoveryProgress;
+
+    // ── Candles ──────────────────────────────────────────────────────
+
+    public event Action<CandleSnapshotEvent>? CandleSnapshot;
+    public event Action<CandleUpdateEvent>? CandleUpdate;
+
+    // ── Rankings ─────────────────────────────────────────────────────
+
+    public event Action<RankingsUpdateEvent>? RankingsUpdate;
+
+    // ── News ─────────────────────────────────────────────────────────
+
+    /// <summary>Raised once per fully-reassembled news delivery. The SDK
+    /// buffers <c>NewsBegin/Chunk/End</c> frames internally and surfaces a
+    /// single typed event with the joined Headline/Text/URL payloads.</summary>
+    public event Action<NewsEvent>? News;
+
     /// <summary>
     /// Raised on the dispatch thread whenever a frame with an unrecognised
     /// <c>MessageType</c> opcode is received. The event payload is the raw opcode.
@@ -92,6 +131,16 @@ public sealed class MarketDataClient : IAsyncDisposable
     public long UnknownMessageCount => Interlocked.Read(ref _unknownMessageCount);
 
     private long _unknownMessageCount;
+
+    /// <summary>
+    /// Per-newsId reassembly buffers for fragmented <c>NewsBegin/Chunk/End</c>
+    /// frames. Single-reader (the receive loop) so plain Dictionary is fine.
+    /// Entries are removed on NewsEnd; abandoned reassemblies (server reboot,
+    /// missing End) leak until the next process restart — acceptable given the
+    /// low rate of News and the small per-entry footprint (≤ a few KB total
+    /// length declared in NewsBegin).
+    /// </summary>
+    private readonly Dictionary<ulong, NewsReassembly> _newsReassembly = new();
 
     /// <summary>
     /// Protocol version negotiated with the server, taken from the most recent
@@ -421,10 +470,164 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => InfoSnapshot?.Invoke(ev));
                 break;
             }
+            // ── L3 / order-by-order (MBO) ─────────────────────────
+            case WireFormat.MessageType.BookSnapshot:
+            {
+                ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = WireFormat.ReadBookSnapshot(payload, symbol, receivedUtc);
+                Enqueue(() => BookSnapshot?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.OrderAdded:
+            {
+                var (secId, orderId, sideByte, price, qty) = WireFormat.ReadOrderEvent(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new OrderAddedEvent(secId, symbol, orderId, (BookSide)sideByte,
+                    price / WireFormat.PriceScale, qty, receivedUtc);
+                Enqueue(() => OrderAdded?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.OrderUpdated:
+            {
+                var (secId, orderId, sideByte, price, qty) = WireFormat.ReadOrderEvent(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new OrderUpdatedEvent(secId, symbol, orderId, (BookSide)sideByte,
+                    price / WireFormat.PriceScale, qty, receivedUtc);
+                Enqueue(() => OrderUpdated?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.OrderDeleted:
+            {
+                var (secId, orderId, sideByte) = WireFormat.ReadOrderDeleted(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new OrderDeletedEvent(secId, symbol, orderId, (BookSide)sideByte, receivedUtc);
+                Enqueue(() => OrderDeleted?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.BookCleared:
+            {
+                var (secId, clearByte) = WireFormat.ReadBookCleared(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                // Unknown clear-side bytes fall back to Both (safest: clears full book).
+                var clearSide = Enum.IsDefined(typeof(BookClearSide), clearByte)
+                    ? (BookClearSide)clearByte : BookClearSide.Both;
+                var ev = new BookClearedEvent(secId, symbol, clearSide, receivedUtc);
+                Enqueue(() => BookCleared?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.MarketTierUpdate:
+            {
+                var (secId, sideByte, totalQty, orderCount) = WireFormat.ReadMarketTierUpdate(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new MarketTierUpdateEvent(secId, symbol, (BookSide)sideByte,
+                    totalQty, orderCount, receivedUtc);
+                Enqueue(() => MarketTierUpdate?.Invoke(ev));
+                break;
+            }
+            // ── MBP / aggregated levels ───────────────────────────
+            case WireFormat.MessageType.LevelSnapshot:
+            {
+                ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = WireFormat.ReadLevelSnapshot(payload, symbol, receivedUtc);
+                Enqueue(() => LevelSnapshot?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.LevelUpdate:
+            {
+                var (secId, sideByte, price, totalQty, orderCount) = WireFormat.ReadLevelUpdate(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new LevelUpdateEvent(secId, symbol, (BookSide)sideByte,
+                    price / WireFormat.PriceScale, totalQty, orderCount, receivedUtc);
+                Enqueue(() => LevelUpdate?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.LevelDeleted:
+            {
+                var (secId, sideByte, price) = WireFormat.ReadLevelDeleted(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new LevelDeletedEvent(secId, symbol, (BookSide)sideByte,
+                    price / WireFormat.PriceScale, receivedUtc);
+                Enqueue(() => LevelDeleted?.Invoke(ev));
+                break;
+            }
+            // ── Stale / recovery ──────────────────────────────────
+            case WireFormat.MessageType.SymbolStaleStatus:
+            {
+                var (secId, isStale) = WireFormat.ReadSymbolStaleStatus(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                Enqueue(() => SymbolStaleStatus?.Invoke(new SymbolStaleStatusEvent(secId, symbol, isStale, receivedUtc)));
+                break;
+            }
+            case WireFormat.MessageType.RecoveryProgress:
+            {
+                var ev = WireFormat.ReadRecoveryProgress(payload, receivedUtc);
+                Enqueue(() => RecoveryProgress?.Invoke(ev));
+                break;
+            }
+            // ── Candles ───────────────────────────────────────────
+            case WireFormat.MessageType.CandleSnapshot:
+            {
+                ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = WireFormat.ReadCandleSnapshot(payload, symbol, receivedUtc);
+                Enqueue(() => CandleSnapshot?.Invoke(ev));
+                break;
+            }
+            case WireFormat.MessageType.CandleUpdate:
+            {
+                var (secId, resolution, candle) = WireFormat.ReadCandleUpdate(payload);
+                string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
+                var ev = new CandleUpdateEvent(secId, symbol, resolution, candle, receivedUtc);
+                Enqueue(() => CandleUpdate?.Invoke(ev));
+                break;
+            }
+            // ── Rankings ──────────────────────────────────────────
+            case WireFormat.MessageType.RankingsUpdate:
+            {
+                var ev = WireFormat.ReadRankingsUpdate(payload, receivedUtc);
+                Enqueue(() => RankingsUpdate?.Invoke(ev));
+                break;
+            }
+            // ── News (fragmented; reassembled before raising) ─────
+            case WireFormat.MessageType.NewsBegin:
+            {
+                var hdr = WireFormat.ReadNewsBegin(payload);
+                if (hdr.Version != WireFormat.NewsFrameVersion)
+                {
+                    _logger.LogWarning("Unsupported NewsBegin frame version {Version}; dropping.", hdr.Version);
+                    break;
+                }
+                _newsReassembly[hdr.NewsId] = new NewsReassembly(hdr.SecurityIdOrZero, hdr.NewsId,
+                    hdr.Source, hdr.Language, hdr.OrigTimeNanos,
+                    (int)Math.Min(hdr.TotalHeadlineLen, int.MaxValue),
+                    (int)Math.Min(hdr.TotalTextLen, int.MaxValue),
+                    (int)Math.Min(hdr.TotalUrlLen, int.MaxValue));
+                break;
+            }
+            case WireFormat.MessageType.NewsChunk:
+            {
+                var (version, newsId, field) = WireFormat.ReadNewsChunk(payload, out var fragment);
+                if (version != WireFormat.NewsFrameVersion) break;
+                if (_newsReassembly.TryGetValue(newsId, out var ra))
+                    ra.Append(field, fragment);
+                break;
+            }
+            case WireFormat.MessageType.NewsEnd:
+            {
+                var (version, newsId, field) = WireFormat.ReadNewsChunk(payload, out var fragment);
+                if (version != WireFormat.NewsFrameVersion) break;
+                if (!_newsReassembly.Remove(newsId, out var ra))
+                    break; // Begin missed — drop.
+                ra.Append(field, fragment);
+                string symbol = _securityIdToSymbol.TryGetValue(ra.SecurityIdOrZero, out var s) ? s : "";
+                var ev = ra.ToEvent(symbol, receivedUtc);
+                Enqueue(() => News?.Invoke(ev));
+                break;
+            }
             // Unsubscribed (0x0012) is currently silent — the application
-            // already knows it called UnsubscribeAsync. Other message
-            // types (Book, Mbp, News, …) are out of scope for v1 and
-            // simply ignored.
+            // already knows it called UnsubscribeAsync.
             case WireFormat.MessageType.Unsubscribed:
                 break;
             default:
@@ -572,5 +775,79 @@ public sealed class MarketDataClient : IAsyncDisposable
             Symbol = symbol;
             Flags = flags;
         }
+    }
+
+    /// <summary>
+    /// Per-newsId reassembly state. Allocates byte arrays sized from the
+    /// totals declared in <c>NewsBegin</c> (clamped to <see cref="int.MaxValue"/>
+    /// for safety) and copies fragment bytes in order. The server emits
+    /// fragments for any given field contiguously, so the trailing fragment
+    /// is always the one carried in <c>NewsEnd</c>.
+    /// </summary>
+    private sealed class NewsReassembly
+    {
+        public ulong SecurityIdOrZero { get; }
+        public ulong NewsId { get; }
+        public byte Source { get; }
+        public ushort Language { get; }
+        public long OrigTimeNanos { get; }
+
+        private readonly byte[] _headline;
+        private readonly byte[] _text;
+        private readonly byte[] _url;
+        private int _headlineLen;
+        private int _textLen;
+        private int _urlLen;
+
+        public NewsReassembly(ulong securityIdOrZero, ulong newsId, byte source, ushort language,
+            long origTimeNanos, int headlineLen, int textLen, int urlLen)
+        {
+            SecurityIdOrZero = securityIdOrZero;
+            NewsId = newsId;
+            Source = source;
+            Language = language;
+            OrigTimeNanos = origTimeNanos;
+            _headline = headlineLen > 0 ? new byte[headlineLen] : Array.Empty<byte>();
+            _text = textLen > 0 ? new byte[textLen] : Array.Empty<byte>();
+            _url = urlLen > 0 ? new byte[urlLen] : Array.Empty<byte>();
+        }
+
+        public void Append(WireFormat.NewsField field, ReadOnlySpan<byte> fragment)
+        {
+            switch (field)
+            {
+                case WireFormat.NewsField.Headline:
+                    AppendTo(_headline, ref _headlineLen, fragment);
+                    break;
+                case WireFormat.NewsField.Text:
+                    AppendTo(_text, ref _textLen, fragment);
+                    break;
+                case WireFormat.NewsField.Url:
+                    AppendTo(_url, ref _urlLen, fragment);
+                    break;
+            }
+        }
+
+        private static void AppendTo(byte[] buffer, ref int filled, ReadOnlySpan<byte> fragment)
+        {
+            int copy = Math.Min(fragment.Length, buffer.Length - filled);
+            if (copy <= 0) return;
+            fragment[..copy].CopyTo(buffer.AsSpan(filled));
+            filled += copy;
+        }
+
+        public NewsEvent ToEvent(string symbol, DateTime receivedUtc) => new()
+        {
+            SecurityIdOrZero = SecurityIdOrZero,
+            Symbol = symbol,
+            NewsId = NewsId,
+            SourceRaw = Source,
+            LanguageRaw = Language,
+            OrigTimeNanos = OrigTimeNanos,
+            Headline = _headlineLen > 0 ? System.Text.Encoding.UTF8.GetString(_headline, 0, _headlineLen) : "",
+            Text = _textLen > 0 ? System.Text.Encoding.UTF8.GetString(_text, 0, _textLen) : "",
+            Url = _urlLen > 0 ? System.Text.Encoding.UTF8.GetString(_url, 0, _urlLen) : "",
+            ReceivedUtc = receivedUtc,
+        };
     }
 }

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -25,9 +25,10 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 });
 
 client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
+client.LevelUpdate += l => Console.WriteLine($"{l.Symbol} {l.Side} {l.Price} qty={l.TotalQty}");
 
 await client.ConnectAsync();
-await client.SubscribeAsync("PETR4");
+await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Mbp);
 ```
 
 Includes:
@@ -37,8 +38,11 @@ Includes:
 - Bounded back-pressure (`Channel<T>` with a configurable policy:
   `DropOldest` / `Block` / `Throw`).
 - DI extension: `services.AddMarketDataClient(...)`.
-
-Out of scope for v1: full L2/MBO subscription, recovery REST endpoints.
+- Full server parity: trades, info snapshots, server status, L3 / MBO
+  (`BookSnapshot`, `OrderAdded/Updated/Deleted`, `BookCleared`,
+  `MarketTierUpdate`), MBP (`LevelSnapshot`, `LevelUpdate`,
+  `LevelDeleted`), candles (snapshot + update), rankings, per-symbol
+  stale status, recovery progress, and reassembled news.
 
 See [`docs/CLIENT-SDK.md`](https://github.com/pedrosakuma/B3MarketDataPlatform/blob/main/docs/CLIENT-SDK.md)
 for the full guide.

--- a/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
+++ b/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
@@ -1,13 +1,23 @@
 namespace B3.MarketData.WebSocketClient;
 
 /// <summary>
-/// Bitmask matching the server's <c>DataFlags</c> enum, scoped to the
-/// channels exposed by v1 of the SDK. Combine with <c>|</c>:
-/// <c>Trades | Info</c>.
+/// Bitmask matching the server's <c>DataFlags</c> enum. Combine with <c>|</c>
+/// (e.g. <c>Trades | Info | Mbp</c>). Bit positions are part of the wire
+/// contract — never reorder or repurpose.
 /// </summary>
 [Flags]
 public enum SubscribeFlags : byte
 {
+    /// <summary>
+    /// L3 / order-by-order book: <see cref="MarketDataClient.BookSnapshot"/> on
+    /// subscribe + incremental <see cref="MarketDataClient.OrderAdded"/> /
+    /// <see cref="MarketDataClient.OrderUpdated"/> /
+    /// <see cref="MarketDataClient.OrderDeleted"/> /
+    /// <see cref="MarketDataClient.BookCleared"/> /
+    /// <see cref="MarketDataClient.MarketTierUpdate"/>.
+    /// </summary>
+    Book = 0x01,
+
     /// <summary>
     /// <c>InfoSnapshot</c> + incremental info updates (carries
     /// <c>LastTradePrice</c>, <c>LastTradeSize</c>, status, etc.).
@@ -15,8 +25,33 @@ public enum SubscribeFlags : byte
     Info = 0x02,
 
     /// <summary>
+    /// News deliveries (<see cref="MarketDataClient.News"/>). Opt-in: clients
+    /// without this bit receive no news. Both instrument-scoped and global
+    /// news flow through this flag.
+    /// </summary>
+    News = 0x04,
+
+    /// <summary>
+    /// Aggregated price-level (MBP) stream:
+    /// <see cref="MarketDataClient.LevelSnapshot"/> on subscribe +
+    /// incremental <see cref="MarketDataClient.LevelUpdate"/> /
+    /// <see cref="MarketDataClient.LevelDeleted"/>. Independent of
+    /// <see cref="Book"/>: a client may request only MBP, only MBO, or both.
+    /// Recommended default for UI consumers (conflated per
+    /// <c>(secId, side, price)</c>, so much less bandwidth on hot levels).
+    /// </summary>
+    Mbp = 0x08,
+
+    /// <summary>
     /// Live trade prints and corrections (<c>TradeBust</c>), plus the
     /// per-symbol recent-trades history snapshot on subscribe.
     /// </summary>
     Trades = 0x10,
+
+    /// <summary>Legacy convenience: <see cref="Book"/> + <see cref="Info"/>.
+    /// Mirrors the server's <c>DataFlags.All</c> — does NOT include News, MBP, or Trades.</summary>
+    All = Book | Info,
+
+    /// <summary>Convenience alias for every data class: Book + Info + News + MBP + Trades.</summary>
+    Everything = Book | Info | News | Mbp | Trades,
 }

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -24,11 +24,28 @@ internal static class WireFormat
         SubscribeOk = 0x0010,
         SubscribeError = 0x0011,
         Unsubscribed = 0x0012,
+        BookSnapshot = 0x0020,
         InfoSnapshot = 0x0021,
+        LevelSnapshot = 0x0022,
+        OrderAdded = 0x0030,
+        OrderUpdated = 0x0031,
+        OrderDeleted = 0x0032,
         Trade = 0x0033,
+        BookCleared = 0x0034,
         TradeBust = 0x0035,
+        MarketTierUpdate = 0x0036,
+        LevelUpdate = 0x0037,
+        LevelDeleted = 0x0038,
+        RankingsUpdate = 0x0040,
         ServerStatus = 0x0050,
+        CandleSnapshot = 0x0060,
+        CandleUpdate = 0x0061,
+        SymbolStaleStatus = 0x0070,
         SymbolDelisted = 0x0071,
+        RecoveryProgress = 0x0080,
+        NewsBegin = 0x0090,
+        NewsChunk = 0x0091,
+        NewsEnd = 0x0092,
         ServerHello = 0x00A0,
         ClientHello = 0x00A1,
     }
@@ -240,5 +257,339 @@ internal static class WireFormat
             TradingStatus = status,
             TradingEvent = evt,
         };
+    }
+
+    // ── MBO / order events ──────────────────────────────────────────
+
+    /// <summary>Read OrderAdded/OrderUpdated payload (33 bytes after framing).</summary>
+    public static (ulong SecurityId, ulong OrderId, byte Side, long Price, long Qty) ReadOrderEvent(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        ulong orderId = BinaryPrimitives.ReadUInt64LittleEndian(payload[8..]);
+        byte side = payload[16];
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[17..]);
+        long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[25..]);
+        return (secId, orderId, side, price, qty);
+    }
+
+    /// <summary>Read OrderDeleted payload (17 bytes after framing).</summary>
+    public static (ulong SecurityId, ulong OrderId, byte Side) ReadOrderDeleted(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        ulong orderId = BinaryPrimitives.ReadUInt64LittleEndian(payload[8..]);
+        byte side = payload[16];
+        return (secId, orderId, side);
+    }
+
+    /// <summary>Read BookCleared payload (9 bytes after framing).</summary>
+    public static (ulong SecurityId, byte ClearSide) ReadBookCleared(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        byte clearSide = payload[8];
+        return (secId, clearSide);
+    }
+
+    /// <summary>Read MarketTierUpdate payload (21 bytes after framing).</summary>
+    public static (ulong SecurityId, byte Side, long TotalQty, int OrderCount) ReadMarketTierUpdate(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        byte side = payload[8];
+        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
+        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[17..]);
+        return (secId, side, totalQty, orderCount);
+    }
+
+    /// <summary>
+    /// Decode BookSnapshot into a populated event. Layout (after framing):
+    /// <c>[u64 secId][u32 rptSeq][u16 bidCount][u16 askCount][orders…]</c>.
+    /// Each order = <c>[u64 orderId][u64 price][u16 qty]</c> wait — server
+    /// writes <c>[i64 price][i64 totalQty][u16 orderCount]</c> for aggregated
+    /// snapshot per the server's <c>WritePriceLevel</c>; we re-export it as
+    /// per-order surface here for MBO consumers.
+    /// </summary>
+    /// <remarks>BookSnapshot on the wire today aggregates by price level
+    /// (price, totalQty, orderCount) — same shape as <see cref="MessageType.LevelSnapshot"/>.
+    /// We expose it via <see cref="BookSnapshotEvent"/> with one entry per
+    /// price level (OrderId is set to 0 since the server does not include
+    /// individual order ids in BookSnapshot).</remarks>
+    public static BookSnapshotEvent ReadBookSnapshot(ReadOnlySpan<byte> payload, string symbol, DateTime receivedUtc)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        uint rptSeq = BinaryPrimitives.ReadUInt32LittleEndian(payload[8..]);
+        ushort bidCount = BinaryPrimitives.ReadUInt16LittleEndian(payload[12..]);
+        ushort askCount = BinaryPrimitives.ReadUInt16LittleEndian(payload[14..]);
+        int offset = 16;
+
+        var bids = bidCount == 0 ? Array.Empty<BookSnapshotOrder>() : new BookSnapshotOrder[bidCount];
+        for (int i = 0; i < bidCount; i++)
+        {
+            long price = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+            long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[(offset + 8)..]);
+            // orderCount (u16) lives in payload[offset+16..offset+18]; aggregated
+            // snapshot — surface as a synthetic per-level entry (OrderId = 0).
+            offset += 18;
+            bids[i] = new BookSnapshotOrder(0UL, price / PriceScale, qty);
+        }
+
+        var asks = askCount == 0 ? Array.Empty<BookSnapshotOrder>() : new BookSnapshotOrder[askCount];
+        for (int i = 0; i < askCount; i++)
+        {
+            long price = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+            long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[(offset + 8)..]);
+            offset += 18;
+            asks[i] = new BookSnapshotOrder(0UL, price / PriceScale, qty);
+        }
+
+        return new BookSnapshotEvent
+        {
+            SecurityId = secId,
+            Symbol = symbol,
+            RptSeq = rptSeq,
+            Bids = bids,
+            Asks = asks,
+            ReceivedUtc = receivedUtc,
+        };
+    }
+
+    // ── MBP / level events ──────────────────────────────────────────
+
+    /// <summary>Read LevelUpdate payload (29 bytes after framing).</summary>
+    public static (ulong SecurityId, byte Side, long Price, long TotalQty, int OrderCount) ReadLevelUpdate(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        byte side = payload[8];
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
+        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[17..]);
+        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[25..]);
+        return (secId, side, price, totalQty, orderCount);
+    }
+
+    /// <summary>Read LevelDeleted payload (17 bytes after framing).</summary>
+    public static (ulong SecurityId, byte Side, long Price) ReadLevelDeleted(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        byte side = payload[8];
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
+        return (secId, side, price);
+    }
+
+    /// <summary>
+    /// Decode LevelSnapshot. Layout: <c>[u64 secId][u16 bidCount][u16 askCount]</c>
+    /// + N + M entries × <c>[i64 price][i64 totalQty][u32 orderCount]</c> (20 B each).
+    /// </summary>
+    public static LevelSnapshotEvent ReadLevelSnapshot(ReadOnlySpan<byte> payload, string symbol, DateTime receivedUtc)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        ushort bidCount = BinaryPrimitives.ReadUInt16LittleEndian(payload[8..]);
+        ushort askCount = BinaryPrimitives.ReadUInt16LittleEndian(payload[10..]);
+        int offset = 12;
+
+        var bids = bidCount == 0 ? Array.Empty<PriceLevel>() : new PriceLevel[bidCount];
+        for (int i = 0; i < bidCount; i++)
+        {
+            long price = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+            long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[(offset + 8)..]);
+            uint orderCount = BinaryPrimitives.ReadUInt32LittleEndian(payload[(offset + 16)..]);
+            offset += 20;
+            bids[i] = new PriceLevel(price / PriceScale, totalQty, (int)orderCount);
+        }
+
+        var asks = askCount == 0 ? Array.Empty<PriceLevel>() : new PriceLevel[askCount];
+        for (int i = 0; i < askCount; i++)
+        {
+            long price = BinaryPrimitives.ReadInt64LittleEndian(payload[offset..]);
+            long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[(offset + 8)..]);
+            uint orderCount = BinaryPrimitives.ReadUInt32LittleEndian(payload[(offset + 16)..]);
+            offset += 20;
+            asks[i] = new PriceLevel(price / PriceScale, totalQty, (int)orderCount);
+        }
+
+        return new LevelSnapshotEvent
+        {
+            SecurityId = secId,
+            Symbol = symbol,
+            Bids = bids,
+            Asks = asks,
+            ReceivedUtc = receivedUtc,
+        };
+    }
+
+    // ── Stale + recovery ────────────────────────────────────────────
+
+    /// <summary>Read SymbolStaleStatus payload (9 bytes after framing).</summary>
+    public static (ulong SecurityId, bool IsStale) ReadSymbolStaleStatus(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        bool isStale = payload[8] != 0;
+        return (secId, isStale);
+    }
+
+    /// <summary>Read RecoveryProgress. Layout: <c>[u32 totalSymbols][u32 totalStale][u8 kindCount]
+    /// + kindCount × ([u8 kindId][u32 count])</c>.</summary>
+    public static RecoveryProgressEvent ReadRecoveryProgress(ReadOnlySpan<byte> payload, DateTime receivedUtc)
+    {
+        uint total = BinaryPrimitives.ReadUInt32LittleEndian(payload);
+        uint totalStale = BinaryPrimitives.ReadUInt32LittleEndian(payload[4..]);
+        byte kindCount = payload[8];
+        int offset = 9;
+        var kinds = kindCount == 0 ? Array.Empty<RecoveryProgressKind>() : new RecoveryProgressKind[kindCount];
+        for (int i = 0; i < kindCount; i++)
+        {
+            byte kind = payload[offset++];
+            uint count = BinaryPrimitives.ReadUInt32LittleEndian(payload[offset..]);
+            offset += 4;
+            kinds[i] = new RecoveryProgressKind(kind, count);
+        }
+        return new RecoveryProgressEvent
+        {
+            TotalSymbols = total,
+            TotalStaleSymbols = totalStale,
+            StaleByKind = kinds,
+            ReceivedUtc = receivedUtc,
+        };
+    }
+
+    // ── Candles ─────────────────────────────────────────────────────
+
+    private const int CandleWireSize = 56;
+
+    /// <summary>Read CandleSnapshot. Layout (after framing):
+    /// <c>[u64 secId][u16 resolution][u8 flags][u16 count][candle × N]</c>.
+    /// flags bit 0 = first, bit 1 = last.</summary>
+    public static CandleSnapshotEvent ReadCandleSnapshot(ReadOnlySpan<byte> payload, string symbol, DateTime receivedUtc)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        ushort resolution = BinaryPrimitives.ReadUInt16LittleEndian(payload[8..]);
+        byte flags = payload[10];
+        ushort count = BinaryPrimitives.ReadUInt16LittleEndian(payload[11..]);
+        int offset = 13;
+        var candles = count == 0 ? Array.Empty<Candle>() : new Candle[count];
+        for (int i = 0; i < count; i++)
+        {
+            candles[i] = ReadCandle(payload[offset..]);
+            offset += CandleWireSize;
+        }
+        return new CandleSnapshotEvent
+        {
+            SecurityId = secId,
+            Symbol = symbol,
+            Resolution = resolution,
+            IsFirst = (flags & 0x01) != 0,
+            IsLast = (flags & 0x02) != 0,
+            Candles = candles,
+            ReceivedUtc = receivedUtc,
+        };
+    }
+
+    /// <summary>Read CandleUpdate payload: <c>[u64 secId][u16 resolution][candle]</c>.</summary>
+    public static (ulong SecurityId, int Resolution, Candle Candle) ReadCandleUpdate(ReadOnlySpan<byte> payload)
+    {
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        ushort resolution = BinaryPrimitives.ReadUInt16LittleEndian(payload[8..]);
+        var candle = ReadCandle(payload[10..]);
+        return (secId, resolution, candle);
+    }
+
+    private static Candle ReadCandle(ReadOnlySpan<byte> src)
+    {
+        long time = BinaryPrimitives.ReadInt64LittleEndian(src);
+        long open = BinaryPrimitives.ReadInt64LittleEndian(src[8..]);
+        long high = BinaryPrimitives.ReadInt64LittleEndian(src[16..]);
+        long low = BinaryPrimitives.ReadInt64LittleEndian(src[24..]);
+        long close = BinaryPrimitives.ReadInt64LittleEndian(src[32..]);
+        long volume = BinaryPrimitives.ReadInt64LittleEndian(src[40..]);
+        long avg = BinaryPrimitives.ReadInt64LittleEndian(src[48..]);
+        return new Candle(
+            time,
+            open / PriceScale,
+            high / PriceScale,
+            low / PriceScale,
+            close / PriceScale,
+            volume,
+            avg / PriceScale);
+    }
+
+    // ── Rankings ────────────────────────────────────────────────────
+
+    /// <summary>Read RankingsUpdate. Three back-to-back categories
+    /// (Volume, Gainers, Losers); each is <c>[u8 count] + count × entry</c>
+    /// where entry = <c>[u64 secId][i64 value][u8 symLen][symbol UTF-8…]</c>.</summary>
+    public static RankingsUpdateEvent ReadRankingsUpdate(ReadOnlySpan<byte> payload, DateTime receivedUtc)
+    {
+        int offset = 0;
+        var volume = ReadRankingCategory(payload, ref offset);
+        var gainers = ReadRankingCategory(payload, ref offset);
+        var losers = ReadRankingCategory(payload, ref offset);
+        return new RankingsUpdateEvent
+        {
+            Volume = volume,
+            Gainers = gainers,
+            Losers = losers,
+            ReceivedUtc = receivedUtc,
+        };
+    }
+
+    private static IReadOnlyList<RankingEntry> ReadRankingCategory(ReadOnlySpan<byte> payload, ref int offset)
+    {
+        byte count = payload[offset++];
+        if (count == 0) return Array.Empty<RankingEntry>();
+        var list = new RankingEntry[count];
+        for (int i = 0; i < count; i++)
+        {
+            ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload[offset..]);
+            long value = BinaryPrimitives.ReadInt64LittleEndian(payload[(offset + 8)..]);
+            byte symLen = payload[offset + 16];
+            string sym = Encoding.UTF8.GetString(payload.Slice(offset + 17, symLen));
+            offset += 17 + symLen;
+            list[i] = new RankingEntry(secId, sym, value);
+        }
+        return list;
+    }
+
+    // ── News ────────────────────────────────────────────────────────
+
+    public const byte NewsFrameVersion = 1;
+
+    public enum NewsField : byte
+    {
+        Headline = 0,
+        Text = 1,
+        Url = 2,
+    }
+
+    /// <summary>Parse a NewsBegin payload (after framing). Layout:
+    /// <c>[u8 version][u64 secIdOrZero][u64 newsId][u8 source][u16 language]
+    /// [i64 origTimeNanos][u32 totalHeadlineLen][u32 totalTextLen][u32 totalUrlLen]</c>.</summary>
+    public static (byte Version, ulong SecurityIdOrZero, ulong NewsId, byte Source, ushort Language,
+        long OrigTimeNanos, uint TotalHeadlineLen, uint TotalTextLen, uint TotalUrlLen)
+        ReadNewsBegin(ReadOnlySpan<byte> payload)
+    {
+        int o = 0;
+        byte version = payload[o++];
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload[o..]); o += 8;
+        ulong newsId = BinaryPrimitives.ReadUInt64LittleEndian(payload[o..]); o += 8;
+        byte source = payload[o++];
+        ushort language = BinaryPrimitives.ReadUInt16LittleEndian(payload[o..]); o += 2;
+        long origTime = BinaryPrimitives.ReadInt64LittleEndian(payload[o..]); o += 8;
+        uint hLen = BinaryPrimitives.ReadUInt32LittleEndian(payload[o..]); o += 4;
+        uint tLen = BinaryPrimitives.ReadUInt32LittleEndian(payload[o..]); o += 4;
+        uint uLen = BinaryPrimitives.ReadUInt32LittleEndian(payload[o..]);
+        return (version, secId, newsId, source, language, origTime, hLen, tLen, uLen);
+    }
+
+    /// <summary>Parse a NewsChunk / NewsEnd payload (after framing). Layout:
+    /// <c>[u8 version][u64 newsId][u8 field][u16 fragmentLen][bytes…]</c>.
+    /// Returned <paramref name="fragment"/> aliases the input buffer — caller
+    /// MUST copy if it needs to outlive the receive scratch.</summary>
+    public static (byte Version, ulong NewsId, NewsField Field) ReadNewsChunk(
+        ReadOnlySpan<byte> payload, out ReadOnlySpan<byte> fragment)
+    {
+        int o = 0;
+        byte version = payload[o++];
+        ulong newsId = BinaryPrimitives.ReadUInt64LittleEndian(payload[o..]); o += 8;
+        byte field = payload[o++];
+        ushort fragLen = BinaryPrimitives.ReadUInt16LittleEndian(payload[o..]); o += 2;
+        fragment = payload.Slice(o, fragLen);
+        return (version, newsId, (NewsField)field);
     }
 }

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -226,6 +226,41 @@ public class MarketDataClientIntegrationTests
         Assert.True(client.UnknownMessageCount >= 1);
     }
 
+    [Fact]
+    public async Task News_BeginChunkEnd_AreReassembledIntoSingleEvent()
+    {
+        var port = FindFreePort();
+        var headline = Encoding.UTF8.GetBytes("Petrobras anuncia dividendos");
+        var body = Encoding.UTF8.GetBytes("Lorem ipsum dolor sit amet, consectetur.");
+        var url = Encoding.UTF8.GetBytes("https://example.com/n/1");
+        const ulong newsId = 9876UL;
+
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            await TestWsServer.SendNewsBeginAsync(ws, securityIdOrZero: 0, newsId: newsId,
+                source: 0, language: 1, origTimeNanos: 1_000,
+                headlineLen: (uint)headline.Length, textLen: (uint)body.Length, urlLen: (uint)url.Length, ct);
+            await TestWsServer.SendNewsChunkAsync(ws, newsId, fieldByte: 0, headline, isFinal: false, ct);
+            await TestWsServer.SendNewsChunkAsync(ws, newsId, fieldByte: 1, body, isFinal: false, ct);
+            await TestWsServer.SendNewsChunkAsync(ws, newsId, fieldByte: 2, url, isFinal: true, ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        var got = new TaskCompletionSource<NewsEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.News += n => got.TrySetResult(n);
+
+        await client.ConnectAsync();
+        var ev = await got.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(newsId, ev.NewsId);
+        Assert.Equal("Petrobras anuncia dividendos", ev.Headline);
+        Assert.Equal("Lorem ipsum dolor sit amet, consectetur.", ev.Text);
+        Assert.Equal("https://example.com/n/1", ev.Url);
+    }
+
     private static async Task WaitUntil(Func<bool> pred, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -360,6 +395,47 @@ internal sealed class TestWsServer : IAsyncDisposable
         BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(8), capabilities);
         buf[12] = (byte)buildBytes.Length;
         buildBytes.CopyTo(buf, 13);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendNewsBeginAsync(WebSocket ws, ulong securityIdOrZero, ulong newsId,
+        byte source, ushort language, long origTimeNanos,
+        uint headlineLen, uint textLen, uint urlLen, CancellationToken ct)
+    {
+        // [len u16][type u16=0x0090][version u8][secId u64][newsId u64][source u8][lang u16][origTime i64]
+        // [hLen u32][tLen u32][uLen u32]
+        ushort total = (ushort)(4 + 1 + 8 + 8 + 1 + 2 + 8 + 4 + 4 + 4);
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0090);
+        int o = 4;
+        buf[o++] = 1; // version
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), securityIdOrZero); o += 8;
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), newsId); o += 8;
+        buf[o++] = source;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(o), language); o += 2;
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), origTimeNanos); o += 8;
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(o), headlineLen); o += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(o), textLen); o += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(o), urlLen);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendNewsChunkAsync(WebSocket ws, ulong newsId, byte fieldByte,
+        byte[] fragment, bool isFinal, CancellationToken ct)
+    {
+        // [len u16][type u16][version u8][newsId u64][field u8][fragLen u16][bytes]
+        ushort opcode = isFinal ? (ushort)0x0092 : (ushort)0x0091;
+        ushort total = (ushort)(4 + 1 + 8 + 1 + 2 + fragment.Length);
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), opcode);
+        int o = 4;
+        buf[o++] = 1; // version
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), newsId); o += 8;
+        buf[o++] = fieldByte;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(o), (ushort)fragment.Length); o += 2;
+        fragment.CopyTo(buf, o);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 }

--- a/tests/B3.MarketData.WebSocketClient.Tests/ParityWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/ParityWireRoundTripTests.cs
@@ -1,0 +1,302 @@
+using System.Buffers.Binary;
+using ServerWire = B3.Umdf.Server.WireProtocol;
+using ServerMsg = B3.Umdf.Server.MessageType;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+/// <summary>
+/// Round-trip tests asserting the SDK <see cref="WireFormat"/> decoders accept
+/// the exact bytes the server's <c>WireProtocol</c> writers produce. These
+/// cover the parity gaps closed by issue #41 — MBO / MBP / News / Candles /
+/// Rankings / SymbolStaleStatus / RecoveryProgress.
+/// </summary>
+public class ParityWireRoundTripTests
+{
+    [Fact]
+    public void OrderAdded_RoundTripsPriceWithSbeExponent()
+    {
+        var buf = new byte[64];
+        int len = ServerWire.WriteOrderEvent(buf, ServerMsg.OrderAdded,
+            securityId: 42, orderId: 9001, side: (byte)BookSide.Bid,
+            price: 12_3456, qty: 250);
+
+        Assert.True(WireFormat.TryReadHeader(buf, out var totalLen, out var type));
+        Assert.Equal(len, totalLen);
+        Assert.Equal(WireFormat.MessageType.OrderAdded, type);
+
+        var (secId, orderId, side, price, qty) = WireFormat.ReadOrderEvent(
+            buf.AsSpan(WireFormat.FramingHeaderSize));
+        Assert.Equal(42UL, secId);
+        Assert.Equal(9001UL, orderId);
+        Assert.Equal((byte)BookSide.Bid, side);
+        Assert.Equal(12_3456L, price);
+        Assert.Equal(250L, qty);
+        Assert.Equal(12.3456m, price / WireFormat.PriceScale);
+    }
+
+    [Fact]
+    public void OrderDeleted_RoundTrips()
+    {
+        var buf = new byte[32];
+        int len = ServerWire.WriteOrderDeleted(buf,
+            securityId: 7, orderId: 555, side: (byte)BookSide.Ask);
+
+        WireFormat.TryReadHeader(buf, out _, out var type);
+        Assert.Equal(WireFormat.MessageType.OrderDeleted, type);
+
+        var (secId, orderId, side) = WireFormat.ReadOrderDeleted(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
+        Assert.Equal(7UL, secId);
+        Assert.Equal(555UL, orderId);
+        Assert.Equal((byte)BookSide.Ask, side);
+    }
+
+    [Fact]
+    public void BookCleared_RoundTrips()
+    {
+        var buf = new byte[16];
+        ServerWire.WriteBookCleared(buf, securityId: 1, clearSide: (byte)BookClearSide.Bid);
+
+        var (secId, clearByte) = WireFormat.ReadBookCleared(
+            buf.AsSpan(WireFormat.FramingHeaderSize));
+        Assert.Equal(1UL, secId);
+        Assert.Equal((byte)BookClearSide.Bid, clearByte);
+    }
+
+    [Fact]
+    public void MarketTierUpdate_RoundTrips()
+    {
+        var buf = new byte[32];
+        int len = ServerWire.WriteMarketTierUpdate(buf,
+            securityId: 11, side: (byte)BookSide.Bid, totalQty: 5_000, orderCount: 3);
+
+        WireFormat.TryReadHeader(buf, out _, out var type);
+        Assert.Equal(WireFormat.MessageType.MarketTierUpdate, type);
+
+        var (secId, side, qty, count) = WireFormat.ReadMarketTierUpdate(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
+        Assert.Equal(11UL, secId);
+        Assert.Equal((byte)BookSide.Bid, side);
+        Assert.Equal(5_000L, qty);
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public void LevelUpdate_RoundTripsPriceWithSbeExponent()
+    {
+        var buf = new byte[64];
+        int len = ServerWire.WriteLevelUpdate(buf,
+            securityId: 99, side: (byte)BookSide.Ask, price: 25_5000, totalQty: 1_200, orderCount: 4);
+
+        WireFormat.TryReadHeader(buf, out _, out var type);
+        Assert.Equal(WireFormat.MessageType.LevelUpdate, type);
+
+        var (secId, side, price, qty, count) = WireFormat.ReadLevelUpdate(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
+        Assert.Equal(99UL, secId);
+        Assert.Equal((byte)BookSide.Ask, side);
+        Assert.Equal(25_5000L, price);
+        Assert.Equal(1_200L, qty);
+        Assert.Equal(4, count);
+        Assert.Equal(25.5m, price / WireFormat.PriceScale);
+    }
+
+    [Fact]
+    public void LevelDeleted_RoundTrips()
+    {
+        var buf = new byte[32];
+        int len = ServerWire.WriteLevelDeleted(buf,
+            securityId: 99, side: (byte)BookSide.Bid, price: 36_7800);
+
+        var (secId, side, price) = WireFormat.ReadLevelDeleted(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
+        Assert.Equal(99UL, secId);
+        Assert.Equal((byte)BookSide.Bid, side);
+        Assert.Equal(36_7800L, price);
+    }
+
+    [Fact]
+    public void LevelSnapshot_RoundTripsBothSides()
+    {
+        // Build a 2-bid + 1-ask snapshot using the server writer.
+        int total = ServerWire.LevelSnapshotSize(2, 1);
+        var buf = new byte[total];
+        int offset = ServerWire.WriteLevelSnapshotHeader(buf, securityId: 42, bidCount: 2, askCount: 1);
+        offset = ServerWire.WriteLevelSnapshotEntry(buf, offset, price: 36_7000, totalQty: 100, orderCount: 2);
+        offset = ServerWire.WriteLevelSnapshotEntry(buf, offset, price: 36_6500, totalQty: 50, orderCount: 1);
+        offset = ServerWire.WriteLevelSnapshotEntry(buf, offset, price: 36_8500, totalQty: 75, orderCount: 1);
+        Assert.Equal(total, offset);
+
+        var ev = WireFormat.ReadLevelSnapshot(
+            buf.AsSpan(WireFormat.FramingHeaderSize, total - WireFormat.FramingHeaderSize).ToArray(),
+            "PETR4", DateTime.UtcNow);
+        Assert.Equal(42UL, ev.SecurityId);
+        Assert.Equal(2, ev.Bids.Count);
+        Assert.Single(ev.Asks);
+        Assert.Equal(36.70m, ev.Bids[0].Price);
+        Assert.Equal(100L, ev.Bids[0].TotalQty);
+        Assert.Equal(2, ev.Bids[0].OrderCount);
+        Assert.Equal(36.85m, ev.Asks[0].Price);
+    }
+
+    [Fact]
+    public void BookSnapshot_HeaderOnlyMarker_DecodesEmpty()
+    {
+        var buf = new byte[ServerWire.BookSnapshotSize(0, 0)];
+        ServerWire.WriteBookSnapshotHeader(buf, securityId: 1, rptSeq: 42, bidCount: 0, askCount: 0);
+
+        var ev = WireFormat.ReadBookSnapshot(
+            buf.AsSpan(WireFormat.FramingHeaderSize).ToArray(),
+            "PETR4", DateTime.UtcNow);
+        Assert.Equal(1UL, ev.SecurityId);
+        Assert.Equal(42U, ev.RptSeq);
+        Assert.Empty(ev.Bids);
+        Assert.Empty(ev.Asks);
+    }
+
+    [Fact]
+    public void SymbolStaleStatus_RoundTrips()
+    {
+        var buf = new byte[16];
+        ServerWire.WriteSymbolStaleStatus(buf, securityId: 77, isStale: true);
+
+        var (secId, isStale) = WireFormat.ReadSymbolStaleStatus(
+            buf.AsSpan(WireFormat.FramingHeaderSize));
+        Assert.Equal(77UL, secId);
+        Assert.True(isStale);
+    }
+
+    [Fact]
+    public void RecoveryProgress_RoundTrips()
+    {
+        var buf = new byte[ServerWire.RecoveryProgressMaxSize];
+        Span<int> staleByKind = stackalloc int[] { 0, 4, 0, 7 };
+        int len = ServerWire.WriteRecoveryProgress(buf,
+            totalSymbols: 100, totalStaleSymbols: 11, staleByKind);
+
+        var ev = WireFormat.ReadRecoveryProgress(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize).ToArray(),
+            DateTime.UtcNow);
+        Assert.Equal(100U, ev.TotalSymbols);
+        Assert.Equal(11U, ev.TotalStaleSymbols);
+        // Only non-zero kinds make it onto the wire (indexes 1 and 3 here).
+        Assert.Equal(2, ev.StaleByKind.Count);
+        Assert.Equal((byte)1, ev.StaleByKind[0].Kind);
+        Assert.Equal(4U, ev.StaleByKind[0].StaleCount);
+        Assert.Equal((byte)3, ev.StaleByKind[1].Kind);
+        Assert.Equal(7U, ev.StaleByKind[1].StaleCount);
+    }
+
+    [Fact]
+    public void News_BeginChunkEnd_ReassemblesAllThreeFields()
+    {
+        // Build a NewsBegin + one chunk per field + a final empty NewsEnd.
+        var headline = System.Text.Encoding.UTF8.GetBytes("Petrobras anuncia dividendos");
+        var body = System.Text.Encoding.UTF8.GetBytes("Lorem ipsum dolor sit amet.");
+        var url = System.Text.Encoding.UTF8.GetBytes("https://example.com/n/1");
+        const ulong newsId = 12345UL;
+
+        var begin = new byte[ServerWire.NewsBeginTotalSize];
+        ServerWire.WriteNewsBegin(begin,
+            securityIdOrZero: 0, newsId: newsId, source: 0, language: 1, origTimeNanos: 1_000,
+            totalHeadlineLen: (uint)headline.Length,
+            totalTextLen: (uint)body.Length,
+            totalUrlLen: (uint)url.Length);
+
+        var hChunk = new byte[ServerWire.NewsChunkTotalSize(headline.Length)];
+        ServerWire.WriteNewsChunk(hChunk, newsId, ServerWire.NewsField.Headline, headline, isFinal: false);
+        var tChunk = new byte[ServerWire.NewsChunkTotalSize(body.Length)];
+        ServerWire.WriteNewsChunk(tChunk, newsId, ServerWire.NewsField.Text, body, isFinal: false);
+        // Last fragment carries the URL and the NewsEnd opcode.
+        var uEnd = new byte[ServerWire.NewsChunkTotalSize(url.Length)];
+        ServerWire.WriteNewsChunk(uEnd, newsId, ServerWire.NewsField.Url, url, isFinal: true);
+
+        // Verify decoding each one matches the SDK's parsers.
+        var hdr = WireFormat.ReadNewsBegin(begin.AsSpan(WireFormat.FramingHeaderSize));
+        Assert.Equal(newsId, hdr.NewsId);
+        Assert.Equal((uint)headline.Length, hdr.TotalHeadlineLen);
+        Assert.Equal((uint)body.Length, hdr.TotalTextLen);
+        Assert.Equal((uint)url.Length, hdr.TotalUrlLen);
+
+        var (_, _, hField) = WireFormat.ReadNewsChunk(
+            hChunk.AsSpan(WireFormat.FramingHeaderSize), out var hFrag);
+        Assert.Equal(WireFormat.NewsField.Headline, hField);
+        Assert.Equal(headline.Length, hFrag.Length);
+        Assert.True(headline.AsSpan().SequenceEqual(hFrag));
+
+        var (_, _, uFieldEnd) = WireFormat.ReadNewsChunk(
+            uEnd.AsSpan(WireFormat.FramingHeaderSize), out var uFrag);
+        Assert.Equal(WireFormat.NewsField.Url, uFieldEnd);
+        Assert.True(url.AsSpan().SequenceEqual(uFrag));
+    }
+
+    [Fact]
+    public void RankingsUpdate_RoundTripsAllThreeCategories()
+    {
+        var entries = new[]
+        {
+            new B3.Umdf.Server.RankingEntry(secId(1), 100, "PETR4"),
+            new B3.Umdf.Server.RankingEntry(secId(2),  90, "VALE3"),
+        };
+        var empty = Array.Empty<B3.Umdf.Server.RankingEntry>();
+
+        var buf = new byte[ServerWire.RankingsUpdateMaxSize];
+        int len = ServerWire.WriteRankingsUpdate(buf, entries, empty, empty);
+
+        var ev = WireFormat.ReadRankingsUpdate(
+            buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize).ToArray(),
+            DateTime.UtcNow);
+        Assert.Equal(2, ev.Volume.Count);
+        Assert.Empty(ev.Gainers);
+        Assert.Empty(ev.Losers);
+        Assert.Equal("PETR4", ev.Volume[0].Symbol);
+        Assert.Equal(100L, ev.Volume[0].Value);
+
+        static ulong secId(ulong v) => v;
+    }
+
+    [Fact]
+    public void Candles_SnapshotAndUpdate_RoundTripWithSbeExponent()
+    {
+        // Hand-craft a CandleSnapshot frame the same way the server's
+        // internal WriteCandleSnapshot would, then verify the SDK decoder.
+        // (WriteCandleSnapshot is internal — recreate the bytes here.)
+        const ulong secId = 42;
+        const ushort resolution = 60;
+        const byte flags = 0x01 | 0x02; // first + last
+        const int candleCount = 1;
+        int total = WireFormat.FramingHeaderSize + 8 + 2 + 1 + 2 + candleCount * 56;
+        var buf = new byte[total];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), (ushort)WireFormat.MessageType.CandleSnapshot);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), secId);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(12), resolution);
+        buf[14] = flags;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(15), (ushort)candleCount);
+        // Candle: time, open, high, low, close, volume, avg
+        int o = 17;
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 1_700_000_000_000_000_000L); o += 8;
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 36_7000L); o += 8;          // open 36.70
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 37_0000L); o += 8;          // high 37.00
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 36_5000L); o += 8;          // low  36.50
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 36_9000L); o += 8;          // close 36.90
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 12_345L);  o += 8;          // volume
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 36_8000L);                  // avg 36.80
+
+        var ev = WireFormat.ReadCandleSnapshot(
+            buf.AsSpan(WireFormat.FramingHeaderSize).ToArray(),
+            "PETR4", DateTime.UtcNow);
+        Assert.Equal(42UL, ev.SecurityId);
+        Assert.Equal(60, ev.Resolution);
+        Assert.True(ev.IsFirst);
+        Assert.True(ev.IsLast);
+        Assert.Single(ev.Candles);
+        var c = ev.Candles[0];
+        Assert.Equal(36.70m, c.Open);
+        Assert.Equal(37.00m, c.High);
+        Assert.Equal(36.50m, c.Low);
+        Assert.Equal(36.90m, c.Close);
+        Assert.Equal(12_345L, c.Volume);
+        Assert.Equal(36.80m, c.Avg);
+    }
+}


### PR DESCRIPTION
Closes #41 — unblocks pedrosakuma/B3TradingPlatform#286.

## Summary

Brings the typed `B3.MarketData.WebSocketClient` SDK to full parity with the server's wire surface so downstream consumers (B3TradingPlatform) no longer need to hand-roll decoders.

## What changed

- **`SubscribeFlags`** mirrors the server's `DataFlags`: `Book` (MBO), `Mbp`, `News`, plus `All` / `Everything` aliases. Bit positions match the wire contract exactly.
- **New typed events** for every server→client opcode:
  - MBO: `BookSnapshot`, `OrderAdded` / `OrderUpdated` / `OrderDeleted`, `BookCleared`, `MarketTierUpdate`
  - MBP: `LevelSnapshot`, `LevelUpdate`, `LevelDeleted`
  - Other: `SymbolStaleStatus`, `RecoveryProgress`, `CandleSnapshot` / `CandleUpdate`, `RankingsUpdate`
  - News: `News` event raised once per news item, transparently reassembled from `NewsBegin` / `NewsChunk` / `NewsEnd` fragments inside the receive loop.
- **`WireFormat`** gained decoders for every new opcode. SBE 4-decimal price scale (10_000) is applied consistently per the schema.
- **BookSnapshot semantics** clarified in xmldoc: the server emits the header with `bid/askCount = 0` followed by an inline `OrderAdded` burst (see `SnapshotEmitter.SendMboSnapshot`). Consumers should clear local state on the snapshot event and rebuild from the order stream that follows.
- **README** updated: dropped the "out of scope for v1: full L2/MBO" note, documented the new flags and event surface.

## Tests

- **13 new wire round-trip tests** in `ParityWireRoundTripTests.cs` — encode with the server's own `B3.Umdf.Server.WireProtocol` writers, decode with the client's `WireFormat`. Catches any future drift between the two sides.
- **1 new end-to-end test** for `News` reassembly through a real `MarketDataClient` over a WebSocket (`NewsBegin` + N `NewsChunk` + `NewsEnd` → single typed `NewsEvent`).
- Total: **22/22 pass** (8 existing + 14 new).
- Full repo build: 0 warn / 0 err.

## Backward compatibility

Purely additive — no existing event shape, flag value, or public type was changed.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>