### PR TITLE
feat(BookFeed): Phase 2 — depth-N CopyLevels, sorted state, auto-evict (closes #52)

### DIFF
--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -7,7 +7,7 @@
     <!-- Packaging -->
     <IsPackable>true</IsPackable>
     <PackageId>B3.MarketData.WebSocketClient</PackageId>
-    <Version Condition="'$(PackageVersion)' == ''">0.3.0</Version>
+    <Version Condition="'$(PackageVersion)' == ''">0.4.0</Version>
     <Authors>pedrosakuma</Authors>
     <Description>Typed C# subscriber SDK for the B3MarketDataPlatform WebSocket distribution layer (v1: trades, info snapshots, server status). Built-in reconnect with transparent re-subscribe and bounded back-pressure.</Description>
     <PackageTags>b3;marketdata;websocket;sdk;trades;reference-price</PackageTags>

--- a/src/B3.MarketData.WebSocketClient/BookFeed.cs
+++ b/src/B3.MarketData.WebSocketClient/BookFeed.cs
@@ -57,6 +57,7 @@ public sealed class BookFeed : IBookFeed, IDisposable
     private readonly Action<OrderDeletedEvent> _onDel;
     private readonly Action<BookClearedEvent> _onClr;
     private readonly Action<SymbolStaleStatusEvent> _onStale;
+    private readonly Action<UnsubscribedEvent> _onUnsubscribed;
     private int _disposed;
 
     /// <inheritdoc/>
@@ -71,12 +72,14 @@ public sealed class BookFeed : IBookFeed, IDisposable
         _onDel = OnDeleted;
         _onClr = OnCleared;
         _onStale = OnStale;
+        _onUnsubscribed = OnUnsubscribed;
         _client.BookSnapshot += _onSnap;
         _client.OrderAdded += _onAdd;
         _client.OrderUpdated += _onUpd;
         _client.OrderDeleted += _onDel;
         _client.BookCleared += _onClr;
         _client.SymbolStaleStatus += _onStale;
+        _client.Unsubscribed += _onUnsubscribed;
     }
 
     /// <inheritdoc/>
@@ -95,10 +98,12 @@ public sealed class BookFeed : IBookFeed, IDisposable
     }
 
     /// <summary>
-    /// Drop the in-memory book for <paramref name="symbol"/>. Call after
-    /// unsubscribing so long-running processes don't accumulate state for
-    /// symbols they no longer care about. (Phase 2 will add automatic eviction
-    /// tied to the subscription lifecycle.)
+    /// Drop the in-memory book for <paramref name="symbol"/>. Normally
+    /// <see cref="MarketDataClient.UnsubscribeAsync"/> handles eviction
+    /// automatically via the
+    /// <see cref="MarketDataClient.Unsubscribed"/> event; call this only when
+    /// you want to discard a book without unsubscribing (e.g. memory
+    /// reclamation for a symbol you still receive but no longer care about).
     /// </summary>
     public bool Forget(string symbol)
     {
@@ -152,6 +157,15 @@ public sealed class BookFeed : IBookFeed, IDisposable
         Changed?.Invoke(ev.Symbol);
     }
 
+    private void OnUnsubscribed(UnsubscribedEvent ev)
+    {
+        if (string.IsNullOrWhiteSpace(ev.Symbol)) return;
+        if (_bySymbol.TryRemove(ev.Symbol.Trim(), out _))
+        {
+            Changed?.Invoke(ev.Symbol);
+        }
+    }
+
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
@@ -161,5 +175,6 @@ public sealed class BookFeed : IBookFeed, IDisposable
         _client.OrderDeleted -= _onDel;
         _client.BookCleared -= _onClr;
         _client.SymbolStaleStatus -= _onStale;
+        _client.Unsubscribed -= _onUnsubscribed;
     }
 }

--- a/src/B3.MarketData.WebSocketClient/BookView.cs
+++ b/src/B3.MarketData.WebSocketClient/BookView.cs
@@ -1,17 +1,29 @@
 namespace B3.MarketData.WebSocketClient;
 
 /// <summary>
