### PR TITLE
feat(trade): surface AuctionPrint flag end-to-end (closes #46)

### DIFF
--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -38,7 +38,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
     Endpoint = new Uri("ws://localhost:8080/ws"),
 });
 
-client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}");
+client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}{(t.Flags.HasFlag(TradeFlags.AuctionPrint) ? " (auction)" : "")}");
 client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice}");
 client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
 client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -166,7 +166,7 @@ bit order). Max `InfoSnapshot` body: 192 bytes.
 | **OrderAdded**   | `0x0030` | `[secId u64][orderId u64][side u8][price i64][qty i64]` |
 | **OrderUpdated** | `0x0031` | *(same as OrderAdded)* |
 | **OrderDeleted** | `0x0032` | `[secId u64][orderId u64][side u8]` |
-| **Trade**        | `0x0033` | `[secId u64][price i64][qty i64][tradeId i64]` |
+| **Trade**        | `0x0033` | `[secId u64][price i64][qty i64][tradeId i64][flags u8]` |
 | **BookCleared**  | `0x0034` | `[secId u64][clearSide u8]` |
 | **MarketTierUpdate** | `0x0036` | `[secId u64][side u8][totalQty i64][orderCount u32]` |
 | **LevelUpdate**  | `0x0037` | `[secId u64][side u8][price i64][totalQty i64][orderCount u32]` |
@@ -177,6 +177,20 @@ For `BookCleared`, `clearSide` = `0` (Both), `1` (Bid), or `2` (Ask).
 Prices use the SBE schema's exponents:
 `Price` / `PriceOptional` = `1e-4`, `Price8` = `1e-8`. Apply
 `mantissa × 10^-decimals` for display.
+
+`Trade.flags` is a `TradeFlags` bitset:
+
+| Bit | Name | Meaning |
+|----:|------|---------|
+| `0x01` | `AuctionPrint` | Trade executed during an auction phase. Set when the upstream SBE `TradeCondition.OpeningPrice` bit is on (opening / reopening cross) **or** the security's current `TradingStatus` is `RESERVED` (pre-open) or `FINAL_CLOSING_CALL`. |
+
+All other bits are reserved (must be 0). Clients MUST mask with the
+documented bit values rather than equality-checking the whole byte.
+Servers that predate the flag byte wrote the legacy 36-byte `Trade`
+frame; the framing header reports the true length, and decoders that
+read flags MUST treat absence as `0` (no flags set). Trade history
+frames replayed from the per-symbol recent-trades ring always carry
+`flags=0` (the ring does not persist per-trade flags).
 
 `MarketTierUpdate` represents B3 null-price MOA/MOC orders as an aggregate
 market tier per side. It is intentionally separate from priced order events:

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -163,8 +163,12 @@ export function parseMessage(buf, baseOffset, msgLen) {
       const securityId = v.getBigUint64(o, true); o += 8;
       const price = Number(v.getBigInt64(o, true)); o += 8;
       const qty = Number(v.getBigInt64(o, true)); o += 8;
-      const tradeId = Number(v.getBigInt64(o, true));
-      return { type: 'Trade', securityId, price, qty, tradeId };
+      const tradeId = Number(v.getBigInt64(o, true)); o += 8;
+      // Trailing flags byte (added later). Tolerate older servers that wrote
+      // the legacy 36-byte frame — treat absence as 0 (no flags).
+      const flags = o < msgLen ? v.getUint8(o) : 0;
+      const auctionPrint = (flags & 0x01) !== 0;
+      return { type: 'Trade', securityId, price, qty, tradeId, flags, auctionPrint };
     }
     case MSG.BOOK_CLEARED: {
       const securityId = v.getBigUint64(o, true); o += 8;

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -25,6 +25,27 @@ public enum ConnectionState
 }
 
 /// <summary>
