### PR TITLE
feat(client): surface auction fields in InfoSnapshot (#40)

### DIFF
--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -39,7 +39,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 });
 
 client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}");
-client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice}");
+client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice} top={i.TheoreticalOpeningPrice} imb={i.AuctionImbalanceCondition}");
 client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
 client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");
 

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -144,20 +144,29 @@ snapshot; clients should reset any prior market tier when processing
 
 | Bit | Field | Bit | Field |
 |-----|-------|-----|-------|
-| 0 | OpeningPrice | 11 | VwapPrice |
-| 1 | ClosingPrice | 12 | NetChange |
-| 2 | HighPrice | 13 | NumberOfTrades |
-| 3 | LowPrice | 14 | OpenInterest |
-| 4 | LastTradePrice | 15 | PriceBandLow |
-| 5 | LastTradeSize | 16 | PriceBandHigh |
-| 6 | SettlementPrice | 17 | TradingReferencePrice |
-| 7 | TheoreticalOpeningPrice | 18 | AvgDailyTradedQty |
-| 8 | TheoreticalOpeningSize | 19 | MaxTradeVol |
-| 9 | AuctionImbalanceSize | 20 | TradingStatus |
-| 10 | TradeVolume | 21 | TradingEvent |
+| 0 | OpeningPrice | 12 | NetChange |
+| 1 | ClosingPrice | 13 | NumberOfTrades |
+| 2 | HighPrice | 14 | OpenInterest |
+| 3 | LowPrice | 15 | PriceBandLow |
+| 4 | LastTradePrice | 16 | PriceBandHigh |
+| 5 | LastTradeSize | 17 | TradingReferencePrice |
+| 6 | SettlementPrice | 18 | AvgDailyTradedQty |
+| 7 | TheoreticalOpeningPrice | 19 | MaxTradeVol |
+| 8 | TheoreticalOpeningSize | 20 | TradingStatus |
+| 9 | AuctionImbalanceSize | 21 | TradingEvent |
+| 10 | TradeVolume | 22 | PriceLimitType |
+| 11 | VwapPrice | 23 | MinPriceIncrement |
+|    |                         | 24 | AuctionImbalanceCondition |
 
 Only fields with their bit set are present in the payload (as `i64` in
-bit order). Max `InfoSnapshot` body: 192 bytes.
+bit order). Max `InfoSnapshot` body: 200 bytes.
+
+`AuctionImbalanceCondition` carries the raw SBE `ImbalanceCondition`
+bitfield from `AuctionImbalance_19` (low 16 bits): `0x0100` =
+`ImbalanceMoreBuyers`, `0x0200` = `ImbalanceMoreSellers`, all bits off =
+`Balanced`. The SDK decodes it into the
+`B3.MarketData.WebSocketClient.AuctionImbalanceCondition` enum;
+unrecognised combinations map to `Unknown`.
 
 ### Incrementals
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -40,6 +40,7 @@ export const INFO_FIELDS = [
   'NetChange', 'NumberOfTrades', 'OpenInterest', 'PriceBandLow',
   'PriceBandHigh', 'TradingReferencePrice', 'AvgDailyTradedQty', 'MaxTradeVol',
   'TradingStatus', 'TradingEvent', 'PriceLimitType', 'MinPriceIncrement',
+  'AuctionImbalanceCondition',
 ];
 
 // Decimal places per price field, derived from SBE schema exponents.

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -58,6 +58,23 @@ public readonly record struct TradeBustEvent(
     DateTime ReceivedUtc);
 
 /// <summary>
+/// Decoded auction-imbalance side from <c>AuctionImbalance_19</c> (SBE schema
+/// 2.2.0 §AuctionImbalance). <see cref="Balanced"/> = both bits clear (no
+/// pending side); <see cref="MoreBuyers"/> / <see cref="MoreSellers"/> mirror
+/// the SBE <c>ImbalanceMoreBuyers</c> / <c>ImbalanceMoreSellers</c> flags.
+/// <see cref="Unknown"/> covers reserved combinations (both bits set) — kept
+/// distinct so forward-compat additions in the schema do not silently collapse
+/// to a known value.
+/// </summary>
+public enum AuctionImbalanceCondition : byte
+{
+    Balanced = 0,
+    MoreBuyers = 1,
+    MoreSellers = 2,
+    Unknown = 3,
+}
+
+/// <summary>
 /// Per-symbol info snapshot. Only fields actually present in the frame
 /// are populated; absent fields are <c>null</c>. Prices are scaled with
 /// the SBE 4-decimal exponent.
