### PR TITLE
tools: BookFeedLoadHarness + Phase 2 baseline

### DIFF
--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -19,6 +19,7 @@
     <Project Path="tools/InboundLatencyProbe/InboundLatencyProbe.csproj" />
     <Project Path="tools/PerfBaselineCompare/PerfBaselineCompare.csproj" />
     <Project Path="tools/PerfBaselineCompare.Tests/PerfBaselineCompare.Tests.csproj" />
+    <Project Path="tools/BookFeedLoadHarness/BookFeedLoadHarness.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/B3.MarketData.WebSocketClient.Tests/B3.MarketData.WebSocketClient.Tests.csproj" />

--- a/docs/perf/bookfeed-baseline.md
+++ b/docs/perf/bookfeed-baseline.md
@@ -7,43 +7,65 @@ was `tools/BookFeedLoadHarness` subscribing all 16 with `SubscribeFlags.Book`.
 ## Headline
 
 The client-side `BookFeed` is **not the bottleneck under realistic B3 traffic** — by
-3 orders of magnitude. The server's per-`(secId, side, price)` conflation flattens
-~22M raw MBO ops into ~125k WebSocket frames (≈175× ratio), so even hot symbols feed
-the SDK at hundreds of events/sec, not tens of thousands.
+3+ orders of magnitude. Under sustained 3,200 events/s the harness consumed **1.5% of
+one CPU core** and our SDK code accounted for **<0.05% of total CPU samples**
+(≤100 of 226,883 samples over 30s). Every measurable hotspot is `Monitor.Enter_Slowpath`
+on internal channel locks; `BookView`'s apply paths register as 1–3 samples each.
 
-## Server (1m48s of pcap @ 50×)
+## Measurement note
+
+The first run used `--speed 50` which compresses inter-burst gaps but preserves them —
+the client saw long idle stretches between hot windows (~58/s mean, 270/s peak). That
+under-represents how the `BookView` data structures actually sit under sustained load.
+The numbers below come from `--speed 5`, which keeps timestamps realistic but ensures
+a continuous stream of MBO events during the measurement window.
+
+## Server (DRV-072 pcap @ 5×, 1m of capture window)
+
+Per-(secId, side, price) conflation in `GroupConflationHandler` flattens dispatcher
+throughput (hundreds of thousands of order ops/s) into hundreds–thousands of WS frames/s
+per group. The harness window saw 277k WS `Changed` events for 16 symbols (mini-index
+futures: WIN/WI1/TF0).
+
+## Client (120s harness window, 16 symbols subscribed)
 
 | metric | value |
 | --- | --- |
-| dispatcher throughput | 420k pkts/s avg, ~490k peak |
-| order adds | 10,601,720 |
-| order updates | 1,312,022 |
-| order deletes | 10,390,417 |
-| trades parsed (SBE) | 5,836,333 |
-| trades emitted (WS) | 88,414 |
-| **conflated frames emitted (WS, all groups)** | **125,473** |
-
-## Client (60s harness window, 16 symbols subscribed)
-
-| metric | value |
-| --- | --- |
-| `BookFeed.Changed` invocations | 3,494 total (~58/s mean, 270/s peak) |
-| `BookSnapshot` events | 151 |
-| unique symbols touched | 11 / 16 |
-| process CPU | 0.9% |
-| working set | 76 MB |
-| GC heap size | 1.4 MB |
-| Gen0 collections in 40s | 1 (1.4ms pause) |
+| `BookFeed.Changed` invocations | 277,065 total (~2,309/s mean, **~3,200/s sustained** for first 42s, then ~1,600/s) |
+| `BookSnapshot` events | 16 (one per subscribed symbol) |
+| unique symbols touched | 16 / 16 |
+| process CPU (under 3,200/s load) | **1.5%** |
+| working set | 74 MB |
+| GC heap size | 1.17 MB (stable) |
+| Gen0 collections in 30s | 8 (max pause 1.5ms, total **5.5ms** = 0.018% time-in-GC) |
 | Gen1 / Gen2 collections | 0 / 0 |
 | monitor lock contention | 0 |
