### PR TITLE
feat(trade-history): preserve TradeFlags in recent-trades snapshot replay (closes #48)

### DIFF
--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -198,8 +198,9 @@ documented bit values rather than equality-checking the whole byte.
 Servers that predate the flag byte wrote the legacy 36-byte `Trade`
 frame; the framing header reports the true length, and decoders that
 read flags MUST treat absence as `0` (no flags set). Trade history
-frames replayed from the per-symbol recent-trades ring always carry
-`flags=0` (the ring does not persist per-trade flags).
+frames replayed from the per-symbol recent-trades ring preserve the
+per-trade flags captured at ingest time (each ring slot stores the
+flag byte alongside price/qty/tradeId).
 
 `MarketTierUpdate` represents B3 null-price MOA/MOC orders as an aggregate
 market tier per side. It is intentionally separate from priced order events:

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -60,9 +60,9 @@ public enum TradeFlags : byte
 /// the frame from the WebSocket. Not the exchange match time.</param>
 /// <param name="Flags">Per-trade flag bitset — see <see cref="TradeFlags"/>.
 /// <see cref="TradeFlags.None"/> when the server pre-dates the flag byte
-/// (the SDK auto-detects payload length and defaults to <c>None</c>) or
-/// for trades replayed from the server's recent-trades snapshot, which
-/// does not carry flags.</param>
+/// (the SDK auto-detects payload length and defaults to <c>None</c>).
+/// Trades replayed from the server's recent-trades snapshot preserve the
+/// per-trade flags captured at ingest time.</param>
 public readonly record struct TradeEvent(
     ulong SecurityId,
     string Symbol,

--- a/src/B3.Umdf.Book/TradeRingBuffer.cs
+++ b/src/B3.Umdf.Book/TradeRingBuffer.cs
@@ -3,6 +3,9 @@ namespace B3.Umdf.Book;
 /// <summary>
 /// One slot in <see cref="TradeRingBuffer"/>. <see cref="Busted"/> is set when a
 /// later TradeBust_57 cancels this trade — see B3 BinaryUMDF v2.2.0 spec §10.
+/// <see cref="Flags"/> mirrors the wire-level <c>TradeFlags</c> bitset (e.g.
+/// <c>AuctionPrint</c>) so the snapshot history can faithfully replay the bit
+/// to late subscribers.
 /// </summary>
 internal struct TradeSlot
 {
@@ -10,6 +13,7 @@ internal struct TradeSlot
     public long Qty;
     public long TradeId;
     public byte Busted;
+    public byte Flags;
 }
 
 /// <summary>Fixed-capacity ring buffer of recent trades for a single security.</summary>
@@ -26,9 +30,9 @@ internal sealed class TradeRingBuffer
 
     public TradeRingBuffer(int capacity) => _buf = new TradeSlot[capacity];
 
-    public void Add(long price, long qty, long tradeId)
+    public void Add(long price, long qty, long tradeId, byte flags = 0)
     {
-        _buf[_head] = new TradeSlot { Price = price, Qty = qty, TradeId = tradeId, Busted = 0 };
+        _buf[_head] = new TradeSlot { Price = price, Qty = qty, TradeId = tradeId, Busted = 0, Flags = flags };
         _head = (_head + 1) % _buf.Length;
         if (_count < _buf.Length) _count++;
         _version++;

--- a/src/B3.Umdf.Server/GroupConflationHandler.cs
+++ b/src/B3.Umdf.Server/GroupConflationHandler.cs
@@ -307,10 +307,12 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
         if (!_parent.IsSubscribed(securityId)) return;
 
         // Capture trade in the per-security ring (snapshot history for future
-        // subscribers that arrive while the symbol is warm).
+        // subscribers that arrive while the symbol is warm). Flags are stamped
+        // into the slot so SnapshotEmitter.SendTradeHistory replays the
+        // AuctionPrint bit instead of defaulting to None.
         var ring = RecentTrades.GetOrAdd(securityId,
             static _ => new TradeRingBuffer(SubscriptionManager.MaxRecentTrades));
-        ring.Add(price, quantity, tradeId);
+        ring.Add(price, quantity, tradeId, (byte)flags);
 
         _eventsReceived++;
         BufferTrade(securityId, price, quantity, tradeId, (byte)flags);
@@ -352,7 +354,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
 
         var ring = RecentTrades.GetOrAdd(securityId,
             static _ => new TradeRingBuffer(SubscriptionManager.MaxRecentTrades));
-        ring.Add(price, quantity, tradeId);
+        ring.Add(price, quantity, tradeId, (byte)flags);
 
         _eventsReceived++;
         BufferTrade(securityId, price, quantity, tradeId, (byte)flags);

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -185,7 +185,7 @@ internal static class SnapshotEmitter
             // live subscribers receive the bust via MessageType.TradeBust.
             if (slot.Busted != 0) continue;
             var buf = new byte[37];
-            int len = WireProtocol.WriteTrade(buf, securityId, slot.Price, slot.Qty, slot.TradeId);
+            int len = WireProtocol.WriteTrade(buf, securityId, slot.Price, slot.Qty, slot.TradeId, slot.Flags);
             if (!session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len)))
                 return false;
         }

--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
@@ -378,4 +378,18 @@ internal sealed class RecordingWebSocket : WebSocket
             return null;
         }
     }
+
+    public List<byte[]> AllFrames(MessageType t)
+    {
+        lock (_lock)
+        {
+            var result = new List<byte[]>();
+            foreach (var f in _frames)
+            {
+                if (f.Length >= 4 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(2)) == t)
+                    result.Add(f);
+            }
+            return result;
+        }
+    }
 }