@@ -84,6 +101,36 @@ public sealed class InfoSnapshotEvent
     public long? TradeVolume { get; init; }
     public long? TradingStatus { get; init; }
     public long? TradingEvent { get; init; }
+
+    // ── Auction ─────────────────────────────────────────────────────
+    /// <summary>
+    /// Latest theoretical opening price from <c>TheoreticalOpeningPrice_16</c>.
+    /// Calculated and updated by the venue during every auction (pre-opening,
+    /// pre-closing, intra-day reopen). Scaled with the SBE 4-decimal exponent
+    /// (raw / 10_000). <c>null</c> when the venue has not yet published a TOP
+    /// for this security, or when the field is not present in this frame.
+    /// </summary>
+    public decimal? TheoreticalOpeningPrice { get; init; }
+
+    /// <summary>
+    /// Theoretical opening quantity matched at <see cref="TheoreticalOpeningPrice"/>
+    /// (raw, unscaled).
+    /// </summary>
+    public long? TheoreticalOpeningSize { get; init; }
+
+    /// <summary>
+    /// Remaining auction quantity from <c>AuctionImbalance_19</c> — the size
+    /// of the pending side (or 0 when balanced). Raw, unscaled. Pair with
+    /// <see cref="AuctionImbalanceCondition"/> to know which side is pending.
+    /// </summary>
+    public long? AuctionImbalanceSize { get; init; }
+
+    /// <summary>
+    /// Pending side of the auction imbalance. <c>null</c> when the venue
+    /// has not yet published an <c>AuctionImbalance</c> for this security
+    /// or when the field is not present in this frame.
+    /// </summary>
+    public AuctionImbalanceCondition? AuctionImbalanceCondition { get; init; }
 }
 
 /// <summary>

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -78,6 +78,10 @@ internal static class WireFormat
     public const int FieldTradingEvent = 21;
     public const int FieldPriceLimitType = 22;
     public const int FieldMinPriceIncrement = 23;
+    /// <summary>Raw <c>ImbalanceCondition</c> bitfield from upstream
+    /// <c>AuctionImbalance_19</c>. Surfaced as
+    /// <see cref="InfoSnapshotEvent.AuctionImbalanceCondition"/>.</summary>
+    public const int FieldAuctionImbalanceCondition = 24;
 
     public static bool TryReadHeader(ReadOnlySpan<byte> src, out ushort length, out MessageType type)
     {
@@ -203,6 +207,10 @@ internal static class WireFormat
         long? trades = null, openInterest = null;
         decimal? bandLow = null, bandHigh = null, refPx = null;
         long? volume = null, status = null, evt = null;
+        decimal? theoreticalOpeningPrice = null;
+        long? theoreticalOpeningSize = null;
+        long? auctionImbalanceSize = null;
+        AuctionImbalanceCondition? auctionImbalanceCondition = null;
 
         int offset = 12;
         for (int bit = 0; bit < 32; bit++)
@@ -219,6 +227,9 @@ internal static class WireFormat
                 case FieldLastTradePrice: lastTradePrice = v / PriceScale; break;
                 case FieldLastTradeSize: lastTradeSize = v; break;
                 case FieldSettlementPrice: settlement = v / PriceScale; break;
+                case FieldTheoreticalOpeningPrice: theoreticalOpeningPrice = v / PriceScale; break;
+                case FieldTheoreticalOpeningSize: theoreticalOpeningSize = v; break;
+                case FieldAuctionImbalanceSize: auctionImbalanceSize = v; break;
                 case FieldVwapPrice: vwap = v / PriceScale; break;
                 case FieldNumberOfTrades: trades = v; break;
                 case FieldOpenInterest: openInterest = v; break;
@@ -228,10 +239,15 @@ internal static class WireFormat
                 case FieldTradeVolume: volume = v; break;
                 case FieldTradingStatus: status = v; break;
                 case FieldTradingEvent: evt = v; break;
-                // Other bits (TheoreticalOpening*, Auction*, NetChange,
-                // AvgDailyTradedQty, MaxTradeVol, PriceLimitType,
-                // MinPriceIncrement) are consumed but not surfaced in
-                // the v1 typed event.
+                case FieldAuctionImbalanceCondition:
+                    // SBE ImbalanceCondition bits: 0x0100 = MoreBuyers,
+                    // 0x0200 = MoreSellers. Decoder masks low 16 bits and
+                    // translates to the clean SDK enum.
+                    auctionImbalanceCondition = DecodeImbalanceCondition((ushort)v);
+                    break;
+                // Other bits (NetChange, AvgDailyTradedQty, MaxTradeVol,
+                // PriceLimitType, MinPriceIncrement) are consumed but not
+                // surfaced in the v1 typed event.
             }
         }
 