+/// Per-trade flag bitset. Currently signals whether the print was executed
+/// during an auction phase (opening cross, pre-open, or final-closing-call).
+/// Reserved bits are kept 0 for forward compatibility; mask with the
+/// individual values rather than equality-checking the whole byte.
+/// </summary>
+[System.Flags]
+public enum TradeFlags : byte
+{
+    /// <summary>No flags set — regular open-phase print.</summary>
+    None = 0,
+    /// <summary>
+    /// Trade is an auction print: either the SBE
+    /// <c>TradeCondition.OpeningPrice</c> bit was set on the source message
+    /// (opening / reopening cross), or the security's trading status was in
+    /// an auction phase (<c>RESERVED</c> / <c>FINAL_CLOSING_CALL</c>) at the
+    /// time of the trade.
+    /// </summary>
+    AuctionPrint = 1,
+}
+
+/// <summary>
 /// A live trade print. Price has the SBE 4-decimal exponent already
 /// applied (the raw wire value is <c>price × 10_000</c>).
 /// </summary>
@@ -37,13 +58,19 @@ public enum ConnectionState
 /// a future <see cref="TradeBustEvent"/>).</param>
 /// <param name="ReceivedUtc">UTC timestamp at which the SDK received
 /// the frame from the WebSocket. Not the exchange match time.</param>
+/// <param name="Flags">Per-trade flag bitset — see <see cref="TradeFlags"/>.
+/// <see cref="TradeFlags.None"/> when the server pre-dates the flag byte
+/// (the SDK auto-detects payload length and defaults to <c>None</c>) or
+/// for trades replayed from the server's recent-trades snapshot, which
+/// does not carry flags.</param>
 public readonly record struct TradeEvent(
     ulong SecurityId,
     string Symbol,
     decimal Price,
     long Qty,
     long TradeId,
-    DateTime ReceivedUtc);
+    DateTime ReceivedUtc,
+    TradeFlags Flags = TradeFlags.None);
 
 /// <summary>
 /// Cancellation of a previously-broadcast trade. Risk consumers usually

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -458,9 +458,9 @@ public sealed class MarketDataClient : IAsyncDisposable
             }
             case WireFormat.MessageType.Trade:
             {
-                var (secId, price, qty, tradeId) = WireFormat.ReadTrade(payload);
+                var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
-                var ev = new TradeEvent(secId, symbol, price / WireFormat.PriceScale, qty, tradeId, receivedUtc);
+                var ev = new TradeEvent(secId, symbol, price / WireFormat.PriceScale, qty, tradeId, receivedUtc, flags);
                 Enqueue(() => Trade?.Invoke(ev));
                 break;
             }

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -168,13 +168,20 @@ internal static class WireFormat
     public static ulong ReadSymbolDelisted(ReadOnlySpan<byte> payload)
         => BinaryPrimitives.ReadUInt64LittleEndian(payload);
 
-    public static (ulong SecurityId, long Price, long Qty, long TradeId) ReadTrade(ReadOnlySpan<byte> payload)
+    /// <summary>
+    /// Decode a Trade payload. Layout: <c>[secId u64][price i64][qty i64][tradeId i64][flags u8?]</c>.
+    /// The trailing flags byte was added in a later server build; when the
+    /// payload is the legacy 32 bytes (no flags), <see cref="TradeFlags.None"/>
+    /// is returned.
+    /// </summary>
+    public static (ulong SecurityId, long Price, long Qty, long TradeId, TradeFlags Flags) ReadTrade(ReadOnlySpan<byte> payload)
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
         long price = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
         long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[16..]);
         long tradeId = BinaryPrimitives.ReadInt64LittleEndian(payload[24..]);
-        return (secId, price, qty, tradeId);
+        var flags = payload.Length >= 33 ? (TradeFlags)payload[32] : TradeFlags.None;
+        return (secId, price, qty, tradeId, flags);
     }
 
     public static (ulong SecurityId, long TradeId) ReadTradeBust(ReadOnlySpan<byte> payload)

--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -898,7 +898,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             return;
         }
 
-        _eventHandler?.OnTrade(securityId, price, quantity, tradeId, tradeTimeNs);
+        _eventHandler?.OnTrade(securityId, price, quantity, tradeId, tradeTimeNs,
+            msg.TradeCondition.IsOpeningPrice() ? TradeFlags.AuctionPrint : TradeFlags.None);
         RecordTrade(securityId, price, quantity, tradeId, tradeTimeNs);
         TrackMatchEvent(securityId, msg.MatchEventIndicator);
     }
@@ -955,7 +956,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             return;
         }
 