-| alloc rate | 235 KB/s |
+| exceptions | 0 |
+| alloc rate | 1.17 MB/s |
+
+## CPU sample breakdown (30s window during sustained 3,200/s)
+
+Sampled 226,883 frames. Every top-15 hotspot is runtime infrastructure (idle
+threadpool wait, semaphore, epoll, TimerThread). Drilling into our code:
+
+| stack | inclusive samples | % of total |
+| --- | --- | --- |
+| `MarketDataClient.ReceiveLoopAsync` (decode + enqueue) | 79 | 0.035% |
+|   ↳ `BoundedChannel.TryWrite → Monitor.Enter_Slowpath` | 36 | 0.016% |
+| `MarketDataClient.DispatchLoopAsync` (handler invoke) | 18 | 0.008% |
+|   ↳ `BookView.ApplyCleared` | 3 | 0.001% |
+|   ↳ `BookFeed.OnAdded → BookView.ApplyAdded → Dictionary.set_Item` | 1 | <0.001% |
+
+The lone non-runtime hotspot is the SDK's internal `BoundedChannel` between receive
+and dispatch — and even that is 0.016% of CPU.
 
 ## Implication for issue #43 Phase 2
 
 The original planning comment asked for a "performance gate" (p50/p99 on hot
 symbols) before shipping depth>1 + sorted structures. Empirically that gate is
 trivially met by any reasonable implementation — even a `SortedDictionary<decimal,
-SideBucket>` would be operating at <1% of headroom.
+SideBucket>` would be operating at <1% of headroom, since the existing
+`Dictionary`-based `BookView` already takes 1–3 samples out of 226,883 (<0.001%).
 
 Reframe Phase 2 as **API / functional completeness** (depth>1 views, zero-alloc
 `CopyLevels(Span<L2Level>)`, eviction policy), not performance. Microbenchmarks in
@@ -56,9 +78,11 @@ regression detection, but they're not blockers.
 # 1) Build
 dotnet build -c Release
 
-# 2) Start server replaying DRV pcap at 50× speed with WS on 8080
+# 2) Start server replaying DRV pcap at 5× speed with WS on 8080
+#    (5× compresses the timeline enough to keep a continuous event stream
+#     during the measurement window, without distorting the burst shape)
 dotnet src/B3.Umdf.ConsoleApp/bin/Release/net10.0/B3.Umdf.ConsoleApp.dll \
-  --ws-port 8080 --speed 50 \
+  --ws-port 8080 --speed 5 \
   pcap/20250929_MBO_072_DRV_Incremental_FeedA.pcap \
   pcap/20250929_MBO_072_DRV_Incremental_FeedB.pcap \
   pcap/20250929_MBO_072_DRV_InstrumentDefinition.pcap \
@@ -66,8 +90,10 @@ dotnet src/B3.Umdf.ConsoleApp/bin/Release/net10.0/B3.Umdf.ConsoleApp.dll \
 
 # 3) Run harness — discovers symbols via GET /symbols, subscribes Book, counts
 dotnet tools/BookFeedLoadHarness/bin/Release/net10.0/bookfeed-load-harness.dll \
-  --duration 60 --warmup 5
+  --duration 120 --warmup 5
 ```
 
-Attach `dotnet-diagnostics` (snapshot_counters / collect_cpu_sample / collect_gc_events)
-to the harness PID printed at startup for runtime metrics.
+Attach `dotnet-diagnostics` (`snapshot_counters` / `collect_cpu_sample` /
+`collect_gc_events`) to the harness PID printed at startup. The CPU sample drill-down
+that produced the breakdown above used `get_call_tree` with
+`rootMethodFilter=MarketDataClient` and `rootMethodFilter=DispatchLoop`.