@@ -256,7 +272,27 @@ internal static class WireFormat
             TradeVolume = volume,
             TradingStatus = status,
             TradingEvent = evt,
+            TheoreticalOpeningPrice = theoreticalOpeningPrice,
+            TheoreticalOpeningSize = theoreticalOpeningSize,
+            AuctionImbalanceSize = auctionImbalanceSize,
+            AuctionImbalanceCondition = auctionImbalanceCondition,
         };
+    }
+
+    // SBE ImbalanceCondition bit positions (uint16):
+    //   bit 8 (0x0100) = ImbalanceMoreBuyers
+    //   bit 9 (0x0200) = ImbalanceMoreSellers
+    private const ushort ImbalanceBitMoreBuyers = 0x0100;
+    private const ushort ImbalanceBitMoreSellers = 0x0200;
+
+    private static AuctionImbalanceCondition DecodeImbalanceCondition(ushort raw)
+    {
+        bool buyers = (raw & ImbalanceBitMoreBuyers) != 0;
+        bool sellers = (raw & ImbalanceBitMoreSellers) != 0;
+        if (buyers && sellers) return WebSocketClient.AuctionImbalanceCondition.Unknown;
+        if (buyers) return WebSocketClient.AuctionImbalanceCondition.MoreBuyers;
+        if (sellers) return WebSocketClient.AuctionImbalanceCondition.MoreSellers;
+        return WebSocketClient.AuctionImbalanceCondition.Balanced;
     }
 
     // ── MBO / order events ──────────────────────────────────────────

--- a/src/B3.Umdf.Book/InstrumentInfo.cs
+++ b/src/B3.Umdf.Book/InstrumentInfo.cs
@@ -73,6 +73,14 @@ public sealed class InstrumentInfo
 
     // Auction
     public long? AuctionImbalanceSize { get; set; }
+    /// <summary>
+    /// Raw <c>ImbalanceCondition</c> bitfield from <c>AuctionImbalance_19</c>
+    /// (SBE schema 2.2.0 §AuctionImbalance). Two bits are defined:
+    /// <c>0x0100</c> = ImbalanceMoreBuyers (P), <c>0x0200</c> = ImbalanceMoreSellers (Q).
+    /// All bits off = BALANCED. Kept as raw <c>ushort</c> so new bits added
+    /// upstream stay forward-compatible.
+    /// </summary>
+    public ushort? AuctionImbalanceCondition { get; set; }
 
     // Bands
     public long? PriceBandLow { get; set; }
@@ -158,6 +166,7 @@ public sealed class InstrumentInfo
         TheoreticalOpeningPrice = null;
         TheoreticalOpeningSize = null;
         AuctionImbalanceSize = null;
+        AuctionImbalanceCondition = null;
         PriceBandLow = null;
         PriceBandHigh = null;
         PriceLimitType = null;
@@ -214,6 +223,7 @@ public sealed class InstrumentInfo
         NumberOfTrades = null;
         NetChangeFromPrevDay = null;
         AuctionImbalanceSize = null;
+        AuctionImbalanceCondition = null;
 
         LastRptSeqOpeningPrice = 0;
         LastRptSeqTheoreticalOpeningPrice = 0;

--- a/src/B3.Umdf.Book/MarketDataManager.cs
+++ b/src/B3.Umdf.Book/MarketDataManager.cs
@@ -658,6 +658,7 @@ public sealed class MarketDataManager : IFeedEventHandler
         }
 
         info.AuctionImbalanceSize = msg.MDEntrySize;