-        _eventHandler?.OnForwardTrade(securityId, price, quantity, tradeId, tradeTimeNs);
+        _eventHandler?.OnForwardTrade(securityId, price, quantity, tradeId, tradeTimeNs,
+            msg.TradeCondition.IsOpeningPrice() ? TradeFlags.AuctionPrint : TradeFlags.None);
         RecordTrade(securityId, price, quantity, tradeId, tradeTimeNs);
         TrackMatchEvent(securityId, msg.MatchEventIndicator);
     }

--- a/src/B3.Umdf.Book/CompositeBookEventHandler.cs
+++ b/src/B3.Umdf.Book/CompositeBookEventHandler.cs
@@ -39,6 +39,11 @@ public sealed class CompositeBookEventHandler : IBookEventHandler
         foreach (var h in _handlers) h.OnTrade(securityId, price, quantity, tradeId, sendingTimeNs);
     }
 
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+    {
+        foreach (var h in _handlers) h.OnTrade(securityId, price, quantity, tradeId, sendingTimeNs, flags);
+    }
+
     public void OnBookCleared(ulong securityId, BookClearSide side)
     {
         foreach (var h in _handlers) h.OnBookCleared(securityId, side);
@@ -47,6 +52,11 @@ public sealed class CompositeBookEventHandler : IBookEventHandler
     public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
     {
         foreach (var h in _handlers) h.OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+    }
+
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+    {
+        foreach (var h in _handlers) h.OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs, flags);
     }
 
     public void OnTradeBust(ulong securityId, long price, long quantity, long tradeId)

--- a/src/B3.Umdf.Book/IBookEventHandler.cs
+++ b/src/B3.Umdf.Book/IBookEventHandler.cs
@@ -8,6 +8,25 @@ public enum BookClearSide : byte
     Ask = 2,
 }
 
+/// <summary>
+/// Per-trade flag bitset emitted alongside <see cref="IBookEventHandler.OnTrade"/>
+/// and <see cref="IBookEventHandler.OnForwardTrade"/>. Currently signals whether
+/// the print was executed during an auction phase (opening cross or pre-open /
+/// final-closing-call). Reserved bits are kept 0 for forward compatibility.
+/// </summary>
+[System.Flags]
+public enum TradeFlags : byte
+{
+    None = 0,
+    /// <summary>
+    /// Trade is an auction print: either <c>TradeCondition.OpeningPrice</c>
+    /// (opening / reopening cross) or the security's <c>TradingStatus</c> is in
+    /// an auction phase (<c>RESERVED</c> / <c>FINAL_CLOSING_CALL</c>) at the
+    /// time of the trade.
+    /// </summary>
+    AuctionPrint = 1,
+}
+
 public interface IBookEventHandler
 {
     void OnOrderAdded(OrderBook book, in OrderBookEntry entry);
@@ -27,9 +46,27 @@ public interface IBookEventHandler
 
     void OnMarketTierChanged(OrderBook book, BookSideType side, long totalQuantity, int orderCount) { }
     void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs);
+
+    /// <summary>
+    /// Flag-aware overload called by <c>BookManager</c>. Default implementation
+    /// forwards to the legacy <see cref="OnTrade(ulong,long,long,long,long)"/>
+    /// (dropping <paramref name="flags"/>) so existing implementers stay source-
+    /// and binary-compatible. Implementers that want to surface AuctionPrint
+    /// (or any future <see cref="TradeFlags"/> bit) override this overload.
+    /// </summary>
+    void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+        => OnTrade(securityId, price, quantity, tradeId, sendingTimeNs);
     void OnBookCleared(ulong securityId, BookClearSide side);
 
     void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs) { }
+
+    /// <summary>
+    /// Flag-aware overload for <see cref="OnForwardTrade(ulong,long,long,long,long)"/>.
+    /// Default implementation forwards to the legacy method, dropping
+    /// <paramref name="flags"/>.
+    /// </summary>
+    void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+        => OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs);
     void OnTradeBust(ulong securityId, long price, long quantity, long tradeId) { }
     void OnExecutionSummary(ulong securityId, long lastPx, long fillQty) { }
 