--- a/docs/perf/bookfeed-baseline.md
+++ b/docs/perf/bookfeed-baseline.md
@@ -1,0 +1,73 @@
+# BookFeed (Phase 1) — empirical baseline
+
+Captured 2026-05-20 against `B3.Umdf.ConsoleApp --ws-port 8080 --speed 50` replaying
+`pcap/20250929_MBO_072_DRV_*.pcap` (16 mini-index futures: WIN/WI1/TF0). Client side
+was `tools/BookFeedLoadHarness` subscribing all 16 with `SubscribeFlags.Book`.
+
+## Headline
+
+The client-side `BookFeed` is **not the bottleneck under realistic B3 traffic** — by
+3 orders of magnitude. The server's per-`(secId, side, price)` conflation flattens
+~22M raw MBO ops into ~125k WebSocket frames (≈175× ratio), so even hot symbols feed
+the SDK at hundreds of events/sec, not tens of thousands.
+
+## Server (1m48s of pcap @ 50×)
+
+| metric | value |
+| --- | --- |
+| dispatcher throughput | 420k pkts/s avg, ~490k peak |
+| order adds | 10,601,720 |
+| order updates | 1,312,022 |
+| order deletes | 10,390,417 |
+| trades parsed (SBE) | 5,836,333 |
+| trades emitted (WS) | 88,414 |
+| **conflated frames emitted (WS, all groups)** | **125,473** |
+
+## Client (60s harness window, 16 symbols subscribed)
+
+| metric | value |
+| --- | --- |
+| `BookFeed.Changed` invocations | 3,494 total (~58/s mean, 270/s peak) |
+| `BookSnapshot` events | 151 |
+| unique symbols touched | 11 / 16 |
+| process CPU | 0.9% |
+| working set | 76 MB |
+| GC heap size | 1.4 MB |
+| Gen0 collections in 40s | 1 (1.4ms pause) |
+| Gen1 / Gen2 collections | 0 / 0 |
+| monitor lock contention | 0 |
+| alloc rate | 235 KB/s |
+
+## Implication for issue #43 Phase 2
+
+The original planning comment asked for a "performance gate" (p50/p99 on hot
+symbols) before shipping depth>1 + sorted structures. Empirically that gate is
+trivially met by any reasonable implementation — even a `SortedDictionary<decimal,
+SideBucket>` would be operating at <1% of headroom.
+
+Reframe Phase 2 as **API / functional completeness** (depth>1 views, zero-alloc
+`CopyLevels(Span<L2Level>)`, eviction policy), not performance. Microbenchmarks in
+`benchmarks/` should still cover the data-structure choice for documentation and
+regression detection, but they're not blockers.
+
+## How to reproduce
+
+```sh
+# 1) Build
+dotnet build -c Release
+
+# 2) Start server replaying DRV pcap at 50× speed with WS on 8080
+dotnet src/B3.Umdf.ConsoleApp/bin/Release/net10.0/B3.Umdf.ConsoleApp.dll \
+  --ws-port 8080 --speed 50 \
+  pcap/20250929_MBO_072_DRV_Incremental_FeedA.pcap \
+  pcap/20250929_MBO_072_DRV_Incremental_FeedB.pcap \
+  pcap/20250929_MBO_072_DRV_InstrumentDefinition.pcap \
+  pcap/20250929_MBO_072_DRV_SnapshotRecovery.pcap &
+
+# 3) Run harness — discovers symbols via GET /symbols, subscribes Book, counts
+dotnet tools/BookFeedLoadHarness/bin/Release/net10.0/bookfeed-load-harness.dll \
+  --duration 60 --warmup 5
+```
+
+Attach `dotnet-diagnostics` (snapshot_counters / collect_cpu_sample / collect_gc_events)
+to the harness PID printed at startup for runtime metrics.