-/// Phase 1 (issue #43). Per-symbol L3 / MBO state + derived top-of-book.
-/// Mutated only by <see cref="BookFeed"/> (single writer = receive loop);
-/// read methods take the per-symbol lock to publish a consistent aggregate.
+/// Phase 1/2 (issue #43). Per-symbol L3 / MBO state + derived top-of-book
+/// and depth-N L2 ladder. Mutated only by <see cref="BookFeed"/> (single
+/// writer = receive loop); read methods take the per-symbol lock to publish
+/// a consistent aggregate.
+/// <para>
+/// State is kept as two parallel structures per side: a flat
+/// <see cref="Dictionary{TKey,TValue}"/> keyed by <c>OrderId</c> for O(1)
+/// update/delete-by-id, and a <see cref="SortedDictionary{TKey,TValue}"/>
+/// keyed by price (descending for bids, ascending for asks) that aggregates
+/// total qty and order count per price level for O(1) top reads and
+/// O(depth) ladder copies.
+/// </para>
 /// </summary>
 internal sealed class BookView : IBookView
 {
     private readonly object _gate = new();
-    private readonly Dictionary<ulong, OrderEntry> _bids = new();
-    private readonly Dictionary<ulong, OrderEntry> _asks = new();
+    private readonly Dictionary<ulong, OrderEntry> _bidOrders = new();
+    private readonly Dictionary<ulong, OrderEntry> _askOrders = new();
+    private readonly SortedDictionary<decimal, PriceLevel> _bidLevels = new(DescendingDecimalComparer.Instance);
+    private readonly SortedDictionary<decimal, PriceLevel> _askLevels = new();
     private bool _isStale;
     private DateTime _updatedUtc;
+    private long _sequence;
 
     public BookView(string symbol, ulong securityId)
     {
@@ -23,14 +35,14 @@ internal sealed class BookView : IBookView
     public ulong SecurityId { get; }
     public bool IsStale { get { lock (_gate) return _isStale; } }
     public DateTime UpdatedUtc { get { lock (_gate) return _updatedUtc; } }
+    public long Sequence { get { lock (_gate) return _sequence; } }
 
     public bool TryGetTop(out L2TopOfBook top)
     {
         lock (_gate)
         {
-            // Bid side = highest price wins; Ask side = lowest.
-            var bid = TopOfSide(_bids, ascending: false);
-            var ask = TopOfSide(_asks, ascending: true);
+            var bid = FirstLevel(_bidLevels);
+            var ask = FirstLevel(_askLevels);
             if (bid.OrderCount == 0 && ask.OrderCount == 0)
             {
                 top = default;
@@ -41,29 +53,46 @@ internal sealed class BookView : IBookView
         }
     }
 
+    public int CopyBidLevels(Span<L2Level> destination, int depth)
+    {
+        ValidateDepth(destination, depth);
+        lock (_gate) return CopyLevels(_bidLevels, destination, depth);
+    }
+
+    public int CopyAskLevels(Span<L2Level> destination, int depth)
+    {
+        ValidateDepth(destination, depth);
+        lock (_gate) return CopyLevels(_askLevels, destination, depth);
+    }
+
     internal void ApplySnapshot(BookSnapshotEvent ev)
     {
         lock (_gate)
         {
-            _bids.Clear();
-            _asks.Clear();
+            _bidOrders.Clear();
+            _askOrders.Clear();
+            _bidLevels.Clear();
+            _askLevels.Clear();
             // BookSnapshotEvent today carries only the phase-marker header;
             // OrderAdded frames follow in the same packet and are applied
-            // separately. But we also support the wire form's optional
-            // aggregated entries (orderId=0) by skipping them — the live
-            // state will rebuild from the order stream.
+            // separately. We also support the wire form's optional aggregated
+            // entries (orderId=0) by skipping them — the live state will
+            // rebuild from the order stream.
             foreach (var o in ev.Bids)
             {
                 if (o.OrderId == 0) continue;
-                _bids[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+                _bidOrders[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+                AddToLevel(_bidLevels, o.Price, o.Qty);
             }
             foreach (var o in ev.Asks)
             {
                 if (o.OrderId == 0) continue;
-                _asks[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+                _askOrders[o.OrderId] = new OrderEntry(o.Price, o.Qty);
+                AddToLevel(_askLevels, o.Price, o.Qty);
             }
             _isStale = false;
             _updatedUtc = ev.ReceivedUtc;
+            _sequence = ev.RptSeq;
         }
     }
 
@@ -71,7 +100,16 @@ internal sealed class BookView : IBookView
     {
         lock (_gate)
         {
-            SideMap(ev.Side)[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
+            var orders = SideOrders(ev.Side);
+            var levels = SideLevels(ev.Side);
+            // Defensive: an Add for a known id is treated as a replace —
+            // remove the old contribution from its level before adding the new.
+            if (orders.TryGetValue(ev.OrderId, out var prior))
+            {
+                RemoveFromLevel(levels, prior.Price, prior.Qty);
+            }
+            orders[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
+            AddToLevel(levels, ev.Price, ev.Qty);
             _updatedUtc = ev.ReceivedUtc;
         }
     }
@@ -80,14 +118,40 @@ internal sealed class BookView : IBookView
     {
         lock (_gate)
         {
-            var map = SideMap(ev.Side);
+            var orders = SideOrders(ev.Side);
+            var levels = SideLevels(ev.Side);
+            bool hadPrior = orders.TryGetValue(ev.OrderId, out var prior);
             if (ev.Qty <= 0)
             {
-                map.Remove(ev.OrderId);
+                if (orders.Remove(ev.OrderId, out var removed))
+                {
+                    RemoveFromLevel(levels, removed.Price, removed.Qty);
+                }
             }
             else
             {
-                map[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
+                if (hadPrior)
+                {
+                    if (prior.Price == ev.Price)
+                    {
+                        long delta = ev.Qty - prior.Qty;
+                        if (delta != 0)
+                        {
+                            // adjust level qty without changing order count
+                            AdjustLevelQty(levels, ev.Price, delta);
+                        }
+                    }
+                    else
+                    {
+                        RemoveFromLevel(levels, prior.Price, prior.Qty);
+                        AddToLevel(levels, ev.Price, ev.Qty);
+                    }
+                }
+                else
+                {
+                    AddToLevel(levels, ev.Price, ev.Qty);
+                }
+                orders[ev.OrderId] = new OrderEntry(ev.Price, ev.Qty);
             }
             _updatedUtc = ev.ReceivedUtc;
         }
@@ -97,7 +161,12 @@ internal sealed class BookView : IBookView
     {
         lock (_gate)
         {
-            SideMap(ev.Side).Remove(ev.OrderId);
+            var orders = SideOrders(ev.Side);
+            var levels = SideLevels(ev.Side);
+            if (orders.Remove(ev.OrderId, out var removed))
+            {
+                RemoveFromLevel(levels, removed.Price, removed.Qty);
+            }
             _updatedUtc = ev.ReceivedUtc;
         }
     }
@@ -109,14 +178,18 @@ internal sealed class BookView : IBookView
             switch (ev.ClearSide)
             {
                 case BookClearSide.Both:
-                    _bids.Clear();
-                    _asks.Clear();
+                    _bidOrders.Clear();
+                    _askOrders.Clear();
+                    _bidLevels.Clear();
+                    _askLevels.Clear();
                     break;
                 case BookClearSide.Bid:
-                    _bids.Clear();
+                    _bidOrders.Clear();
+                    _bidLevels.Clear();
                     break;
                 case BookClearSide.Ask:
-                    _asks.Clear();
+                    _askOrders.Clear();
+                    _askLevels.Clear();
                     break;
             }
             _updatedUtc = ev.ReceivedUtc;
@@ -135,33 +208,102 @@ internal sealed class BookView : IBookView
     /// <summary>Test/diagnostic hook: per-side live order count.</summary>
     internal (int Bids, int Asks) GetOrderCounts()
     {
-        lock (_gate) return (_bids.Count, _asks.Count);
+        lock (_gate) return (_bidOrders.Count, _askOrders.Count);
     }
 
-    private static L2Side TopOfSide(Dictionary<ulong, OrderEntry> side, bool ascending)
+    /// <summary>Test/diagnostic hook: per-side live price-level count.</summary>
+    internal (int Bids, int Asks) GetLevelCounts()
     {
-        if (side.Count == 0) return new L2Side(0m, 0, 0);
-        decimal best = ascending ? decimal.MaxValue : decimal.MinValue;
-        foreach (var e in side.Values)
-        {
-            if (ascending ? e.Price < best : e.Price > best)
-                best = e.Price;
-        }
-        long qty = 0;
-        int count = 0;
-        foreach (var e in side.Values)
-        {
-            if (e.Price == best)
-            {
-                qty += e.Qty;
-                count++;
-            }
-        }
-        return new L2Side(best, qty, count);
+        lock (_gate) return (_bidLevels.Count, _askLevels.Count);
     }
 
-    private Dictionary<ulong, OrderEntry> SideMap(BookSide side) =>
-        side == BookSide.Bid ? _bids : _asks;
+    private Dictionary<ulong, OrderEntry> SideOrders(BookSide side) =>
+        side == BookSide.Bid ? _bidOrders : _askOrders;
+
+    private SortedDictionary<decimal, PriceLevel> SideLevels(BookSide side) =>
+        side == BookSide.Bid ? _bidLevels : _askLevels;
+
+    private static L2Side FirstLevel(SortedDictionary<decimal, PriceLevel> levels)
+    {
+        if (levels.Count == 0) return new L2Side(0m, 0, 0);
+        // SortedDictionary enumerator is in key order — first element is the
+        // best price under the configured comparer (descending for bids,
+        // ascending for asks).
+        using var e = levels.GetEnumerator();
+        e.MoveNext();
+        var kv = e.Current;
+        return new L2Side(kv.Key, kv.Value.TotalQty, kv.Value.OrderCount);
+    }
+
+    private static int CopyLevels(SortedDictionary<decimal, PriceLevel> levels, Span<L2Level> dst, int depth)
+    {
+        int n = Math.Min(depth, levels.Count);
+        if (n == 0) return 0;
+        int i = 0;
+        foreach (var kv in levels)
+        {
+            if (i >= n) break;
+            dst[i++] = new L2Level(kv.Key, kv.Value.TotalQty, kv.Value.OrderCount);
+        }
+        return i;
+    }
+
+    private static void AddToLevel(SortedDictionary<decimal, PriceLevel> levels, decimal price, long qty)
+    {
+        if (levels.TryGetValue(price, out var lvl))
+        {
+            levels[price] = new PriceLevel(lvl.TotalQty + qty, lvl.OrderCount + 1);
+        }
+        else
+        {
+            levels.Add(price, new PriceLevel(qty, 1));
+        }
+    }
+
+    private static void RemoveFromLevel(SortedDictionary<decimal, PriceLevel> levels, decimal price, long qty)
+    {
+        if (!levels.TryGetValue(price, out var lvl)) return;
+        int newCount = lvl.OrderCount - 1;
+        long newQty = lvl.TotalQty - qty;
+        if (newCount <= 0 || newQty <= 0)
+        {
+            levels.Remove(price);
+        }
+        else
+        {
+            levels[price] = new PriceLevel(newQty, newCount);
+        }
+    }
+
+    private static void AdjustLevelQty(SortedDictionary<decimal, PriceLevel> levels, decimal price, long delta)
+    {
+        if (!levels.TryGetValue(price, out var lvl)) return;
+        long newQty = lvl.TotalQty + delta;
+        if (newQty <= 0)
+        {
+            // Shouldn't happen in well-formed streams, but stay defensive.
+            levels.Remove(price);
+        }
+        else
+        {
+            levels[price] = new PriceLevel(newQty, lvl.OrderCount);
+        }
+    }
+
+    private static void ValidateDepth(Span<L2Level> destination, int depth)
+    {
+        if (depth < 0) throw new ArgumentOutOfRangeException(nameof(depth), "depth must be >= 0");
+        if (depth > destination.Length)
+            throw new ArgumentOutOfRangeException(nameof(depth), "depth exceeds destination length");
+    }
 
     private readonly record struct OrderEntry(decimal Price, long Qty);
+
+    private readonly record struct PriceLevel(long TotalQty, int OrderCount);
+
+    private sealed class DescendingDecimalComparer : IComparer<decimal>
+    {
+        public static readonly DescendingDecimalComparer Instance = new();
+        public int Compare(decimal x, decimal y) => y.CompareTo(x);
+    }
 }

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -201,6 +201,16 @@ public readonly record struct SymbolDelistedEvent(
     DateTime ReceivedUtc);
 
 /// <summary>
+/// Client-side notification raised after <see cref="MarketDataClient.UnsubscribeAsync"/>
+/// drops a symbol from the active subscription set. <see cref="SecurityId"/>
+/// is zero when no <c>SubscribeOk</c> had been observed yet.
+/// </summary>
+public readonly record struct UnsubscribedEvent(
+    string Symbol,
+    ulong SecurityId,
+    DateTime ReceivedUtc);
+
+/// <summary>
 /// Returned by the server when a <c>Subscribe</c> can't be satisfied.
 /// </summary>
 public enum SubscribeErrorCode : byte

--- a/src/B3.MarketData.WebSocketClient/IBookFeed.cs
+++ b/src/B3.MarketData.WebSocketClient/IBookFeed.cs
@@ -65,6 +65,38 @@ public interface IBookView
     /// snapshot — safe to keep on the stack while the live state advances.
     /// </summary>
     bool TryGetTop(out L2TopOfBook top);
+
+    /// <summary>
+    /// Last <see cref="BookSnapshotEvent.RptSeq"/> observed for this book.
+    /// Incremental MBO events do not carry an explicit sequence number on the
+    /// current wire, so this advances only on (re)snapshots. Zero before the
+    /// first snapshot is applied.
+    /// </summary>
+    long Sequence { get; }
+
+    /// <summary>
+    /// Copy up to <paramref name="depth"/> price levels of the bid side
+    /// (highest price first) into <paramref name="destination"/>. Returns
+    /// the number of levels actually written, which may be less than
+    /// <paramref name="depth"/> when the side has fewer levels.
+    /// Zero-alloc; safe to call on the hot path with a stack-allocated span.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="depth"/> is negative or greater than
+    /// <paramref name="destination"/>.Length.
+    /// </exception>
+    int CopyBidLevels(Span<L2Level> destination, int depth);
+
+    /// <summary>
+    /// Copy up to <paramref name="depth"/> price levels of the ask side
+    /// (lowest price first) into <paramref name="destination"/>. Returns
+    /// the number of levels actually written. Zero-alloc.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="depth"/> is negative or greater than
+    /// <paramref name="destination"/>.Length.
+    /// </exception>
+    int CopyAskLevels(Span<L2Level> destination, int depth);
 }
 
 /// <summary>
@@ -81,6 +113,17 @@ public readonly record struct L2TopOfBook(
 
 /// <summary>Aggregate of one side at one price level.</summary>
 public readonly record struct L2Side(
+    decimal Price,
+    long TotalQty,
+    int OrderCount);
+
+/// <summary>
+/// One price level inside an L2 ladder — returned by
+/// <see cref="IBookView.CopyBidLevels"/> / <see cref="IBookView.CopyAskLevels"/>.
+/// Structurally identical to <see cref="L2Side"/>; named separately for clarity
+/// at call sites that walk multi-level depth instead of just the top.
+/// </summary>
+public readonly record struct L2Level(
     decimal Price,
     long TotalQty,
     int OrderCount);

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -75,6 +75,15 @@ public sealed class MarketDataClient : IAsyncDisposable
     public event Action<SubscribeErrorEvent>? SubscribeError;
     public event Action<ConnectionStateChangedEvent>? ConnectionStateChanged;
 
+    /// <summary>
+    /// Raised after <see cref="UnsubscribeAsync"/> drops a symbol from the
+    /// active subscription set. Fires synchronously on the caller's thread
+    /// (before the Unsubscribe frame is sent on the wire) so consumers can
+    /// release any per-symbol state — the materialized
+    /// <see cref="BookFeed"/>, for example, uses this to evict the book.
+    /// </summary>
+    public event Action<UnsubscribedEvent>? Unsubscribed;
+
     // ── L3 / Order-by-order (MBO) ────────────────────────────────────
 
     /// <summary>L3 snapshot-phase marker. Consumers SHOULD clear prior book
@@ -244,6 +253,9 @@ public sealed class MarketDataClient : IAsyncDisposable
         ThrowIfDisposed();
         ArgumentException.ThrowIfNullOrEmpty(symbol);
         if (!_subscriptions.TryRemove(symbol, out var record)) return default;
+
+        try { Unsubscribed?.Invoke(new UnsubscribedEvent(symbol, record.SecurityId, DateTime.UtcNow)); }
+        catch (Exception ex) { _logger.LogError(ex, "Unsubscribed handler threw for {Symbol}", symbol); }
 
         ulong secId = record.SecurityId;
         if (secId == 0) return default;

--- a/tests/B3.MarketData.WebSocketClient.Tests/BookFeedTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/BookFeedTests.cs
@@ -145,6 +145,177 @@ public class BookFeedTests
         Assert.False(view.IsStale);
     }
 
+    // ── Phase 2: depth-N + Sequence ─────────────────────────────────
+
+    [Fact]
+    public void CopyBidLevels_returns_levels_in_descending_price_order()
+    {
+        var view = SeedDepth();
+        Span<L2Level> levels = stackalloc L2Level[5];
+        int n = view.CopyBidLevels(levels, 5);
+        Assert.Equal(3, n);
+        Assert.Equal(30.20m, levels[0].Price);
+        Assert.Equal(250, levels[0].TotalQty);
+        Assert.Equal(2, levels[0].OrderCount);
+        Assert.Equal(30.10m, levels[1].Price);
+        Assert.Equal(100, levels[1].TotalQty);
+        Assert.Equal(30.00m, levels[2].Price);
+        Assert.Equal(80, levels[2].TotalQty);
+    }
+
+    [Fact]
+    public void CopyAskLevels_returns_levels_in_ascending_price_order()
+    {
+        var view = SeedDepth();
+        Span<L2Level> levels = stackalloc L2Level[5];
+        int n = view.CopyAskLevels(levels, 5);
+        Assert.Equal(2, n);
+        Assert.Equal(30.40m, levels[0].Price);
+        Assert.Equal(300, levels[0].TotalQty);
+        Assert.Equal(30.50m, levels[1].Price);
+        Assert.Equal(100, levels[1].TotalQty);
+    }
+
+    [Fact]
+    public void CopyLevels_truncates_when_depth_lt_available()
+    {
+        var view = SeedDepth();
+        Span<L2Level> levels = stackalloc L2Level[2];
+        int n = view.CopyBidLevels(levels, 2);
+        Assert.Equal(2, n);
+        Assert.Equal(30.20m, levels[0].Price);
+        Assert.Equal(30.10m, levels[1].Price);
+    }
+
+    [Fact]
+    public void CopyLevels_returns_zero_for_empty_side()
+    {
+        var view = new BookView("PETR4", 4321);
+        Span<L2Level> levels = stackalloc L2Level[5];
+        Assert.Equal(0, view.CopyBidLevels(levels, 5));
+        Assert.Equal(0, view.CopyAskLevels(levels, 5));
+    }
+
+    [Fact]
+    public void CopyLevels_validates_depth_against_destination()
+    {
+        var view = SeedDepth();
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var dst = new L2Level[2];
+            view.CopyBidLevels(dst.AsSpan(), 3);
+        });
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            var dst = new L2Level[2];
+            view.CopyAskLevels(dst.AsSpan(), -1);
+        });
+    }
+
+    [Fact]
+    public void Update_with_price_change_moves_order_between_levels()
+    {
+        var view = SeedDepth();
+        // Move order 101 from 30.10 → 30.20 (joining the top level)
+        view.ApplyUpdated(Upd("PETR4", 4321, 101, BookSide.Bid, 30.20m, 100, T0.AddSeconds(1)));
+
+        Span<L2Level> levels = stackalloc L2Level[5];
+        int n = view.CopyBidLevels(levels, 5);
+        Assert.Equal(2, n);
+        Assert.Equal(30.20m, levels[0].Price);
+        Assert.Equal(350, levels[0].TotalQty); // 200 + 50 + 100
+        Assert.Equal(3, levels[0].OrderCount);
+        Assert.Equal(30.00m, levels[1].Price);
+        Assert.Equal(80, levels[1].TotalQty);
+    }
+
+    [Fact]
+    public void Update_same_price_qty_change_adjusts_level_qty_only()
+    {
+        var view = SeedDepth();
+        view.ApplyUpdated(Upd("PETR4", 4321, 103, BookSide.Bid, 30.20m, 150, T0.AddSeconds(1)));
+        Span<L2Level> levels = stackalloc L2Level[5];
+        int n = view.CopyBidLevels(levels, 5);
+        Assert.Equal(3, n);
+        Assert.Equal(30.20m, levels[0].Price);
+        Assert.Equal(350, levels[0].TotalQty); // 200 + 150
+        Assert.Equal(2, levels[0].OrderCount);
+    }
+
+    [Fact]
+    public void Delete_collapses_empty_level()
+    {
+        var view = SeedDepth();
+        view.ApplyDeleted(Del("PETR4", 4321, 100, BookSide.Bid, T0.AddSeconds(1)));
+        var (_, _) = view.GetLevelCounts();
+        Span<L2Level> levels = stackalloc L2Level[5];
+        int n = view.CopyBidLevels(levels, 5);
+        Assert.Equal(2, n); // 30.00 collapsed
+        Assert.Equal(30.20m, levels[0].Price);
+        Assert.Equal(30.10m, levels[1].Price);
+    }
+
+    [Fact]
+    public void Sequence_tracks_last_snapshot_RptSeq()
+    {
+        var view = new BookView("PETR4", 4321);
+        Assert.Equal(0, view.Sequence);
+        view.ApplySnapshot(SnapWithSeq("PETR4", 4321, 42, T0));
+        Assert.Equal(42, view.Sequence);
+        // Incrementals do not bump Sequence on the current wire.
+        view.ApplyAdded(Add("PETR4", 4321, 1, BookSide.Bid, 30m, 10, T0.AddSeconds(1)));
+        Assert.Equal(42, view.Sequence);
+        view.ApplySnapshot(SnapWithSeq("PETR4", 4321, 99, T0.AddSeconds(2)));
+        Assert.Equal(99, view.Sequence);
+    }
+
+    [Fact]
+    public async Task BookFeed_evicts_book_on_UnsubscribeAsync()
+    {
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var sym = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 4321, sym, ct);
+            await SendBookSnapshotEmptyAsync(ws, securityId: 4321, ct);
+            await SendOrderEventAsync(ws, ServerMsg.OrderAdded, secId: 4321, orderId: 1, side: BookSide.Bid, price: 30_0000, qty: 100, ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        using var feed = client.CreateBookFeed();
+        await client.ConnectAsync();
+        await client.SubscribeAsync("PETR4", SubscribeFlags.Book);
+        await WaitUntil(() => feed.GetBook("PETR4") is not null, TimeSpan.FromSeconds(5));
+
+        await client.UnsubscribeAsync("PETR4");
+        await WaitUntil(() => feed.GetBook("PETR4") is null, TimeSpan.FromSeconds(2));
+        Assert.Null(feed.GetBook("PETR4"));
+        // Re-Unsubscribe of an unknown symbol is a no-op (does not throw, does not re-fire eviction)
+        await client.UnsubscribeAsync("PETR4");
+    }
+
+    private static BookView SeedDepth()
+    {
+        var view = new BookView("PETR4", 4321);
+        view.ApplySnapshot(Snap("PETR4", 4321, T0));
+        // Bid: 30.20 (101, 103), 30.10 (102), 30.00 (100)
+        view.ApplyAdded(Add("PETR4", 4321, 102, BookSide.Bid, 30.20m, 200, T0));
+        view.ApplyAdded(Add("PETR4", 4321, 103, BookSide.Bid, 30.20m, 50, T0));
+        view.ApplyAdded(Add("PETR4", 4321, 101, BookSide.Bid, 30.10m, 100, T0));
+        view.ApplyAdded(Add("PETR4", 4321, 100, BookSide.Bid, 30.00m, 80, T0));
+        // Ask: 30.40 (201), 30.50 (202)
+        view.ApplyAdded(Add("PETR4", 4321, 201, BookSide.Ask, 30.40m, 300, T0));
+        view.ApplyAdded(Add("PETR4", 4321, 202, BookSide.Ask, 30.50m, 100, T0));
+        return view;
+    }
+
+    private static BookSnapshotEvent SnapWithSeq(string sym, ulong secId, uint rpt, DateTime ts) =>
+        new() { SecurityId = secId, Symbol = sym, RptSeq = rpt, ReceivedUtc = ts };
+
     // ── BookFeed wiring tests (uses real MarketDataClient events) ───
 
     [Fact]


### PR DESCRIPTION
Implements Phase 2 of #43 (tracked in #52). v0.3.0 → v0.4.0.

## What changes

**API additions on `IBookView`**

| Member | Notes |
|---|---|
| `long Sequence { get; }` | Last applied `BookSnapshot.RptSeq`. Incrementals don't carry sequence on the current wire, so this advances only on (re)snapshots. |
| `int CopyBidLevels(Span<L2Level>, int depth)` | Zero-alloc, descending price order. Returns count written (≤ depth). Throws `ArgumentOutOfRangeException` on negative depth or depth > destination length. |
| `int CopyAskLevels(Span<L2Level>, int depth)` | Zero-alloc, ascending price order. |
| `L2Level` record struct | New: `(decimal Price, long TotalQty, int OrderCount)`. |

**Internal state — `BookView` now keeps two parallel structures per side**

- `Dictionary<ulong, OrderEntry>` keyed by OrderId for O(1) update/delete by id.
- `SortedDictionary<decimal, PriceLevel>` keyed by price (descending for bids, ascending for asks) aggregating `TotalQty` + `OrderCount` per level.

`TopOfSide` becomes O(1) (first key of the SortedDictionary) instead of O(N) over all orders. `ApplyUpdated` handles price changes by moving the order between price levels; same-price qty changes adjust the aggregate without touching `OrderCount`.

**Auto-eviction on Unsubscribe**

New `MarketDataClient.Unsubscribed` event fires synchronously from `UnsubscribeAsync` after the symbol is removed from the active subscription set. `BookFeed` listens and drops the book — no more manual `Forget` for the normal lifecycle. `Forget(string)` is preserved (and re-documented) for the explicit-discard case.

## Baseline implications

`docs/perf/bookfeed-baseline.md` (merged in #51) showed Phase 1 used <0.05% CPU at 3.2k evt/s. Adding the SortedDictionary side-by-side roughly doubles per-Apply bookkeeping work but stays well below any measurable threshold. A microbench suite is out of scope here (separate ticket).

## Testing

+10 unit tests covering depth-N ordering, truncation, empty side, span/depth validation, price-change update (level move), same-price qty change (level adjust), level-collapse on delete, `Sequence` semantics, and end-to-end auto-eviction over WebSocket.

- `B3.MarketData.WebSocketClient.Tests`: 53/53 pass (43 → 53).
- Full solution: **694/694** tests pass.

## Out of scope (future tickets)

- BenchmarkDotNet microbench suite (baseline already proves perf is fine).
- Optional eviction TTL for stale-but-still-subscribed books.
- `BoundedChannel.TryWrite → Monitor.Enter_Slowpath` micro-opt in `MarketDataClient` (the only hotspot the baseline found, orthogonal to BookFeed).