--- a/src/B3.Umdf.Server/GroupConflationHandler.cs
+++ b/src/B3.Umdf.Server/GroupConflationHandler.cs
@@ -23,7 +23,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
     private readonly Dictionary<ulong, BufferedOrder> _orderBuffer = new();
     private readonly Dictionary<(ulong SecurityId, byte Side), (long TotalQty, int OrderCount)> _marketTierBuffer = new();
     private readonly List<(ulong SecurityId, byte Side)> _clearBuffer = new();
-    private readonly Dictionary<(ulong SecurityId, long Price), (long Qty, long TradeId)> _tradeBuffer = new();
+    private readonly Dictionary<(ulong SecurityId, long Price), (long Qty, long TradeId, byte Flags)> _tradeBuffer = new();
     // Per-symbol stale-status flips. Coalesced per security:
     // multiple flips in the same batch collapse to the latest value.
     private readonly Dictionary<ulong, bool> _staleStatusBuffer = new();
@@ -270,7 +270,19 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
     }
 
     public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+        => OnTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
+
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
     {
+        // Hybrid AuctionPrint derivation (issue #46):
+        //   (a) BookManager already lit TradeFlags.AuctionPrint if the SBE
+        //       TradeCondition.OpeningPrice bit is set (opening / reopening cross).
+        //   (b) Here we additionally light it if the security's current
+        //       TradingStatus is an auction phase (RESERVED / FINAL_CLOSING_CALL)
+        //       at the time of the trade — covers intraday auctions that don't
+        //       carry the OpeningPrice bit on the print itself.
+        if (IsAuctionPhase(securityId)) flags |= TradeFlags.AuctionPrint;
+
         // Always-on work — needed by *future* subscribers, so it must run even
         // when no client is currently subscribed:
         //   • Candle aggregator: chart history would have gaps otherwise.
@@ -301,7 +313,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
         ring.Add(price, quantity, tradeId);
 
         _eventsReceived++;
-        BufferTrade(securityId, price, quantity, tradeId);
+        BufferTrade(securityId, price, quantity, tradeId, (byte)flags);
     }
 
     public void OnBookCleared(ulong securityId, BookClearSide side)
@@ -315,7 +327,12 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
     }
 
     public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+        => OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
+
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
     {
+        if (IsAuctionPhase(securityId)) flags |= TradeFlags.AuctionPrint;
+
         // Always-on aggregation (same rationale as OnTrade): candles + InfoSnapshot
         // last-price must be maintained for late subscribers.
         if (IsOpenPhase(securityId))
@@ -338,7 +355,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
         ring.Add(price, quantity, tradeId);
 
         _eventsReceived++;
-        BufferTrade(securityId, price, quantity, tradeId);
+        BufferTrade(securityId, price, quantity, tradeId, (byte)flags);
     }
 
     public void OnTradeBust(ulong securityId, long price, long quantity, long tradeId)
@@ -432,6 +449,20 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
     {
         if (!_tradingStatus.TryGetValue(securityId, out int status)) return true;
         return status == (int)TradingSessionSubID.OPEN;
+    }
+
+    /// <summary>
+    /// True when the security is currently in an auction phase
+    /// (<c>RESERVED</c> / <c>FINAL_CLOSING_CALL</c>). Used to derive
+    /// <see cref="TradeFlags.AuctionPrint"/> for trades that the upstream
+    /// SBE message did not flag with <c>TradeCondition.OpeningPrice</c>
+    /// (e.g. intraday auction prints).
+    /// </summary>
+    private bool IsAuctionPhase(ulong securityId)
+    {
+        if (!_tradingStatus.TryGetValue(securityId, out int status)) return false;
+        return status == (int)TradingSessionSubID.RESERVED
+            || status == (int)TradingSessionSubID.FINAL_CLOSING_CALL;
     }
 
     // ── IMarketDataEventHandler ──
@@ -837,14 +868,16 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
         slot = new BufferedOrder(PendingOrderKind.Deleted, securityId, side, 0, 0);
     }
 