--- a/tools/BookFeedLoadHarness/BookFeedLoadHarness.csproj
+++ b/tools/BookFeedLoadHarness/BookFeedLoadHarness.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>B3.MarketData.Tools.BookFeedLoadHarness</RootNamespace>
+    <AssemblyName>bookfeed-load-harness</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+    <TieredPGO>true</TieredPGO>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.MarketData.WebSocketClient\B3.MarketData.WebSocketClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/BookFeedLoadHarness/Program.cs
+++ b/tools/BookFeedLoadHarness/Program.cs
@@ -1,0 +1,228 @@
+using System.Diagnostics.Tracing;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using B3.MarketData.WebSocketClient;
+
+namespace B3.MarketData.Tools.BookFeedLoadHarness;
+
+/// <summary>
+/// Client-side load harness that drives <see cref="BookFeed"/> against a live
+/// server (typically the <c>B3.Umdf.ConsoleApp</c> replaying a PCAP). Designed
+/// to be the target process for <c>dotnet-diagnostics-mcp</c> when measuring
+/// the SDK's materialized-book layer.
+///
+/// The harness publishes per-second counters via the <c>B3.BookFeedHarness</c>
+/// EventSource so <c>dotnet-counters monitor</c> / EventPipe consumers can see
+/// throughput without parsing console output. Connect to the server, discover
+/// the top symbols via <c>GET /symbols</c>, subscribe with
+/// <see cref="SubscribeFlags.Book"/>, then count every <c>BookFeed.Changed</c>
+/// invocation.
+/// </summary>
+internal static class Program
+{
+    private static long s_changedCount;
+    private static long s_snapshotCount;
+    private static long s_uniqueSymbols;
+    private static long s_topReadCount;
+
+    public static async Task<int> Main(string[] args)
+    {
+        var opts = HarnessOptions.Parse(args);
+        Console.WriteLine($"[harness] endpoint={opts.Endpoint} http={opts.HttpBase} symbols={(opts.Symbols.Length == 0 ? $"discover top {opts.DiscoverTop}" : string.Join(",", opts.Symbols))} duration={opts.DurationSeconds}s topReadHz={opts.TopReadHz} pid={Environment.ProcessId}");
+
+        var symbols = opts.Symbols;
+        if (symbols.Length == 0)
+        {
+            symbols = await DiscoverSymbolsAsync(opts.HttpBase, opts.DiscoverTop).ConfigureAwait(false);
+            Console.WriteLine($"[harness] discovered {symbols.Length} symbols: {string.Join(",", symbols)}");
+        }
+
+        if (symbols.Length == 0)
+        {
+            Console.Error.WriteLine("[harness] no symbols to subscribe — aborting");
+            return 2;
+        }
+
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = opts.Endpoint,
+            EventChannelCapacity = 16_384,
+        });
+
+        var bookFeed = client.CreateBookFeed();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        bookFeed.Changed += sym =>
+        {
+            Interlocked.Increment(ref s_changedCount);
+            lock (seen)
+            {
+                if (seen.Add(sym))
+                    Interlocked.Exchange(ref s_uniqueSymbols, seen.Count);
+            }
+        };
+        client.BookSnapshot += _ => Interlocked.Increment(ref s_snapshotCount);
+
+        using var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
+
+        await client.ConnectAsync(cts.Token).ConfigureAwait(false);
+        Console.WriteLine("[harness] connected");
+
+        foreach (var symbol in symbols)
+        {
+            try
+            {
+                await client.SubscribeAsync(symbol, SubscribeFlags.Book, cts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[harness] subscribe {symbol} failed: {ex.Message}");
+            }
+        }
+
+        Console.WriteLine($"[harness] subscribed {symbols.Length} symbols — warming up {opts.WarmupSeconds}s");
+        try { await Task.Delay(TimeSpan.FromSeconds(opts.WarmupSeconds), cts.Token).ConfigureAwait(false); }
+        catch (OperationCanceledException) { return 0; }
+
+        var topReadTask = opts.TopReadHz > 0
+            ? Task.Run(() => HotPathLoop(bookFeed, symbols, opts.TopReadHz, cts.Token))
+            : Task.CompletedTask;
+
+        var reporter = Task.Run(() => ReportLoop(cts.Token));
+
+        try { await Task.Delay(TimeSpan.FromSeconds(opts.DurationSeconds), cts.Token).ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+
+        cts.Cancel();
+        try { await topReadTask.ConfigureAwait(false); } catch { }
+        try { await reporter.ConfigureAwait(false); } catch { }
+
+        Console.WriteLine($"[harness] done — changed={s_changedCount} snapshots={s_snapshotCount} uniqueSymbols={s_uniqueSymbols} topReads={s_topReadCount}");
+        return 0;
+    }
+
+    private static async Task HotPathLoop(BookFeed feed, string[] symbols, int hz, CancellationToken ct)
+    {
+        var delayMs = Math.Max(1, 1000 / hz);
+        var i = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            var symbol = symbols[i++ % symbols.Length];
+            if (feed.TryGetTop(symbol, out _))
+                Interlocked.Increment(ref s_topReadCount);
+            try { await Task.Delay(delayMs, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
+
+    private static async Task ReportLoop(CancellationToken ct)
+    {
+        long prevChanged = 0;
+        long prevSnapshots = 0;
+        long prevTopReads = 0;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(1000, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+
+            var changed = Interlocked.Read(ref s_changedCount);
+            var snaps = Interlocked.Read(ref s_snapshotCount);
+            var tops = Interlocked.Read(ref s_topReadCount);
+            var uniq = Interlocked.Read(ref s_uniqueSymbols);
+
+            HarnessEventSource.Log.Tick(changed - prevChanged, snaps - prevSnapshots, tops - prevTopReads, uniq);
+
+            Console.WriteLine($"[harness {sw.Elapsed:mm\\:ss}] changed/s={changed - prevChanged} snaps/s={snaps - prevSnapshots} topReads/s={tops - prevTopReads} uniqSymbols={uniq}");
+            prevChanged = changed;
+            prevSnapshots = snaps;
+            prevTopReads = tops;
+        }
+    }
+
+    private static async Task<string[]> DiscoverSymbolsAsync(Uri httpBase, int top)
+    {
+        using var http = new HttpClient { BaseAddress = httpBase, Timeout = TimeSpan.FromSeconds(5) };
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            try
+            {
+                var resp = await http.GetFromJsonAsync($"/symbols?limit={top}", SymbolsContext.Default.SymbolsResponse).ConfigureAwait(false);
+                if (resp?.Symbols is { Length: > 0 } sy) return sy;
+            }
+            catch { /* server still warming */ }
+            await Task.Delay(500).ConfigureAwait(false);
+        }
+        return Array.Empty<string>();
+    }
+}
+
+internal sealed record HarnessOptions(
+    Uri Endpoint,
+    Uri HttpBase,
+    string[] Symbols,
+    int DiscoverTop,
+    int DurationSeconds,
+    int WarmupSeconds,
+    int TopReadHz)
+{
+    public static HarnessOptions Parse(string[] args)
+    {
+        var endpoint = new Uri("ws://localhost:8080/ws");
+        var httpBase = new Uri("http://localhost:8080");
+        string[] symbols = Array.Empty<string>();
+        var top = 25;
+        var duration = 30;
+        var warmup = 3;
+        var topHz = 0;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var a = args[i];
+            string Next() => ++i < args.Length ? args[i] : throw new ArgumentException($"missing value for {a}");
+            switch (a)
+            {
+                case "--endpoint": endpoint = new Uri(Next()); break;
+                case "--http": httpBase = new Uri(Next()); break;
+                case "--symbols": symbols = Next().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries); break;
+                case "--top": top = int.Parse(Next()); break;
+                case "--duration": duration = int.Parse(Next()); break;
+                case "--warmup": warmup = int.Parse(Next()); break;
+                case "--top-read-hz": topHz = int.Parse(Next()); break;
+                case "-h" or "--help":
+                    Console.WriteLine("BookFeedLoadHarness — drives BookFeed against a live B3 server\n" +
+                        "  --endpoint <ws-uri>     default ws://localhost:8080/ws\n" +
+                        "  --http <http-uri>       default http://localhost:8080 (for /symbols discovery)\n" +
+                        "  --symbols A,B,C         explicit list; if omitted, discover via GET /symbols\n" +
+                        "  --top N                 discovery limit (default 25)\n" +
+                        "  --duration N            measurement window in seconds (default 30)\n" +
+                        "  --warmup N              warmup before counters start (default 3)\n" +
+                        "  --top-read-hz N         optional hot-path TryGetTop reads per second (default 0)\n");
+                    Environment.Exit(0); break;
+                default: throw new ArgumentException($"unknown arg {a}");
+            }
+        }
+        return new HarnessOptions(endpoint, httpBase, symbols, top, duration, warmup, topHz);
+    }
+}
+
+internal sealed class SymbolsResponse
+{
+    public int Count { get; set; }
+    public int Matched { get; set; }
+    public string[] Symbols { get; set; } = Array.Empty<string>();
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(SymbolsResponse))]
+internal sealed partial class SymbolsContext : JsonSerializerContext { }
+
+[EventSource(Name = "B3.BookFeedHarness")]
+internal sealed class HarnessEventSource : EventSource
+{
+    public static readonly HarnessEventSource Log = new();
+
+    [Event(1, Level = EventLevel.Informational)]
+    public void Tick(long changedPerSec, long snapshotsPerSec, long topReadsPerSec, long uniqueSymbols)
+        => WriteEvent(1, changedPerSec, snapshotsPerSec, topReadsPerSec, uniqueSymbols);
+}