--- a/tests/B3.Umdf.Server.Tests/TradeHistoryFlagsTests.cs
+++ b/tests/B3.Umdf.Server.Tests/TradeHistoryFlagsTests.cs
@@ -1,0 +1,81 @@
+using B3.Umdf.Book;
+using B3.Umdf.Server;
+
+namespace B3.Umdf.Server.Tests;
+
+/// <summary>
+/// Pins issue #48: per-trade <see cref="TradeFlags"/> survive the
+/// recent-trades snapshot replay path. The <see cref="TradeRingBuffer"/>
+/// slot stores the flag byte and <see cref="SnapshotEmitter.SendTradeHistory"/>
+/// writes it into the replayed Trade frame (offset 36 = trailing flags byte).
+/// </summary>
+public class TradeHistoryFlagsTests
+{
+    [Fact]
+    public void TradeRingBuffer_Add_RoundTripsFlags()
+    {
+        var ring = new TradeRingBuffer(4);
+        ring.Add(price: 100, qty: 1, tradeId: 1, flags: (byte)TradeFlags.None);
+        ring.Add(price: 101, qty: 2, tradeId: 2, flags: (byte)TradeFlags.AuctionPrint);
+        ring.Add(price: 102, qty: 3, tradeId: 3, flags: 0xFF); // future bits preserved verbatim
+
+        var slots = ring.AsSpan();
+        Assert.Equal(3, slots.Length);
+        Assert.Equal(0, slots[0].Flags);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, slots[1].Flags);
+        Assert.Equal(0xFF, slots[2].Flags);
+    }
+
+    [Fact]
+    public void TradeRingBuffer_Add_DefaultsFlagsToZero()
+    {
+        // Optional-parameter back-compat: existing callers that don't supply
+        // flags must still get a zero-initialized slot.
+        var ring = new TradeRingBuffer(2);
+        ring.Add(price: 100, qty: 1, tradeId: 1);
+        Assert.Equal(0, ring.AsSpan()[0].Flags);
+    }
+
+    [Fact]
+    public async Task SnapshotEmitter_SendTradeHistory_EmitsFlagsByte()
+    {
+        // Direct test: populate a ring with mixed flags, replay through
+        // SnapshotEmitter, and assert each Trade frame carries the slot's
+        // flag byte at offset 36 (the trailing flags byte added in #47).
+        const ulong SecurityId = 7777;
+        var ring = new TradeRingBuffer(4);
+        ring.Add(price: 100, qty: 1, tradeId: 10, flags: (byte)TradeFlags.None);
+        ring.Add(price: 101, qty: 2, tradeId: 11, flags: (byte)TradeFlags.AuctionPrint);
+        ring.Add(price: 102, qty: 3, tradeId: 12, flags: (byte)TradeFlags.AuctionPrint);
+
+        var recorder = new RecordingWebSocket();
+        var session = new ClientSession(recorder, channelCapacity: 16);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var writeLoop = Task.Run(() => session.RunWriteLoopAsync());
+
+        Assert.True(SnapshotEmitter.SendTradeHistory(session, SecurityId, ring));
+
+        // Drain: wait until all 3 Trade frames are flushed to the recorder.
+        await WaitUntil(() => recorder.CountByType(MessageType.Trade) >= 3, TimeSpan.FromSeconds(2));
+        session.Dispose();
+        await writeLoop;
+
+        Assert.Equal(3, recorder.CountByType(MessageType.Trade));
+        var frames = recorder.AllFrames(MessageType.Trade);
+        Assert.All(frames, f => Assert.Equal(37, f.Length));
+        Assert.Equal(0, frames[0][36]);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[1][36]);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[2][36]);
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(10);
+        }
+        Assert.True(predicate(), "timed out waiting for predicate");
+    }
+}


### PR DESCRIPTION
Closes #48.

> Recriado depois que #49 foi auto-fechado pela deleção do branch base `feat/auction-print-trade-flag` (que era a stack do PR original — agora mergiado via #47). Cherry-pick limpo do commit `988b25e` sobre `main`.

## What

Adds a `Flags` byte to `TradeSlot` so the per-security recent-trades ring faithfully replays the `AuctionPrint` bit (and any future `TradeFlags` bit) to late subscribers, instead of defaulting to `TradeFlags.None`.

## Changes

- `TradeRingBuffer.Add` gains an optional `byte flags = 0` parameter; new `TradeSlot.Flags` field stores it.
- `GroupConflationHandler.OnTrade` / `OnForwardTrade` thread the derived flags into `ring.Add` (already threading them into `BufferTrade` for the live tape).
- `SnapshotEmitter.SendTradeHistory` passes `slot.Flags` through to `WriteTrade` (was hard-coded `0`).
- Docs (`WEBSOCKET-PROTOCOL.md` + `TradeEvent.Flags` XML doc) updated to remove the prior 'history always carries flags=0' caveat.

## Backwards-compat

- Wire layout unchanged — `WriteTrade` already accepted a flags byte since #47; this just changes the value the server emits.
- `TradeRingBuffer.Add`'s flags parameter is optional — existing callers (`SymbolTradeState.AddTrade` for bust reversal + ring unit tests) continue to compile and default to `flags=0`.

## Tests

**+3** in new `TradeHistoryFlagsTests`:
- Ring round-trip (mixed flags incl. `0xFF` to pin verbatim preservation).
- Optional-param back-compat (omitted `flags` → slot `Flags == 0`).
- End-to-end `SnapshotEmitter.SendTradeHistory` → `RecordingWebSocket` → assertion on trailing flag byte (offset 36) of each replayed Trade frame.

Also added `RecordingWebSocket.AllFrames(MessageType)` helper for multi-frame inspection.

Full suite green: **679/679**.