-    private void BufferTrade(ulong securityId, long price, long quantity, long tradeId)
+    private void BufferTrade(ulong securityId, long price, long quantity, long tradeId, byte flags)
     {
         _tradesReceivedTotal++;
         ref var slot = ref CollectionsMarshal.GetValueRefOrAddDefault(_tradeBuffer, (securityId, price), out bool existed);
         if (existed)
-            slot = (slot.Qty + quantity, tradeId);
+            // Coalesce qty within (secId, price); OR flag bits so AuctionPrint
+            // sticks if any of the merged prints carried it.
+            slot = (slot.Qty + quantity, tradeId, (byte)(slot.Flags | flags));
         else
-            slot = (quantity, tradeId);
+            slot = (quantity, tradeId, flags);
     }
 
     private void PurgeBufferedOrders(ulong securityId, byte clearSide)
@@ -1086,9 +1119,9 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
             _scratchCandleSecIds.Add(secId);
 
         // Flush trades (Trades-flag opt-in routing)
-        foreach (var ((secId, price), (qty, tradeId)) in _tradeBuffer)
+        foreach (var ((secId, price), (qty, tradeId, flags)) in _tradeBuffer)
         {
-            int len = WireProtocol.WriteTrade(tmp, secId, price, qty, tradeId);
+            int len = WireProtocol.WriteTrade(tmp, secId, price, qty, tradeId, flags);
             AppendTradeEventToBatch(secId, tmp[..len], logicalCount: 1);
             flushed++;
         }

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -184,7 +184,7 @@ internal static class SnapshotEmitter
             // subscribers must not see busted trades in their initial history;
             // live subscribers receive the bust via MessageType.TradeBust.
             if (slot.Busted != 0) continue;
-            var buf = new byte[36];
+            var buf = new byte[37];
             int len = WireProtocol.WriteTrade(buf, securityId, slot.Price, slot.Qty, slot.TradeId);
             if (!session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len)))
                 return false;

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -297,16 +297,24 @@ public static class WireProtocol
         return totalLen;
     }
 
-    /// <summary>Write Trade: securityId, price, qty, tradeId.</summary>
-    public static int WriteTrade(Span<byte> dest, ulong securityId, long price, long qty, long tradeId)
+    /// <summary>
+    /// Write Trade: securityId, price, qty, tradeId, flags.
+    /// Wire layout: <c>[hdr 4][secId 8][price 8][qty 8][tradeId 8][flags 1]</c> = 37 bytes.
+    /// The trailing <paramref name="flags"/> byte (default 0) carries
+    /// <see cref="B3.Umdf.Book.TradeFlags"/> bits. Older clients that read the
+    /// previous 36-byte layout simply ignore the trailing byte — the framing
+    /// header always reports the true length so frame alignment stays intact.
+    /// </summary>
+    public static int WriteTrade(Span<byte> dest, ulong securityId, long price, long qty, long tradeId, byte flags = 0)
     {
-        const ushort totalLen = FramingHeaderSize + 8 + 8 + 8 + 8; // 36
+        const ushort totalLen = FramingHeaderSize + 8 + 8 + 8 + 8 + 1; // 37
         WriteFramingHeader(dest, totalLen, MessageType.Trade);
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
         BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], price); offset += 8;
         BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], qty); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], tradeId);
+        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], tradeId); offset += 8;
+        dest[offset] = flags;
         return totalLen;
     }
 

--- a/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
@@ -14,22 +14,52 @@ public class WireFormatTests
     public void Trade_RoundTrip_ScalesPriceWithSbeExponent()
     {
         // Encode a Trade frame the way the server would.
-        Span<byte> buf = stackalloc byte[36];
-        WriteServerTradeFrame(buf, securityId: 42, price: 12_3456, qty: 100, tradeId: 7);
+        Span<byte> buf = stackalloc byte[37];
+        WriteServerTradeFrame(buf, securityId: 42, price: 12_3456, qty: 100, tradeId: 7, flags: 0);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var len, out var type));
-        Assert.Equal(36, len);
+        Assert.Equal(37, len);
         Assert.Equal(WireFormat.MessageType.Trade, type);
 
-        var (secId, price, qty, tradeId) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
         Assert.Equal(42UL, secId);
         Assert.Equal(12_3456L, price);
         Assert.Equal(100L, qty);
         Assert.Equal(7L, tradeId);
+        Assert.Equal(TradeFlags.None, flags);
 
         // Scaling: raw 12_3456 with exponent -4 == 12.3456
         decimal scaled = price / WireFormat.PriceScale;
         Assert.Equal(12.3456m, scaled);