### PR DESCRIPTION
Adds `tools/BookFeedLoadHarness` — a small console app that drives `BookFeed` against a live server (typically `B3.Umdf.ConsoleApp` replaying a PCAP). Intended target process for `dotnet-diagnostics` when measuring the SDK's materialized-book layer.

**Baseline finding (docs/perf/bookfeed-baseline.md):** under realistic B3 traffic (DRV-072 pcap @ 50×, 16 WIN/TF0 futures), the server's per-(secId, side, price) conflation flattens ~22M raw MBO ops into ~125k WS frames (≈175× ratio). The client sees ~58 \`Changed\`/s mean, 270/s peak, runs at 0.9% CPU, 1.4MB heap, 1 Gen0 GC in 40s. **BookFeed is not CPU-bound by 2–3 orders of magnitude.**

Implication for #43: Phase 2 (depth>1 + zero-alloc \`CopyLevels\` + eviction) should be motivated by API completeness, not performance. A simple \`SortedDictionary<decimal, ...>\` will sail through the gate; no need for skiplist/sorted-array micro-optimizations.

### How to reproduce
\`\`\`sh
dotnet src/B3.Umdf.ConsoleApp/bin/Release/net10.0/B3.Umdf.ConsoleApp.dll \\
  --ws-port 8080 --speed 50 pcap/20250929_MBO_072_DRV_*.pcap &
dotnet tools/BookFeedLoadHarness/bin/Release/net10.0/bookfeed-load-harness.dll \\
  --duration 60 --warmup 5
\`\`\`
Attach \`dotnet-diagnostics\` to the harness PID printed at startup.

### Refs
- Issue #43