+        info.AuctionImbalanceCondition = (ushort)msg.ImbalanceCondition;
         info.LastUpdateTimestamp = msg.MDEntryTimestamp.Time ?? 0;
         info.BumpVersion();
 

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -607,9 +607,14 @@ public static class WireProtocol
     public const int FieldTradingEvent = 21;
     public const int FieldPriceLimitType = 22;
     public const int FieldMinPriceIncrement = 23;
+    /// <summary>Raw <c>ImbalanceCondition</c> bitfield from the upstream
+    /// <c>AuctionImbalance_19</c> message: bit 8 = ImbalanceMoreBuyers (P),
+    /// bit 9 = ImbalanceMoreSellers (Q), all bits off = BALANCED. Widened
+    /// to i64 like every other slot. Decoder masks low 16 bits.</summary>
+    public const int FieldAuctionImbalanceCondition = 24;
 
-    /// <summary>Max buffer size for InfoSnapshot: header + securityId + mask + 24 fields × 8.</summary>
-    public const int InfoSnapshotMaxSize = FramingHeaderSize + 8 + 4 + 24 * 8; // 208
+    /// <summary>Max buffer size for InfoSnapshot: header + securityId + mask + 25 fields × 8.</summary>
+    public const int InfoSnapshotMaxSize = FramingHeaderSize + 8 + 4 + 25 * 8; // 216
 
     /// <summary>
     /// Write InfoSnapshot: securityId + u32 field bitmask + i64 values for present fields.
@@ -646,6 +651,9 @@ public static class WireProtocol
         // homogeneous (one slot = 8 bytes). Decoder reads low 8 bits.
         if (info.PriceLimitType is { } v22) { mask |= 1u << FieldPriceLimitType; BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], v22); offset += 8; }
         if (info.MinPriceIncrement is { } v23) { mask |= 1u << FieldMinPriceIncrement; BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], v23); offset += 8; }
+        // AuctionImbalanceCondition is a ushort bitfield; widened to i64 so the
+        // wire keeps one slot = 8 bytes. Decoder masks low 16 bits.
+        if (info.AuctionImbalanceCondition is { } v24) { mask |= 1u << FieldAuctionImbalanceCondition; BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], v24); offset += 8; }
 
         // Write framing header, securityId, and mask
         ushort totalLen = (ushort)offset;

--- a/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
@@ -71,6 +71,42 @@ public class WireFormatTests
         // Unset fields stay null.
         Assert.Null(ev.OpeningPrice);
         Assert.Null(ev.VwapPrice);
+        Assert.Null(ev.TheoreticalOpeningPrice);
+        Assert.Null(ev.AuctionImbalanceSize);
+        Assert.Null(ev.AuctionImbalanceCondition);
+    }
+
+    [Theory]
+    [InlineData(0x0000, AuctionImbalanceCondition.Balanced)]
+    [InlineData(0x0100, AuctionImbalanceCondition.MoreBuyers)]
+    [InlineData(0x0200, AuctionImbalanceCondition.MoreSellers)]
+    [InlineData(0x0300, AuctionImbalanceCondition.Unknown)] // both bits set
+    public void InfoSnapshot_DecodesAuctionFields(int rawImbalance, AuctionImbalanceCondition expected)
+    {
+        // Set bits: TheoreticalOpeningPrice(7), TheoreticalOpeningSize(8),
+        //           AuctionImbalanceSize(9), AuctionImbalanceCondition(24).
+        uint mask = (1u << WireFormat.FieldTheoreticalOpeningPrice)
+                  | (1u << WireFormat.FieldTheoreticalOpeningSize)
+                  | (1u << WireFormat.FieldAuctionImbalanceSize)
+                  | (1u << WireFormat.FieldAuctionImbalanceCondition);
+        Span<byte> buf = stackalloc byte[256];
+        // header(4) + secId(8) + mask(4) + 4 * i64
+        ushort total = 4 + 8 + 4 + 32;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.InfoSnapshot);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 7UL);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf[12..], mask);
+        // Bit-order on wire: 7, 8, 9, 24.
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[16..], 30_2500L); // 30.25 TOP
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[24..], 1_500L);   // TOP size
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[32..], 800L);     // imbalance size
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[40..], rawImbalance);
+
+        var ev = WireFormat.ReadInfoSnapshot(buf[4..total], "VALE3", DateTime.UtcNow);
+        Assert.Equal(30.25m, ev.TheoreticalOpeningPrice);
+        Assert.Equal(1_500L, ev.TheoreticalOpeningSize);
+        Assert.Equal(800L, ev.AuctionImbalanceSize);
+        Assert.Equal(expected, ev.AuctionImbalanceCondition);
     }
 
     private static void WriteServerTradeFrame(Span<byte> dest, ulong securityId, long price, long qty, long tradeId)