+    }
+
+    [Theory]
+    [InlineData(0, TradeFlags.None)]
+    [InlineData(1, TradeFlags.AuctionPrint)]
+    public void Trade_DecodesFlagsByte(byte raw, TradeFlags expected)
+    {
+        Span<byte> buf = stackalloc byte[37];
+        WriteServerTradeFrame(buf, securityId: 99, price: 1000, qty: 7, tradeId: 123, flags: raw);
+
+        var (_, _, _, _, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        Assert.Equal(expected, flags);
+    }
+
+    [Fact]
+    public void Trade_LegacyServer_OmittedFlagsByte_DefaultsToNone()
+    {
+        // Simulate an older server that wrote the 36-byte trade frame.
+        Span<byte> buf = stackalloc byte[36];
+        const ushort totalLen = 36;
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, totalLen);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.Trade);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 42UL);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[12..], 1000L);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[20..], 7L);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[28..], 123L);
+
+        var (_, _, _, _, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        Assert.Equal(TradeFlags.None, flags);
     }
 
     [Fact]
@@ -73,14 +103,15 @@ public class WireFormatTests
         Assert.Null(ev.VwapPrice);
     }
 
-    private static void WriteServerTradeFrame(Span<byte> dest, ulong securityId, long price, long qty, long tradeId)
+    private static void WriteServerTradeFrame(Span<byte> dest, ulong securityId, long price, long qty, long tradeId, byte flags)
     {
-        const ushort totalLen = 4 + 8 + 8 + 8 + 8;
+        const ushort totalLen = 4 + 8 + 8 + 8 + 8 + 1;
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)WireFormat.MessageType.Trade);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
         System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[12..], price);
         System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[20..], qty);
         System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[28..], tradeId);
+        dest[36] = flags;
     }
 }