--- a/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
@@ -195,6 +195,39 @@ public class WireProtocolTests
     }
 
     [Fact]
+    public void WriteInfoSnapshot_AuctionFields_RoundTrip()
+    {
+        var buf = new byte[WireProtocol.InfoSnapshotMaxSize];
+        var info = new InstrumentInfo
+        {
+            TheoreticalOpeningPrice = 12_3450L, // 12.3450
+            TheoreticalOpeningSize = 7_500L,
+            AuctionImbalanceSize = 250L,
+            // SBE ImbalanceCondition bit 8 = MoreBuyers
+            AuctionImbalanceCondition = 0x0100,
+        };
+        int len = WireProtocol.WriteInfoSnapshot(buf, securityId: 99, info);
+
+        var (msgLen, type) = ReadFraming(buf);
+        Assert.Equal(len, msgLen);
+        Assert.Equal(MessageType.InfoSnapshot, type);
+
+        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12));
+        Assert.True((mask & (1u << WireProtocol.FieldTheoreticalOpeningPrice)) != 0);
+        Assert.True((mask & (1u << WireProtocol.FieldTheoreticalOpeningSize)) != 0);
+        Assert.True((mask & (1u << WireProtocol.FieldAuctionImbalanceSize)) != 0);
+        Assert.True((mask & (1u << WireProtocol.FieldAuctionImbalanceCondition)) != 0);
+
+        // Values appear in bit order. The set bits here are 7,8,9,24 → that's
+        // the order on the wire. (24 is set last, after the four lower bits.)
+        int off = 16;
+        Assert.Equal(12_3450L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8; // TheoreticalOpeningPrice
+        Assert.Equal(7_500L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;   // TheoreticalOpeningSize
+        Assert.Equal(250L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;     // AuctionImbalanceSize
+        Assert.Equal(0x0100L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off)));            // AuctionImbalanceCondition
+    }
+
+    [Fact]
     public void WriteCandleUpdate_RoundTrip()
     {
         var buf = new byte[128];


### PR DESCRIPTION
Closes part of #40.

## What

Surface the theoretical-opening and auction-imbalance fields the server already had on the wire (but the client discarded), and add the missing **AuctionImbalanceCondition** (buyer/seller imbalance side).

New `InfoSnapshotEvent` properties:
- `TheoreticalOpeningPrice` (decimal?)
- `TheoreticalOpeningSize` (long?)
- `AuctionImbalanceSize` (long?)
- `AuctionImbalanceCondition` (enum: Balanced / MoreBuyers / MoreSellers / Unknown)

## Wire change (additive, backwards-compatible)

- New optional field bit `FieldAuctionImbalanceCondition = 24` in InfoSnapshot field mask.
- `InfoSnapshotMaxSize` bumped (24 → 25 slots).
- Client tolerates older servers (bit absent ⇒ property null).

## Tests

- `WriteInfoSnapshot_AuctionFields_RoundTrip` (server)
- `InfoSnapshot_DecodesAuctionFields` `[Theory]` (client, 4 condition cases)
- Full suite: **661 passed, 0 failed**.

## Docs

- `docs/WEBSOCKET-PROTOCOL.md` — bit table + paragraph on condition encoding.
- `docs/CLIENT-SDK.md` — quickstart sample updated.
- `frontend/js/protocol.js` — `INFO_FIELDS` extended.

## Not in this PR — AuctionPrint (issue #40 part 2)

Schema 2.2.0 repurposed `TradeCondition` bit 12 from `PointInTimeAuction` to `BlockBookTrade`, so the obvious signal is gone. AuctionPrint needs a different derivation (e.g. `TradeCondition.OpeningPrice` cross, or `TradingStatus != Open` at trade time). Filing a follow-up.