--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
@@ -1,0 +1,207 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Reflection;
+using B3.Umdf.Book;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Pins the AuctionPrint derivation (issue #46): a trade is flagged with
+/// <see cref="TradeFlags.AuctionPrint"/> when either
+/// <list type="bullet">
+///   <item>the upstream SBE message carried <c>TradeCondition.OpeningPrice</c>
+///     (BookManager.HandleTrade emits the flag), or</item>
+///   <item>the security's current TradingStatus is <c>RESERVED</c> /
+///     <c>FINAL_CLOSING_CALL</c> (GroupConflationHandler augments the flag).</item>
+/// </list>
+/// Verified end-to-end through the BufferTrade → FlushTradeBuffer → WriteTrade
+/// pipeline so the flag survives all the way to the wire.
+/// </summary>
+public class GroupConflationHandlerAuctionPrintTests
+{
+    private const ulong SecurityId = 5001;
+    private const string Symbol = "AUC";
+
+    [Fact]
+    public void OnTrade_FlagFromBookManager_PropagatesToWireFrame()
+    {
+        var w = NewWiring();
+        try
+        {
+            SubscribeOne(w);
+
+            // Simulate BookManager calling the flagged overload because the
+            // SBE TradeCondition.OpeningPrice bit was set on the source message.
+            w.Group.OnTrade(SecurityId, price: 100, quantity: 5, tradeId: 1,
+                sendingTimeNs: 0, flags: TradeFlags.AuctionPrint);
+            w.Group.OnBatchComplete();
+
+            Assert.Equal(TradeFlags.AuctionPrint, LastWireFlags(w));
+        }
+        finally
+        {
+            w.Manager.Dispose();
+        }
+    }
+
+    [Fact]
+    public void OnTrade_RegularPhase_NoFlag()
+    {
+        var w = NewWiring();
+        try
+        {
+            SubscribeOne(w);
+            // Default phase: status unknown → IsAuctionPhase returns false.
+            w.Group.OnTrade(SecurityId, price: 100, quantity: 5, tradeId: 1, sendingTimeNs: 0);
+            w.Group.OnBatchComplete();
+
+            Assert.Equal(TradeFlags.None, LastWireFlags(w));
+        }
+        finally
+        {
+            w.Manager.Dispose();
+        }
+    }
+
+    [Theory]
+    [InlineData((int)TradingSessionSubID.RESERVED)]
+    [InlineData((int)TradingSessionSubID.FINAL_CLOSING_CALL)]
+    public void OnTrade_AuctionPhase_AddsFlag(int status)
+    {
+        var w = NewWiring();
+        try
+        {
+            SubscribeOne(w);
+            SetTradingStatus(w, status);
+
+            // Legacy overload, no upstream flag — handler must derive it from phase.
+            w.Group.OnTrade(SecurityId, price: 100, quantity: 5, tradeId: 1, sendingTimeNs: 0);
+            w.Group.OnBatchComplete();
+
+            Assert.Equal(TradeFlags.AuctionPrint, LastWireFlags(w));
+        }
+        finally
+        {
+            w.Manager.Dispose();
+        }
+    }
+
+    [Fact]
+    public void OnTrade_OpenPhase_NoFlag()
+    {
+        var w = NewWiring();
+        try
+        {
+            SubscribeOne(w);
+            SetTradingStatus(w, (int)TradingSessionSubID.OPEN);
+
+            w.Group.OnTrade(SecurityId, price: 100, quantity: 5, tradeId: 1, sendingTimeNs: 0);
+            w.Group.OnBatchComplete();
+
+            Assert.Equal(TradeFlags.None, LastWireFlags(w));
+        }
+        finally
+        {
+            w.Manager.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Conflation_AnyAuctionFlag_StickyAfterCoalescing()
+    {
+        var w = NewWiring();
+        try
+        {
+            SubscribeOne(w);
+
+            // Three trades at same (secId, price): middle one is auction; the
+            // OR-merge in BufferTrade must keep the flag set after coalescing.
+            w.Group.OnTrade(SecurityId, 100, 1, 1, 0, TradeFlags.None);
+            w.Group.OnTrade(SecurityId, 100, 1, 2, 0, TradeFlags.AuctionPrint);
+            w.Group.OnTrade(SecurityId, 100, 1, 3, 0, TradeFlags.None);
+            w.Group.OnBatchComplete();
+
+            Assert.Equal(TradeFlags.AuctionPrint, LastWireFlags(w));
+        }
+        finally
+        {
+            w.Manager.Dispose();
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static TradeFlags LastWireFlags((SubscriptionManager Manager, GroupConflationHandler Group,
+        BookManager BookManager, RecordingWebSocket Recorder) w)
+    {
+        // Wait for the broadcast — fall back to spinning on Test thread; the
+        // broadcaster runs in the background.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        byte[]? frame = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            frame = w.Recorder.LastFrame(MessageType.Trade);
+            if (frame is not null) break;
+            Thread.Sleep(10);
+        }
+        Assert.NotNull(frame);
+        Assert.Equal(37, frame!.Length);
+        return (TradeFlags)frame[36];
+    }
+
+    private static void SetTradingStatus((SubscriptionManager Manager, GroupConflationHandler Group,
+        BookManager BookManager, RecordingWebSocket Recorder) w, int status)
+    {
+        var info = new InstrumentInfo { TradingStatus = status };
+        w.Group.OnMarketDataUpdated(SecurityId, info);
+    }
+
+    private static (SubscriptionManager Manager, GroupConflationHandler Group, BookManager BookManager,
+        RecordingWebSocket Recorder) NewWiring()
+    {
+        var manager = new SubscriptionManager();
+        var group = manager.CreateGroupHandler();
+        group.StartBroadcaster(0);
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var staleBuffer = new StaleMboBuffer(NullLogger.Instance);
+        var book = new BookManager(stateRegistry: registry, staleBuffer: staleBuffer);
+        group.SetBookManager(book);
+
+        var symbols = new SymbolRegistry();
+        RegisterSymbol(symbols, Symbol, SecurityId);
+
+        manager.SetDataSources(
+            new[] { book },
+            new[] { new MarketDataManager(stateRegistry: registry) },
+            symbols,
+            new[] { group });
+        manager.SetReady();
+
+        return (manager, group, book, new RecordingWebSocket());
+    }
+
+    private static void SubscribeOne((SubscriptionManager Manager, GroupConflationHandler Group,
+        BookManager BookManager, RecordingWebSocket Recorder) w)
+    {
+        var session = new ClientSession(w.Recorder, channelCapacity: 64);
+        w.Manager.RegisterClient(session);
+        _ = Task.Run(() => session.RunWriteLoopAsync());
+        w.Manager.HandleSubscribe(session.Id, Symbol, DataFlags.Trades,
+            w.BookManager, w.Group, bookBatchCutoffSequence: 0);
+    }
+
+    private static void RegisterSymbol(SymbolRegistry registry, string symbol, ulong securityId)
+    {
+        var bySymbol = (ConcurrentDictionary<string, ulong>)typeof(SymbolRegistry)
+            .GetField("_bySymbol", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(registry)!;
+        var byId = (ConcurrentDictionary<ulong, string>)typeof(SymbolRegistry)
+            .GetField("_byId", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(registry)!;
+        bySymbol[symbol] = securityId;
+        byId[securityId] = symbol;
+    }
+}

--- a/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
@@ -100,16 +100,28 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteTrade(buf, securityId: 1001, price: 55_000L, qty: 100L, tradeId: 9876L);
 
-        Assert.Equal(36, len);
+        Assert.Equal(37, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(36, msgLen);
+        Assert.Equal(37, msgLen);
         Assert.Equal(MessageType.Trade, type);
 
         int off = 4;
         Assert.Equal(1001UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(55_000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(100L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
-        Assert.Equal(9876L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off)));
+        Assert.Equal(9876L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
+        Assert.Equal(0, buf[off]); // flags default
+    }
+
+    [Fact]
+    public void WriteTrade_WithAuctionFlag_RoundTrip()
+    {
+        var buf = new byte[64];
+        int len = WireProtocol.WriteTrade(buf, securityId: 1001, price: 55_000L, qty: 100L, tradeId: 9876L,
+            flags: (byte)TradeFlags.AuctionPrint);
+
+        Assert.Equal(37, len);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, buf[36]);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #46.

Implements **Option C (hybrid)** from the issue: BookManager lights `AuctionPrint` from the SBE `TradeCondition.OpeningPrice` bit, and `GroupConflationHandler` OR's it in when the symbol's current `TradingStatus` is `RESERVED` (21) or `FINAL_CLOSING_CALL` (101).

## Wire change (backwards-compatible)

Trade frame grows **36 → 37 bytes** with a trailing `byte flags`.

| Bit  | Name           | Value |
|------|----------------|-------|
| 0x01 | `AuctionPrint` | trade printed at an auction (opening / closing call / RESERVED) |

The framing header `[u16 length][u16 type]` always reports the true length, so:
- **Old server → new client:** payload is 32 bytes (post-header); `ReadTrade` detects `< 33` and returns `TradeFlags.None`.
- **New server → old client:** old decoder reads the first 32 body bytes and the next-frame offset = `length` correctly skips the trailing flags byte.

## Plumbing

- `IBookEventHandler`: new public `TradeFlags` enum + flag-aware `OnTrade` / `OnForwardTrade` overloads (default-impl forwards to legacy methods, mirroring the existing `OnPriceLevelChanged` pattern).
- `CompositeBookEventHandler`: explicit overrides for both flagged overloads — otherwise the default impl would forward to children's legacy methods and drop the flag.
- `GroupConflationHandler`: `_tradeBuffer` value type now carries flags; OR-merge on `(secId, price)` coalescing preserves the strongest signal (any auction print in the merged group → `AuctionPrint` set on the flushed frame).
- Client SDK: `TradeEvent` gains a `Flags` property (default `None`); `WireFormat.ReadTrade` auto-detects payload length.
- `frontend/js/protocol.js`: TRADE decoder reads the flag byte with the same legacy-length tolerance and surfaces `auctionPrint`.

## Caveat

`SnapshotEmitter` recent-trades replay carries `flags = 0` — the `TradeRingBuffer` slot doesn't store flags. Live trades after the snapshot carry the bit correctly. Documented in `docs/WEBSOCKET-PROTOCOL.md`; future enhancement if anyone needs historical AuctionPrint.

## Tests

- **+6** server tests pinning derivation + conflation OR-merge (`GroupConflationHandlerAuctionPrintTests`).
- **+3** client tests (legacy-tolerance + new flag round-trip theory).
- Updated `WireProtocolTests.WriteTrade_RoundTrip` to 37 bytes + added `WriteTrade_WithAuctionFlag_RoundTrip`.
- Full suite green: **676/676**.