### PR TITLE
WebSocket binary protocol v2 (forward-compatible framing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
 
     - name: Test
       run: dotnet test --no-build --verbosity normal
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: JS golden-vector decode test
+      run: node --test tests/golden/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         node-version: '22'
 
     - name: JS golden-vector decode test
-      run: node --test tests/golden/
+      run: node --test tests/golden/*.test.mjs

--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -5,6 +5,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj" />
+    <Project Path="src/B3.MarketData.Wire/B3.MarketData.Wire.csproj" />
     <Project Path="src/B3.Umdf.Book/B3.Umdf.Book.csproj" />
     <Project Path="src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj" />
     <Project Path="src/B3.Umdf.Feed/B3.Umdf.Feed.csproj" />

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ straight from the B3 SBE XML schema.
   1 s candles), and 2 s rankings broadcast.
 - **News pipeline (`News_5`)** — multi-part SBE reassembly with strict per-part
   validation, 5 s TTL, 16 MiB inflight cap, and zero-copy span delivery.
-  Fragmented over the wire as `NewsBegin`/`NewsChunk`/`NewsEnd` so payloads
-  larger than the `u16` framing length still flow through the same client
+  Fragmented over the wire as `NewsBegin`/`NewsChunk`/`NewsEnd` so arbitrarily
+  large payloads still flow through the same client
   pipeline. (Note: zero `News_5` occurrences observed in 8 sample PCAPs;
   pipeline is verified via synthetic fixtures.)
 - **Layered backpressure** — bounded per-client outbound ring, hard

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -119,7 +119,7 @@ client.SecurityDefinition += sd =>
     Console.WriteLine($"{sd.Symbol} tick={sd.MinPriceIncrement} lot={sd.MinTradeVolume} isin={sd.IsinNumber}");
 await client.SubscribeAsync("PETR4",
     SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.SecurityDefinition);
-// or just: SubscribeFlags.Everything
+// or just: SubscribeFlags.AllKnown
 ```
 
 `MinPriceIncrement` is already scaled (raw SBE `Fixed8` mantissa divided by
@@ -147,7 +147,7 @@ client.PriceBand += pb =>
         $"avgQty={pb.AvgDailyTradedQty} maxQty={pb.MaxOrderQty}");
 await client.SubscribeAsync("WINJ5",
     SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.PriceBand);
-// or just: SubscribeFlags.Everything
+// or just: SubscribeFlags.AllKnown
 ```
 
 **Price fields** (from `PriceBand_22`):
@@ -198,7 +198,7 @@ client.Auction += a =>
         $"side={a.ImbalanceSide} openTime={a.TradSesOpenTime}");
 await client.SubscribeAsync("PETR4",
     SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Auction);
-// or just: SubscribeFlags.Everything
+// or just: SubscribeFlags.AllKnown
 ```
 
 `ImbalanceSide` is an enum (`Balanced`, `MoreBuyers`, `MoreSellers`)

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -1,34 +1,88 @@
 # WebSocket Binary Protocol
 
+**Protocol version: 2** (`ProtocolVersion = 2`). See the
+[Forward-Compatibility Contract](#forward-compatibility-contract) for the rules
+that keep every future change additive.
+
 The server speaks a compact, length-prefixed binary protocol over a single
-WebSocket. All numeric fields are **little-endian**.
+WebSocket. All numeric fields are **little-endian** (the protocol is LE-only; a
+big-endian runtime is rejected).
 
 - Default URL: `ws://<host>:<ws-port>/ws` (e.g. `ws://localhost:8080/ws`).
-- Frames are WebSocket **binary** messages (one wire message per frame).
-- Multiple wire messages may be coalesced inside a single TCP segment by the
-  server's per-client `UMDF_CLIENT_COALESCE_WINDOW_MS` window.
+- Frames are WebSocket **binary** messages.
+- **A single WebSocket binary message MAY contain multiple wire frames**
+  concatenated back-to-back (*coalescing*). The server batches whatever is
+  queued for a client during its per-client `UMDF_CLIENT_COALESCE_WINDOW_MS`
+  window into one `SendAsync`. Decoders **MUST** therefore treat each WS message
+  as a stream: read the `messageLength` at the current offset, consume that many
+  bytes, advance, and repeat until the message is drained — never assume one WS
+  message equals one wire frame. See
+  [Consuming coalesced messages](#consuming-coalesced-messages).
 
 ## Framing
 
-Every message starts with a fixed 4-byte header:
+Every message starts with a fixed **8-byte** header:
 
 ```
  0               1               2               3
  0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|       messageLength (u16)     |       messageType (u16)       |
+|                     messageLength (u32)                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                          payload …                            |
+|       messageType (u16)       |      headerFlags (u16)        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                          payload … (@8)                       |
 ```
 
-- `messageLength` is the total frame size **including the header itself**.
-- Maximum single message size: `65 535 bytes` (`u16`).
+- `messageLength` (`u32`) is the total frame size **including the 8-byte header
+  itself**. It is authoritative: decoders MUST use it to find the next frame and
+  to skip trailing bytes they do not understand.
+- `messageType` (`u16`) identifies the frame.
+- `headerFlags` (`u16`) is `0` in protocol v2. Reserved for future transport
+  features (e.g. compression / fragmentation). A receiver that sees **any**
+  header-flag bit it does not understand **MUST reject the frame / close the
+  connection** — an unknown bit may change how the payload is interpreted.
+- The payload always starts at byte offset **8**.
+- Maximum single frame size: **16 MiB** (`MaxFrameLength`, a DoS guard against a
+  bogus `u32` length). Frames larger than this are rejected.
+
+## Consuming coalesced messages
+
+Because one WebSocket binary message can pack many wire frames, a consumer
+splits them in a loop driven entirely by `messageLength`:
+
+```
+offset = 0
+while offset < wsMessage.length:
+    length = readU32LE(wsMessage, offset)          # total frame size incl. 8-byte header
+    if length < 8 or offset + length > wsMessage.length:
+        drop rest of message (truncated/corrupt)   # should not happen from a healthy server
+    type        = readU16LE(wsMessage, offset + 4)
+    headerFlags = readU16LE(wsMessage, offset + 6)  # reject if any unknown bit is set
+    payload     = wsMessage[offset + 8 : offset + length]
+    dispatch(type, payload)
+    offset += length
+```
+
+Sizing the receive buffer:
+
+- A single **frame** never exceeds `MaxFrameLength` (16 MiB). A single coalesced
+  **WS message** is bounded by the server's per-client outbound cap
+  (`UMDF_CLIENT_MAX_PENDING_BYTES`, default 4 MiB), so in practice a message
+  stays well under 16 MiB.
+- Consumers should **not** pre-allocate the maximum. Start with a small buffer
+  (the reference SDK uses 64 KiB) and **grow on demand** — doubling up to a
+  16 MiB ceiling — only for the rare batch that overflows it. This keeps
+  steady-state memory at a few KiB per connection while still tolerating a large
+  coalesced burst; a message that would exceed the 16 MiB ceiling is treated as
+  a protocol violation and the connection is closed.
 
 ## Message types
 
 ```
 Client → Server                 Server → Client
 ─────────────────────────────   ─────────────────────────────────
+ClientHello       0x00A1        ServerHello         0x00A0
 Subscribe         0x0001        SubscribeOk         0x0010
 Unsubscribe       0x0002        SubscribeError      0x0011
 Get               0x0003        Unsubscribed        0x0012
@@ -60,11 +114,20 @@ Get               0x0003        Unsubscribed        0x0012
 
 | Message | Type | Payload |
 |---------|------|---------|
-| **Subscribe**   | `0x0001` | `[flags u8][symLen u8][symbol UTF-8…]` |
+| **ClientHello** | `0x00A1` | `[protocolVersion u32][clientCapabilities u32]` |
+| **Subscribe**   | `0x0001` | `[flags u32][symLen u8][symbol UTF-8…]` |
 | **Unsubscribe** | `0x0002` | `[securityId u64]` |
-| **Get**         | `0x0003` | `[flags u8][symLen u8][symbol UTF-8…]` |
+| **Get**         | `0x0003` | `[flags u32][symLen u8][symbol UTF-8…]` |
 
-`flags` is a `DataFlags` bitmask:
+**ClientHello** is optional. The server sends `ServerHello` first on connect; a
+client MAY reply with `ClientHello` to declare the `protocolVersion` it speaks
+(and any `clientCapabilities`, all `0` today). Clients that never send it are
+assumed to speak the current `ProtocolVersion`. If a `ClientHello` claims a
+version outside the server's supported `[min, max]` range, the server closes the
+socket with WS close code `1003` (unsupported data). Trailing bytes beyond the
+two known `u32` fields are ignored (min-length rule).
+
+`flags` is a `DataFlags` `u32` bitmask:
 
 | Value | Name | Meaning |
 |-------|------|---------|
@@ -78,7 +141,15 @@ Get               0x0003        Unsubscribed        0x0012
 | `0x20` | SecurityDefinition | `SecurityDefinition` frame (tick size, lot size, ISIN, CFI code, and the full static metadata projection from UMDF `SecurityDefinition_12`). Bootstrap snapshot on subscribe + push on every real definition change (idempotent re-broadcasts upstream are suppressed). Opt-in so legacy clients keep their bandwidth profile. |
 | `0x40` | PriceBand | `PriceBand` frame (dynamic per-symbol price + quantity limits from UMDF `PriceBand_22` + `QuantityBand_21`). Includes low/high price limits, limit-type, midpoint-type, trading reference price, plus `AvgDailyTradedQty` and `MaxOrderQty` for quantity-based fat-finger guards. Bootstrap snapshot on subscribe + push on every real band change. Opt-in; required by pre-trade guards that want the venue-authoritative bands instead of a static config. |
 | `0x80` | Auction | `Auction` frame (aggregated auction state from UMDF `AuctionImbalance_19` + `SecurityGroupPhase_10`). Imbalance qty/side + trading phase + TradSesOpenTime. Bootstrap snapshot on subscribe + push on every real delta. Opt-in for clients needing pre-open/auction-phase state or imbalance-aware algo logic. |
-| `0xFF` | Everything | `Book` + `Info` + `News` + `Mbp` + `Trades` + `SecurityDefinition` + `PriceBand` + `Auction` |
+| `0x000000FF` | AllKnown | Every channel this build knows about: `Book` + `Info` + `News` + `Mbp` + `Trades` + `SecurityDefinition` + `PriceBand` + `Auction`. **This is NOT all-ones** — new channels are added to `AllKnown` explicitly, so unknown/future bits stay unrequested. |
+
+> **`flags` is a `u32`.** The high 24 bits are currently unused. The server
+> **masks off any bit it does not recognise** and echoes only the accepted set
+> back in `SubscribeOk.flags`, so a client can inspect the reply to learn which
+> channels it actually got. Do **not** send `0xFFFFFFFF` to mean "everything" —
+> use `AllKnown`; sending all-ones would silently opt you into channels this
+> build does not implement (they are masked off) and, worse, into future
+> channels you are not prepared to decode.
 
 > **News and Trades are opt-in.** Existing clients that send `0x03` (or
 > `0x00`) keep the legacy behaviour and never receive news or trade frames.
@@ -100,13 +171,13 @@ Behavior:
 ### Hex example — Subscribe `BEEF3` (Book + Info)
 
 ```
- 0c 00 01 00 03 05 42 45 45 46 33
- └──┬──┘└──┬──┘ │  │  └────┬────┘
-   len   type  fl ln    "BEEF3"
-   12    0x01  All 5
+ 12 00 00 00  01 00  00 00  03 00 00 00  05  42 45 45 46 33
+ └────┬────┘ └──┬─┘ └──┬─┘ └────┬─────┘  │   └────┬──────┘
+   len(u32)   type   hdrFlags  flags(u32) ln    "BEEF3"
+    18       0x0001    0        All=3      5
 ```
 
-Total length = 12 bytes (4 header + 1 flags + 1 symLen + 5 symbol).
+Total length = 18 bytes (8 header + 4 flags + 1 symLen + 5 symbol).
 
 ## Server → Client
 
@@ -114,10 +185,17 @@ Total length = 12 bytes (4 header + 1 flags + 1 symLen + 5 symbol).
 
 | Message | Type | Payload |
 |---------|------|---------|
+| **ServerHello**    | `0x00A0` | `[protocolVersion u32][serverCapabilities u32][buildLen u8][build UTF-8…]` |
 | **ServerStatus**   | `0x0050` | `[ready u8]` |
-| **SubscribeOk**    | `0x0010` | `[securityId u64][flags u8][symLen u8][symbol UTF-8…]` |
+| **SubscribeOk**    | `0x0010` | `[securityId u64][flags u32][symLen u8][symbol UTF-8…]` |
 | **SubscribeError** | `0x0011` | `[errorCode u8][symLen u8][symbol UTF-8…]` |
 | **Unsubscribed**   | `0x0012` | `[securityId u64]` |
+
+**ServerHello** is the **first** server-initiated frame on every connection. It
+advertises the server's `protocolVersion` and a `serverCapabilities` bitmask
+(`0x01` SnapshotOnSubscribe, `0x02` SymbolDelistedNotification; append-only).
+`SubscribeOk.flags` echoes the **accepted** `DataFlags` (`u32`) after the server
+masks off unknown/unimplemented bits requested by the client.
 
 `ServerStatus.ready` = `1` once **every** feed group is in `RealTime`,
 `0` otherwise. The server emits one immediately on connect and again on
@@ -283,14 +361,23 @@ so this frame fires only on true deltas.
 
 | Message | Type | Payload |
 |---------|------|---------|
-| **OrderAdded**   | `0x0030` | `[secId u64][orderId u64][side u8][price i64][qty i64]` |
+| **OrderAdded**   | `0x0030` | `[secId u64][orderId u64][price i64][qty i64][side u8]` |
 | **OrderUpdated** | `0x0031` | *(same as OrderAdded)* |
 | **OrderDeleted** | `0x0032` | `[secId u64][orderId u64][side u8]` |
 | **Trade**        | `0x0033` | `[secId u64][price i64][qty i64][tradeId i64][flags u8]` |
 | **BookCleared**  | `0x0034` | `[secId u64][clearSide u8]` |
-| **MarketTierUpdate** | `0x0036` | `[secId u64][side u8][totalQty i64][orderCount u32]` |
-| **LevelUpdate**  | `0x0037` | `[secId u64][side u8][price i64][totalQty i64][orderCount u32]` |
-| **LevelDeleted** | `0x0038` | `[secId u64][side u8][price i64]` |
+| **MarketTierUpdate** | `0x0036` | `[secId u64][totalQty i64][orderCount u32][side u8]` |
+| **LevelUpdate**  | `0x0037` | `[secId u64][price i64][totalQty i64][orderCount u32][side u8]` |
+| **LevelDeleted** | `0x0038` | `[secId u64][price i64][side u8]` |
+
+> **v2 hot-frame layout.** These fixed-size frames are laid out **largest-field
+> first** (`u64`/`i64` before `u32` before `u8`) so they map to blittable
+> structs with natural alignment. The single-byte discriminators (`side`,
+> `flags`) sit at the **end** of the payload. This is the one place v2 reordered
+> fields relative to v1; all other (variable) frames keep their historic field
+> order. Decoders MUST honour the framing length and the min-length rule (read
+> the fields they know, ignore any trailing bytes) rather than assuming an exact
+> size.
 
 For order events and `MarketTierUpdate`, `side` = `0` (Bid) or `1` (Ask).
 For `BookCleared`, `clearSide` = `0` (Both), `1` (Bid), or `2` (Ask).
@@ -306,12 +393,12 @@ Prices use the SBE schema's exponents:
 
 All other bits are reserved (must be 0). Clients MUST mask with the
 documented bit values rather than equality-checking the whole byte.
-Servers that predate the flag byte wrote the legacy 36-byte `Trade`
-frame; the framing header reports the true length, and decoders that
-read flags MUST treat absence as `0` (no flags set). Trade history
-frames replayed from the per-symbol recent-trades ring preserve the
-per-trade flags captured at ingest time (each ring slot stores the
-flag byte alongside price/qty/tradeId).
+Decoders MUST apply the **min-length rule**: read the fields they know
+using the framing length, treat a `flags` byte that is absent (a shorter
+frame) as `0`, and ignore any trailing bytes beyond what they understand.
+Trade history frames replayed from the per-symbol recent-trades ring
+preserve the per-trade flags captured at ingest time (each ring slot
+stores the flag byte alongside price/qty/tradeId).
 
 `MarketTierUpdate` represents B3 null-price MOA/MOC orders as an aggregate
 market tier per side. It is intentionally separate from priced order events:
@@ -336,8 +423,8 @@ The server retains **the last 10 hours of 1 s candles per instrument**. On
 subscribe (with `Book` flag) the entire window is delivered as a sequence
 of `CandleSnapshot` frames:
 
-- Each snapshot carries up to **1364 candles** (the per-message limit
-  imposed by the `u16` framing length).
+- Each snapshot carries up to **1364 candles** (a per-frame chunk cap that
+  bounds individual message size).
 - `flags`:
   - `0x01` (`First`) — first batch of the snapshot; client should reset
     its candle buffer for that security.
@@ -347,8 +434,8 @@ of `CandleSnapshot` frames:
 
 ### News (opt-in via `DataFlags.News`)
 
-News deliveries are split across three message types so that bodies larger
-than the `u16` framing length (~64 KiB) still fit in the protocol. A single
+News deliveries are split across three message types so that arbitrarily
+large bodies stay within a bounded per-frame size. A single
 logical news item is emitted as exactly one `NewsBegin`, then `N`
 `NewsChunk` frames (one or more per field, in `Headline → Text → URL`
 order), then exactly one `NewsEnd` (which carries the *last* fragment of
@@ -377,6 +464,45 @@ Routing:
 Clients with the `News` flag will not receive news that arrives **before**
 they subscribe — the server has no replay buffer for news.
 
+## Forward-Compatibility Contract
+
+Protocol v2 is designed so that **every future change is additive** — a v2
+decoder keeps working against a newer server, and a newer decoder keeps working
+against a v2 server. The rules below are **normative**; both the server and every
+client decoder MUST follow them.
+
+1. **`messageLength` is authoritative.** Always use the framing length to locate
+   the next frame and to bound the current one. Never infer a frame's end from
+   the fields you happen to know.
+2. **Skip-unknown / min-length rule.** Fixed frames have a documented minimum
+   length. A decoder reads only the fields it knows and **ignores any trailing
+   bytes**. New fields are appended at the end of a frame (length-gated), so an
+   old decoder transparently skips them. Never validate an *exact* frame size —
+   only `length >= minLength`. A field that is absent (shorter frame than your
+   build expects) is treated as its documented default (e.g. `Trade.flags = 0`).
+3. **Append-only type & bit space.** Message-type codes, `DataFlags` bits,
+   capability bits, and per-field bitmask positions are **never renumbered or
+   reused**. New values are only ever *added*. A decoder that receives an unknown
+   `messageType` MUST skip the whole frame (using `length`); an unknown
+   `DataFlags`/mask bit MUST be ignored (the server masks off unknown requested
+   bits and echoes only the accepted set in `SubscribeOk`).
+4. **`headerFlags` is reject-on-unknown.** Unlike payload extensions, an unknown
+   header-flag bit may change how the payload is framed/encoded (e.g.
+   compression). A receiver that sees any header-flag bit it does not understand
+   MUST reject the frame / close the connection rather than skip it.
+5. **Little-endian only.** All integers are LE. A big-endian runtime is
+   unsupported and rejected at startup.
+6. **`MaxFrameLength` guard.** A frame whose `messageLength` exceeds 16 MiB is
+   rejected before allocation (DoS protection against a bogus `u32` length).
+7. **Version negotiation.** The server announces its version in `ServerHello`;
+   a client MAY announce its own in `ClientHello`. Incompatible versions are
+   closed with WS `1003`. Because of rules 1–3, a version bump is only required
+   for a genuinely breaking change — additive channels/fields do **not** need one.
+
+Because v2 already reserves `headerFlags`, widened `DataFlags`/lengths to `u32`,
+and mandates skip-unknown everywhere, the intent is that **no further breaking
+wire change is needed** after v2.
+
 ## Subscription flow
 
 ```mermaid
@@ -385,6 +511,11 @@ sequenceDiagram
     participant C as Client
     participant S as Server (feed thread)
 
+    Note over C,S: WS connect
+    S-->>C: ServerHello(version, capabilities)
+    opt client negotiates
+        C->>S: ClientHello(version)
+    end
     C->>S: Subscribe(BEEF3, Book+Info)
     Note right of S: ProcessPendingRequests()
     S-->>C: SubscribeOk(id, flags)
@@ -415,6 +546,7 @@ sequenceDiagram
     Note over C,S: TCP/WS drop
     Note left of C: reconnect, exponential backoff
     C->>S: (open)
+    S-->>C: ServerHello(version, capabilities)
     S-->>C: ServerStatus(ready=1)
     Note right of S: or ready=0 while a group is recovering
     C->>S: Subscribe(symA, flags)

--- a/docs/WEBSOCKET_API.md
+++ b/docs/WEBSOCKET_API.md
@@ -1,14 +1,15 @@
 # WebSocket API — consumer guide
 
-**Status: v1, stable.** This page is the contract surface for downstream
+**Status: v2, stable.** This page is the contract surface for downstream
 apps that want to consume `B3MarketDataPlatform` over the network without
 reverse-engineering the bundled JS frontend. The exhaustive wire spec
 (framing, full message catalog, every field) lives in
 [WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md); this file is a thin
 landing page that highlights the parts a typical consumer needs.
 
-The canonical downstream use case driving v1 is `B3TradingPlatform`'s
-`IReferencePrice` (last-trade price feed for pre-trade risk).
+The canonical downstream use case driving the protocol is
+`B3TradingPlatform`'s `IReferencePrice` (last-trade price feed for
+pre-trade risk).
 
 ---
 
@@ -31,7 +32,7 @@ All messages — both directions — are length-prefixed little-endian
 binary frames sent as **WebSocket binary messages**:
 
 ```
-[length u16][type u16][payload …]   length includes the 4-byte header
+[length u32][type u16][headerFlags u16][payload …]   length includes the 8-byte header
 ```
 
 **The protocol is binary, not JSON.** This is a deliberate performance
@@ -39,9 +40,21 @@ choice: each message decodes with zero allocations using
 `BinaryPrimitives.ReadXxxLittleEndian`. A typed C# subscriber is ~50
 lines.
 
-`type` is a `u16` from the catalog in
-[WEBSOCKET-PROTOCOL.md §Message types](WEBSOCKET-PROTOCOL.md#message-types).
-The ones a price consumer cares about:
+`length` (`u32`) is the whole frame including the header; `type` is a `u16`
+from the catalog in
+[WEBSOCKET-PROTOCOL.md §Message types](WEBSOCKET-PROTOCOL.md#message-types);
+`headerFlags` (`u16`) is `0` in v2 — **reject any frame whose header-flags
+carry a bit you don't understand**. The payload starts at byte offset **8**.
+
+> **One WebSocket message may carry several frames.** The server *coalesces*
+> everything queued for you during a short window into a single binary message,
+> so your read loop must split frames by `length` and iterate until the message
+> is drained — do not assume one WS message equals one frame. Start with a small
+> receive buffer and grow it on demand (up to 16 MiB) rather than pre-allocating
+> the max. See
+> [WEBSOCKET-PROTOCOL.md §Consuming coalesced messages](WEBSOCKET-PROTOCOL.md#consuming-coalesced-messages).
+
+The types a price consumer cares about:
 
 | Direction | Type | Name | Purpose |
 |-----------|------|------|---------|
@@ -67,6 +80,7 @@ The minimal flow for an `IReferencePrice`-style consumer:
    (`Trades` only) — or `0x12` (`Info|Trades`) if you also want the
    periodic `InfoSnapshot` fields (which include `LastTradePrice` /
    `LastTradeSize` as canonical "last value seen by the server").
+   `flags` is a **`u32`**.
 4. Read frames in a loop. For each `Trade` (`0x0033`), update your
    in-memory `lastPrice[securityId] = price * 1e-4`.
 5. On `TradeBust` (`0x0035`), risk consumers usually **ignore** it (the
@@ -77,22 +91,22 @@ The minimal flow for an `IReferencePrice`-style consumer:
 ### Subscribe frame layout
 
 ```
-Subscribe (0x0001) — body: [flags u8][symLen u8][symbol UTF-8…]
+Subscribe (0x0001) — body (after 8-byte header): [flags u32][symLen u8][symbol UTF-8…]
 ```
 
 Example — subscribe to `PETR4` for trades only (`flags=0x10`):
 
 ```
-0c 00 01 00 10 05 50 45 54 52 34
-└──┬──┘└──┬──┘ │  │  └────┬────┘
-  len   type  fl ln    "PETR4"
-   12  0x0001 Trades 5
+12 00 00 00  01 00  00 00  10 00 00 00  05  50 45 54 52 34
+└────┬────┘ └──┬─┘ └──┬─┘ └────┬─────┘  │   └────┬──────┘
+  len(u32)   type   hdrFlags  flags(u32) ln    "PETR4"
+   18       0x0001    0        Trades     5
 ```
 
 Server replies with **`SubscribeOk`** (`0x0010`):
 
 ```
-SubscribeOk — body: [securityId u64][flags u8][symLen u8][symbol UTF-8…]
+SubscribeOk — body (after 8-byte header): [securityId u64][flags u32][symLen u8][symbol UTF-8…]
 ```
 
 Persist `securityId` — every subsequent server frame uses it as the
@@ -101,8 +115,9 @@ primary key, *not* the symbol string.
 ### `Trade` frame layout
 
 ```
-Trade (0x0033) — body: [securityId u64][price i64][qty i64][tradeId i64]
-Total: 4 + 8 + 8 + 8 + 8 = 36 bytes
+Trade (0x0033) — body (after 8-byte header):
+  [securityId u64][price i64][qty i64][tradeId i64][flags u8]
+Total: 8 (header) + 8 + 8 + 8 + 8 + 1 = 41 bytes
 ```
 
 | Field | Type | Notes |
@@ -111,28 +126,31 @@ Total: 4 + 8 + 8 + 8 + 8 = 36 bytes
 | `price` | `i64` LE | Mantissa with **exponent `-4`** (B3 SBE `Price`). Display value = `price × 10⁻⁴`. |
 | `qty` | `i64` LE | Trade size, integer units. |
 | `tradeId` | `i64` LE | Server-assigned, monotonically increasing per security. |
+| `flags` | `u8` | `TradeFlags` bitset (`0x01` = AuctionPrint). Trailing field — treat as `0` if the frame is shorter than 41 bytes (min-length rule). |
 
 ### `Trade` hex example
 
 A trade of **10.0000 @ 50** for `securityId = 0x00000000CAFEBABE`,
-`tradeId = 9999`:
+`tradeId = 9999`, `flags = 0`:
 
 ```
-24 00 33 00  BE BA FE CA 00 00 00 00  A0 86 01 00 00 00 00 00  32 00 00 00 00 00 00 00  0F 27 00 00 00 00 00 00
-└──┬──┘└──┬──┘└────────┬────────────┘└────────┬────────────┘└────────┬────────────┘└────────┬────────────┘
- len=36  type=0x33     securityId=             price=100000           qty=50                 tradeId=9999
-                       0xCAFEBABE              (= 10.0000)
+29 00 00 00  33 00  00 00  BE BA FE CA 00 00 00 00  A0 86 01 00 00 00 00 00  32 00 00 00 00 00 00 00  0F 27 00 00 00 00 00 00  00
+└────┬────┘ └──┬─┘ └──┬─┘ └────────┬────────────┘ └────────┬────────────┘ └────────┬────────────┘ └────────┬────────────┘ └┬┘
+ len=41(u32) type  hdrFlags   securityId=              price=100000            qty=50                 tradeId=9999          flags
+             0x33    0         0xCAFEBABE               (= 10.0000)                                                          =0
 ```
 
 C# decode:
 
 ```csharp
-ushort len  = BinaryPrimitives.ReadUInt16LittleEndian(buf);            // 36
-ushort type = BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]);       // 0x0033
-ulong  sid  = BinaryPrimitives.ReadUInt64LittleEndian(buf[4..]);
-long   pxM  = BinaryPrimitives.ReadInt64LittleEndian(buf[12..]);       // mantissa
-long   qty  = BinaryPrimitives.ReadInt64LittleEndian(buf[20..]);
-long   tid  = BinaryPrimitives.ReadInt64LittleEndian(buf[28..]);
+uint  len  = BinaryPrimitives.ReadUInt32LittleEndian(buf);            // 41
+ushort type = BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]);      // 0x0033
+// buf[6..8] = headerFlags (must be 0)
+ulong  sid  = BinaryPrimitives.ReadUInt64LittleEndian(buf[8..]);
+long   pxM  = BinaryPrimitives.ReadInt64LittleEndian(buf[16..]);      // mantissa
+long   qty  = BinaryPrimitives.ReadInt64LittleEndian(buf[24..]);
+long   tid  = BinaryPrimitives.ReadInt64LittleEndian(buf[32..]);
+byte   flg  = len > 40 ? buf[40] : (byte)0;                           // min-length rule
 decimal price = pxM / 10_000m;
 ```
 
@@ -147,10 +165,10 @@ A minimal snapshot with **only** `LastTradePrice = 10.0000` for
 `securityId = 0x00000000CAFEBABE` (mask bit 4):
 
 ```
-18 00 21 00  BE BA FE CA 00 00 00 00  10 00 00 00  A0 86 01 00 00 00 00 00
-└──┬──┘└──┬──┘└────────┬────────────┘└─────┬─────┘└────────┬────────────┘
- len=24  type=0x21     securityId          mask=0x10        LastTradePrice
-                       0xCAFEBABE          (bit 4)          = 100000 → 10.0000
+1c 00 00 00  21 00  00 00  BE BA FE CA 00 00 00 00  10 00 00 00  A0 86 01 00 00 00 00 00
+└────┬────┘ └──┬─┘ └──┬─┘ └────────┬────────────┘ └─────┬─────┘ └────────┬────────────┘
+ len=28(u32) type  hdrFlags   securityId=            mask=0x10       LastTradePrice
+             0x21    0         0xCAFEBABE             (bit 4)         = 100000 → 10.0000
 ```
 
 For the full bit map (24 fields, including `LastTradeSize`,
@@ -176,26 +194,27 @@ For the full bit map (24 fields, including `LastTradeSize`,
 
 ## Versioning & breaking-change policy
 
-- **v1 is stable.** Existing message types and field layouts (the rows
-  in the table above, plus everything else in
-  [WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md)) will not change shape
-  within v1.
+- **v2 is the current wire and is stable.** It replaced the pre-1.0 v1 wire
+  with a single, deliberate breaking change (8-byte `u32`-length header,
+  `u32` `DataFlags`, blittable hot-frame layout) so that **every future
+  change can be additive**. The full rules live in
+  [WEBSOCKET-PROTOCOL.md §Forward-Compatibility Contract](WEBSOCKET-PROTOCOL.md#forward-compatibility-contract).
+  Clients built against v0.x SDK tags must upgrade.
 - **Additive changes are non-breaking** and may ship in any release:
-  - New `MessageType` values.
-  - New bits in `DataFlags`.
-  - New bits in `InfoSnapshot.fieldMask` (appended at the next free
-    bit position; existing masks remain valid).
+  - New `MessageType` values (unknown types are skipped via the framing length).
+  - New bits in `DataFlags` (unknown bits are masked off by the server).
+  - New trailing fields appended to an existing fixed frame (old decoders
+    skip them via the min-length rule).
+  - New bits in `InfoSnapshot.fieldMask` (appended at the next free bit
+    position; existing masks remain valid).
   - New optional REST endpoints alongside the WS layer.
-- **Breaking changes require a v2 surface.** That includes: changing
-  the size or order of fields in an existing message, removing a
-  message type, repurposing a `DataFlags` bit, or changing the framing
-  header. v2 will be advertised by a new `MessageType` (e.g. a
-  versioned `Hello`) before the legacy v1 wire is removed; v1 will be
-  supported for at least one major release after v2 ships.
-- The published Docker image tag (`v1.x.y`) is the stability anchor.
-  Pin to a specific `vX.Y.Z` (or `sha-<short>`) in production; `latest`
-  tracks `main` and may include experimental aditive features behind
-  flags.
+- **A future breaking change would require a v3 surface** and a
+  `ProtocolVersion` bump advertised in `ServerHello`. Because v2 already
+  reserves `headerFlags`, widened lengths/flags to `u32`, and mandates
+  skip-unknown everywhere, none is anticipated.
+- The published Docker image tag (`v1.x.y`) is the stability anchor. Pin to
+  a specific `vX.Y.Z` (or `sha-<short>`) in production; `latest` tracks
+  `main` and may include experimental additive features behind flags.
 
 ## Out of scope here
 

--- a/frontend/js/protocol.js
+++ b/frontend/js/protocol.js
@@ -78,23 +78,24 @@ const encoder = new TextEncoder();
 
 export function buildSubscribeOrGet(msgType, symbol, flags) {
   const symBytes = encoder.encode(symbol.toUpperCase().trim());
-  const totalLen = 4 + 1 + 1 + symBytes.length;
+  // v2: [len u32][type u16][headerFlags u16][flags u32][symLen u8][symbol]
+  const totalLen = 8 + 4 + 1 + symBytes.length;
   const buf = new ArrayBuffer(totalLen);
   const v = new DataView(buf);
-  v.setUint16(0, totalLen, true);
-  v.setUint16(2, msgType, true);
-  v.setUint8(4, flags);
-  v.setUint8(5, symBytes.length);
-  new Uint8Array(buf, 6).set(symBytes);
+  v.setUint32(0, totalLen, true);
+  v.setUint16(4, msgType, true);
+  v.setUint32(8, flags >>> 0, true);
+  v.setUint8(12, symBytes.length);
+  new Uint8Array(buf, 13).set(symBytes);
   return buf;
 }
 
 export function buildUnsubscribe(securityId) {
-  const buf = new ArrayBuffer(12);
+  const buf = new ArrayBuffer(16);
   const v = new DataView(buf);
-  v.setUint16(0, 12, true);
-  v.setUint16(2, MSG.UNSUBSCRIBE, true);
-  v.setBigUint64(4, securityId, true);
+  v.setUint32(0, 16, true);
+  v.setUint16(4, MSG.UNSUBSCRIBE, true);
+  v.setBigUint64(8, securityId, true);
   return buf;
 }
 
@@ -104,15 +105,15 @@ export function buildUnsubscribe(securityId) {
 const decoder = new TextDecoder();
 
 export function parseMessage(buf, baseOffset, msgLen) {
-  if (msgLen < 4) return null;
+  if (msgLen < 8) return null;
   const v = new DataView(buf, baseOffset, msgLen);
-  const type = v.getUint16(2, true);
-  let o = 4;
+  const type = v.getUint16(4, true);
+  let o = 8;
 
   switch (type) {
     case MSG.SUBSCRIBE_OK: {
       const securityId = v.getBigUint64(o, true); o += 8;
-      const flags = v.getUint8(o); o += 1;
+      const flags = v.getUint32(o, true); o += 4;
       const sLen = v.getUint8(o); o += 1;
       const symbol = decoder.decode(new Uint8Array(buf, baseOffset + o, sLen));
       return { type: 'SubscribeOk', securityId, flags, symbol };
@@ -146,11 +147,12 @@ export function parseMessage(buf, baseOffset, msgLen) {
     }
     case MSG.ORDER_ADDED:
     case MSG.ORDER_UPDATED: {
+      // v2 layout: secId, orderId, price, qty, side (side moved to the end).
       const securityId = v.getBigUint64(o, true); o += 8;
       const orderId = v.getBigUint64(o, true); o += 8;
-      const side = v.getUint8(o); o += 1;
       const price = Number(v.getBigInt64(o, true)); o += 8;
-      const qty = Number(v.getBigInt64(o, true));
+      const qty = Number(v.getBigInt64(o, true)); o += 8;
+      const side = v.getUint8(o);
       const typeName = type === MSG.ORDER_ADDED ? 'OrderAdded' : 'OrderUpdated';
       return { type: typeName, securityId, orderId, side, price, qty };
     }
@@ -165,8 +167,8 @@ export function parseMessage(buf, baseOffset, msgLen) {
       const price = Number(v.getBigInt64(o, true)); o += 8;
       const qty = Number(v.getBigInt64(o, true)); o += 8;
       const tradeId = Number(v.getBigInt64(o, true)); o += 8;
-      // Trailing flags byte (added later). Tolerate older servers that wrote
-      // the legacy 36-byte frame — treat absence as 0 (no flags).
+      // Trailing flags byte. Min-length rule: tolerate a shorter frame that
+      // omits it by treating absence as 0 (no flags).
       const flags = o < msgLen ? v.getUint8(o) : 0;
       const auctionPrint = (flags & 0x01) !== 0;
       return { type: 'Trade', securityId, price, qty, tradeId, flags, auctionPrint };
@@ -177,10 +179,11 @@ export function parseMessage(buf, baseOffset, msgLen) {
       return { type: 'BookCleared', securityId, side };
     }
     case MSG.MARKET_TIER_UPDATE: {
+      // v2 layout: secId, totalQty, orderCount(u32), side(u8).
       const securityId = v.getBigUint64(o, true); o += 8;
-      const side = v.getUint8(o); o += 1;
       const qty = Number(v.getBigInt64(o, true)); o += 8;
-      const count = v.getUint32(o, true);
+      const count = v.getUint32(o, true); o += 4;
+      const side = v.getUint8(o);
       return { type: 'MarketTierUpdate', securityId, side, qty, count };
     }
     case MSG.LEVEL_SNAPSHOT: {
@@ -206,17 +209,19 @@ export function parseMessage(buf, baseOffset, msgLen) {
       return { type: 'LevelSnapshot', securityId, bids, asks };
     }
     case MSG.LEVEL_UPDATE: {
+      // v2 layout: secId, price, totalQty, orderCount(u32), side(u8).
       const securityId = v.getBigUint64(o, true); o += 8;
-      const side = v.getUint8(o); o += 1;
       const price = Number(v.getBigInt64(o, true)); o += 8;
       const qty = Number(v.getBigInt64(o, true)); o += 8;
-      const count = v.getUint32(o, true);
+      const count = v.getUint32(o, true); o += 4;
+      const side = v.getUint8(o);
       return { type: 'LevelUpdate', securityId, side, price, qty, count };
     }
     case MSG.LEVEL_DELETED: {
+      // v2 layout: secId, price, side(u8).
       const securityId = v.getBigUint64(o, true); o += 8;
-      const side = v.getUint8(o); o += 1;
-      const price = Number(v.getBigInt64(o, true));
+      const price = Number(v.getBigInt64(o, true)); o += 8;
+      const side = v.getUint8(o);
       return { type: 'LevelDeleted', securityId, side, price };
     }
     case MSG.RANKINGS_UPDATE: {

--- a/frontend/js/worker.js
+++ b/frontend/js/worker.js
@@ -554,9 +554,9 @@ function connect(url) {
     const buf = evt.data;
     const view = new DataView(buf);
     let offset = 0;
-    while (offset + 4 <= buf.byteLength) {
-      const len = view.getUint16(offset, true);
-      if (len < 4 || offset + len > buf.byteLength) break;
+    while (offset + 8 <= buf.byteLength) {
+      const len = view.getUint32(offset, true);
+      if (len < 8 || offset + len > buf.byteLength) break;
       stats.msgs++;
       const msg = parseMessage(buf, offset, len);
       if (msg) handleMessage(msg);

--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -28,6 +28,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Single canonical wire-protocol definition (neutral protocol assembly).
+         Referenced (not the server) so the published SDK stays server-free while
+         both sides share one definition. -->
+    <ProjectReference Include="..\B3.MarketData.Wire\B3.MarketData.Wire.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
@@ -380,9 +381,13 @@ public sealed class MarketDataClient : IAsyncDisposable
 
     private async Task ReceiveLoopAsync(ClientWebSocket socket, CancellationToken ct)
     {
-        // 64 KiB matches the protocol's u16-length cap; anything larger
-        // would be a server-side bug (and we'd close on it anyway).
-        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        // Start small and grow on demand for the rare coalesced batch that
+        // exceeds it, up to WireV2.MaxFrameLength (16 MiB). Renting the max up
+        // front would pin 16 MiB per live connection while typical messages are
+        // only a few KiB. The 16 MiB ceiling comfortably clears the server's
+        // per-client coalescing/pending cap, so no legitimate batch is rejected.
+        const int InitialReceiveBufferSize = 64 * 1024;
+        var buffer = ArrayPool<byte>.Shared.Rent(InitialReceiveBufferSize);
         try
         {
             while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
@@ -399,7 +404,17 @@ public sealed class MarketDataClient : IAsyncDisposable
                     }
                     filled += result.Count;
                     if (filled == buffer.Length && !result.EndOfMessage)
-                        throw new InvalidOperationException("WebSocket frame exceeded 64 KiB buffer (protocol violation).");
+                    {
+                        if (buffer.Length >= WireV2.MaxFrameLength)
+                            throw new InvalidOperationException(
+                                $"WebSocket message exceeded {WireV2.MaxFrameLength} bytes (protocol violation).");
+
+                        int newSize = (int)Math.Min((long)buffer.Length * 2, WireV2.MaxFrameLength);
+                        var bigger = ArrayPool<byte>.Shared.Rent(newSize);
+                        Buffer.BlockCopy(buffer, 0, bigger, 0, filled);
+                        ArrayPool<byte>.Shared.Return(buffer);
+                        buffer = bigger;
+                    }
                 }
                 while (!result.EndOfMessage);
 
@@ -429,34 +444,34 @@ public sealed class MarketDataClient : IAsyncDisposable
 
         while (offset < span.Length)
         {
-            if (!WireFormat.TryReadHeader(span[offset..], out ushort len, out var type) || len < WireFormat.FramingHeaderSize)
+            if (!WireFormat.TryReadHeader(span[offset..], out uint len, out var type) || len < WireFormat.FramingHeaderSize)
             {
-                _logger.LogWarning("Truncated frame header at offset {Offset}; dropping rest of packet.", offset);
+                _logger.LogWarning("Truncated/unsupported frame header at offset {Offset}; dropping rest of packet.", offset);
                 return;
             }
-            if (offset + len > span.Length)
+            if (offset + (int)len > span.Length)
             {
                 _logger.LogWarning("Truncated frame body (declared {Len}, available {Avail}); dropping rest.", len, span.Length - offset);
                 return;
             }
 
-            var payload = span.Slice(offset + WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize);
+            var payload = span.Slice(offset + WireFormat.FramingHeaderSize, (int)len - WireFormat.FramingHeaderSize);
             DecodeAndEnqueue(type, payload, receivedUtc);
-            offset += len;
+            offset += (int)len;
         }
     }
 
-    private void DecodeAndEnqueue(WireFormat.MessageType type, ReadOnlySpan<byte> payload, DateTime receivedUtc)
+    private void DecodeAndEnqueue(MessageType type, ReadOnlySpan<byte> payload, DateTime receivedUtc)
     {
         switch (type)
         {
-            case WireFormat.MessageType.ServerStatus:
+            case MessageType.ServerStatus:
             {
                 bool ready = WireFormat.ReadServerStatus(payload);
                 Enqueue(() => ServerStatus?.Invoke(new ServerStatusEvent(ready, receivedUtc)));
                 break;
             }
-            case WireFormat.MessageType.ServerHello:
+            case MessageType.ServerHello:
             {
                 var (ver, caps, build) = WireFormat.ReadServerHello(payload);
                 var ev = new ServerHelloEvent(ver, caps, build, receivedUtc);
@@ -464,14 +479,14 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => ServerHello?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.SymbolDelisted:
+            case MessageType.SymbolDelisted:
             {
                 ulong secId = WireFormat.ReadSymbolDelisted(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
                 Enqueue(() => SymbolDelisted?.Invoke(new SymbolDelistedEvent(secId, symbol, receivedUtc)));
                 break;
             }
-            case WireFormat.MessageType.SubscribeOk:
+            case MessageType.SubscribeOk:
             {
                 var (secId, _, sym) = WireFormat.ReadSubscribeOk(payload);
                 _securityIdToSymbol[secId] = sym;
@@ -479,7 +494,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                     rec.SecurityId = secId;
                 break;
             }
-            case WireFormat.MessageType.SubscribeError:
+            case MessageType.SubscribeError:
             {
                 var (sym, code) = WireFormat.ReadSubscribeError(payload);
                 Enqueue(() => SubscribeError?.Invoke(new SubscribeErrorEvent(
@@ -488,7 +503,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                     receivedUtc)));
                 break;
             }
-            case WireFormat.MessageType.Trade:
+            case MessageType.Trade:
             {
                 var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -496,14 +511,14 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => Trade?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.TradeBust:
+            case MessageType.TradeBust:
             {
                 var (secId, tradeId) = WireFormat.ReadTradeBust(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
                 Enqueue(() => TradeBust?.Invoke(new TradeBustEvent(secId, symbol, tradeId, receivedUtc)));
                 break;
             }
-            case WireFormat.MessageType.InfoSnapshot:
+            case MessageType.InfoSnapshot:
             {
                 ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -514,7 +529,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => InfoSnapshot?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.SecurityDefinition:
+            case MessageType.SecurityDefinition:
             {
                 // SecurityDefinition embeds its own Symbol field on the wire, so
                 // the decoder does not consult _securityIdToSymbol — useful for
@@ -524,7 +539,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => SecurityDefinition?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.PriceBand:
+            case MessageType.PriceBand:
             {
                 // PriceBand embeds its own Symbol field on the wire, same as
                 // SecurityDefinition — no _securityIdToSymbol lookup needed.
@@ -532,7 +547,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => PriceBand?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.Auction:
+            case MessageType.Auction:
             {
                 // Auction embeds Symbol on the wire — no _securityIdToSymbol needed.
                 var ev = WireFormat.ReadAuction(payload, receivedUtc);
@@ -540,7 +555,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 break;
             }
             // ── L3 / order-by-order (MBO) ─────────────────────────
-            case WireFormat.MessageType.BookSnapshot:
+            case MessageType.BookSnapshot:
             {
                 ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -548,7 +563,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => BookSnapshot?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.OrderAdded:
+            case MessageType.OrderAdded:
             {
                 var (secId, orderId, sideByte, price, qty) = WireFormat.ReadOrderEvent(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -557,7 +572,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => OrderAdded?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.OrderUpdated:
+            case MessageType.OrderUpdated:
             {
                 var (secId, orderId, sideByte, price, qty) = WireFormat.ReadOrderEvent(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -566,7 +581,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => OrderUpdated?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.OrderDeleted:
+            case MessageType.OrderDeleted:
             {
                 var (secId, orderId, sideByte) = WireFormat.ReadOrderDeleted(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -574,7 +589,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => OrderDeleted?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.BookCleared:
+            case MessageType.BookCleared:
             {
                 var (secId, clearByte) = WireFormat.ReadBookCleared(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -585,7 +600,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => BookCleared?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.MarketTierUpdate:
+            case MessageType.MarketTierUpdate:
             {
                 var (secId, sideByte, totalQty, orderCount) = WireFormat.ReadMarketTierUpdate(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -595,7 +610,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 break;
             }
             // ── MBP / aggregated levels ───────────────────────────
-            case WireFormat.MessageType.LevelSnapshot:
+            case MessageType.LevelSnapshot:
             {
                 ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -603,7 +618,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => LevelSnapshot?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.LevelUpdate:
+            case MessageType.LevelUpdate:
             {
                 var (secId, sideByte, price, totalQty, orderCount) = WireFormat.ReadLevelUpdate(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -612,7 +627,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => LevelUpdate?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.LevelDeleted:
+            case MessageType.LevelDeleted:
             {
                 var (secId, sideByte, price) = WireFormat.ReadLevelDeleted(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -622,21 +637,21 @@ public sealed class MarketDataClient : IAsyncDisposable
                 break;
             }
             // ── Stale / recovery ──────────────────────────────────
-            case WireFormat.MessageType.SymbolStaleStatus:
+            case MessageType.SymbolStaleStatus:
             {
                 var (secId, isStale) = WireFormat.ReadSymbolStaleStatus(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
                 Enqueue(() => SymbolStaleStatus?.Invoke(new SymbolStaleStatusEvent(secId, symbol, isStale, receivedUtc)));
                 break;
             }
-            case WireFormat.MessageType.RecoveryProgress:
+            case MessageType.RecoveryProgress:
             {
                 var ev = WireFormat.ReadRecoveryProgress(payload, receivedUtc);
                 Enqueue(() => RecoveryProgress?.Invoke(ev));
                 break;
             }
             // ── Candles ───────────────────────────────────────────
-            case WireFormat.MessageType.CandleSnapshot:
+            case MessageType.CandleSnapshot:
             {
                 ulong secId = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -644,7 +659,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                 Enqueue(() => CandleSnapshot?.Invoke(ev));
                 break;
             }
-            case WireFormat.MessageType.CandleUpdate:
+            case MessageType.CandleUpdate:
             {
                 var (secId, resolution, candle) = WireFormat.ReadCandleUpdate(payload);
                 string symbol = _securityIdToSymbol.TryGetValue(secId, out var s) ? s : "";
@@ -653,14 +668,14 @@ public sealed class MarketDataClient : IAsyncDisposable
                 break;
             }
             // ── Rankings ──────────────────────────────────────────
-            case WireFormat.MessageType.RankingsUpdate:
+            case MessageType.RankingsUpdate:
             {
                 var ev = WireFormat.ReadRankingsUpdate(payload, receivedUtc);
                 Enqueue(() => RankingsUpdate?.Invoke(ev));
                 break;
             }
             // ── News (fragmented; reassembled before raising) ─────
-            case WireFormat.MessageType.NewsBegin:
+            case MessageType.NewsBegin:
             {
                 var hdr = WireFormat.ReadNewsBegin(payload);
                 if (hdr.Version != WireFormat.NewsFrameVersion)
@@ -675,7 +690,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                     (int)Math.Min(hdr.TotalUrlLen, int.MaxValue));
                 break;
             }
-            case WireFormat.MessageType.NewsChunk:
+            case MessageType.NewsChunk:
             {
                 var (version, newsId, field) = WireFormat.ReadNewsChunk(payload, out var fragment);
                 if (version != WireFormat.NewsFrameVersion) break;
@@ -683,7 +698,7 @@ public sealed class MarketDataClient : IAsyncDisposable
                     ra.Append(field, fragment);
                 break;
             }
-            case WireFormat.MessageType.NewsEnd:
+            case MessageType.NewsEnd:
             {
                 var (version, newsId, field) = WireFormat.ReadNewsChunk(payload, out var fragment);
                 if (version != WireFormat.NewsFrameVersion) break;
@@ -697,7 +712,7 @@ public sealed class MarketDataClient : IAsyncDisposable
             }
             // Unsubscribed (0x0012) is currently silent — the application
             // already knows it called UnsubscribeAsync.
-            case WireFormat.MessageType.Unsubscribed:
+            case MessageType.Unsubscribed:
                 break;
             default:
             {

--- a/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
+++ b/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
@@ -3,10 +3,11 @@ namespace B3.MarketData.WebSocketClient;
 /// <summary>
 /// Bitmask matching the server's <c>DataFlags</c> enum. Combine with <c>|</c>
 /// (e.g. <c>Trades | Info | Mbp</c>). Bit positions are part of the wire
-/// contract — never reorder or repurpose.
+/// contract — never reorder or repurpose. Underlying type is <c>uint</c> to
+/// match the 32-bit wire <c>DataFlags</c>, leaving room for future channels.
 /// </summary>
 [Flags]
-public enum SubscribeFlags : byte
+public enum SubscribeFlags : uint
 {
     /// <summary>
     /// L3 / order-by-order book: <see cref="MarketDataClient.BookSnapshot"/> on
@@ -84,6 +85,10 @@ public enum SubscribeFlags : byte
     /// Mirrors the server's <c>DataFlags.All</c> — does NOT include News, MBP, Trades, SecurityDefinition, PriceBand, or Auction.</summary>
     All = Book | Info,
 
-    /// <summary>Convenience alias for every data class: Book + Info + News + MBP + Trades + SecurityDefinition + PriceBand + Auction.</summary>
-    Everything = Book | Info | News | Mbp | Trades | SecurityDefinition | PriceBand | Auction,
+    /// <summary>Every data class this SDK build knows about: Book + Info + News + MBP + Trades + SecurityDefinition + PriceBand + Auction.
+    /// NOT all-ones — future channels are added here explicitly so unknown bits stay unrequested.</summary>
+    AllKnown = Book | Info | News | Mbp | Trades | SecurityDefinition | PriceBand | Auction,
+
+    /// <summary>Deprecated alias for <see cref="AllKnown"/>. Prefer <see cref="AllKnown"/>.</summary>
+    Everything = AllKnown,
 }

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -1,18 +1,20 @@
 using System.Buffers.Binary;
 using System.Text;
+using B3.MarketData.Wire;
 
 namespace B3.MarketData.WebSocketClient;
 
 /// <summary>
-/// Binary wire format for the B3MarketDataPlatform WebSocket protocol.
-/// Mirrors a minimal subset of the server's <c>WireProtocol</c> + the
-/// <c>MessageType</c> enum, just for the v1 SDK surface.
-/// Layout: <c>[length u16][type u16][payload]</c>, little-endian; length
-/// includes the 4-byte header.
+/// Binary wire format (v2) for the B3MarketDataPlatform WebSocket protocol.
+/// Framing and the <see cref="MessageType"/> / <see cref="DataFlags"/> enums plus
+/// the blittable fixed-frame structs come from the shared <c>B3.MarketData.Wire</c>
+/// assembly so this SDK cannot drift from the server. Layout:
+/// <c>[u32 length][u16 type][u16 headerFlags][payload]</c>, little-endian; length
+/// includes the 8-byte header.
 /// </summary>
 internal static class WireFormat
 {
-    public const int FramingHeaderSize = 4;
+    public const int FramingHeaderSize = WireV2.HeaderSize;
 
     /// <summary>SBE schema's <c>Price</c>/<c>PriceOptional</c> exponent (1e-4).</summary>
     public const decimal PriceScale = 10_000m;
@@ -20,42 +22,6 @@ internal static class WireFormat
     /// <summary>SBE schema's <c>Fixed8</c> exponent (1e-8) — used by
     /// <c>SecurityDefinition_12.MinPriceIncrement</c>.</summary>
     public const decimal PriceScale8 = 100_000_000m;
-
-    public enum MessageType : ushort
-    {
-        Subscribe = 0x0001,
-        Unsubscribe = 0x0002,
-        SubscribeOk = 0x0010,
-        SubscribeError = 0x0011,
-        Unsubscribed = 0x0012,
-        BookSnapshot = 0x0020,
-        InfoSnapshot = 0x0021,
-        LevelSnapshot = 0x0022,
-        OrderAdded = 0x0030,
-        OrderUpdated = 0x0031,
-        OrderDeleted = 0x0032,
-        Trade = 0x0033,
-        BookCleared = 0x0034,
-        TradeBust = 0x0035,
-        MarketTierUpdate = 0x0036,
-        LevelUpdate = 0x0037,
-        LevelDeleted = 0x0038,
-        RankingsUpdate = 0x0040,
-        ServerStatus = 0x0050,
-        CandleSnapshot = 0x0060,
-        CandleUpdate = 0x0061,
-        SymbolStaleStatus = 0x0070,
-        SymbolDelisted = 0x0071,
-        RecoveryProgress = 0x0080,
-        NewsBegin = 0x0090,
-        NewsChunk = 0x0091,
-        NewsEnd = 0x0092,
-        ServerHello = 0x00A0,
-        ClientHello = 0x00A1,
-        SecurityDefinition = 0x00B0,
-        PriceBand = 0x00B1,
-        Auction = 0x00B2,
-    }
 
     // InfoSnapshot field-mask bit positions. Must match the server's
     // WireProtocol field constants (Field*). Only the bits the SDK
@@ -138,16 +104,15 @@ internal static class WireFormat
     public const int AuctionFieldAsOfTimestampNanos = 4;
     public const int AuctionFieldRptSeq = 5;
 
-    public static bool TryReadHeader(ReadOnlySpan<byte> src, out ushort length, out MessageType type)
+    public static bool TryReadHeader(ReadOnlySpan<byte> src, out uint length, out MessageType type)
     {
-        if (src.Length < FramingHeaderSize)
+        if (!WireFrame.TryReadHeader(src, out length, out type, out var headerFlags)
+            || headerFlags != HeaderFlags.None)
         {
             length = 0;
             type = 0;
             return false;
         }
-        length = BinaryPrimitives.ReadUInt16LittleEndian(src);
-        type = (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(src[2..]);
         return true;
     }
 
@@ -156,46 +121,35 @@ internal static class WireFormat
     /// on every (re)connect; servers that do not understand the version close the
     /// connection with WS code 1003.
     /// </summary>
-    public const uint ProtocolVersion = 1;
+    public const uint ProtocolVersion = WireV2.ProtocolVersion;
 
-    /// <summary>Encode a <c>ClientHello</c> frame: <c>[u32 protocolVersion]</c>.</summary>
-    public static int WriteClientHello(Span<byte> dest, uint protocolVersion)
-    {
-        const ushort totalLen = FramingHeaderSize + 4;
-        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)MessageType.ClientHello);
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[FramingHeaderSize..], protocolVersion);
-        return totalLen;
-    }
+    /// <summary>Encode a <c>ClientHello</c> frame:
+    /// <c>[u32 protocolVersion][u32 clientCapabilities]</c> (16 bytes).</summary>
+    public static int WriteClientHello(Span<byte> dest, uint protocolVersion, ClientCapabilities capabilities = ClientCapabilities.None)
+        => WireFrame.Write(dest, new ClientHelloFrame(protocolVersion, capabilities));
 
-    /// <summary>Encode a <c>Subscribe</c> frame: <c>[flags u8][symLen u8][symbol UTF-8…]</c>.</summary>
+    /// <summary>Encode a <c>Subscribe</c> frame: <c>[flags u32][symLen u8][symbol UTF-8…]</c>.</summary>
     public static int WriteSubscribe(Span<byte> dest, SubscribeFlags flags, string symbol)
     {
-        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[(FramingHeaderSize + 2)..]);
-        ushort totalLen = (ushort)(FramingHeaderSize + 1 + 1 + symbolLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)MessageType.Subscribe);
-        dest[FramingHeaderSize] = (byte)flags;
-        dest[FramingHeaderSize + 1] = (byte)symbolLen;
+        int o = FramingHeaderSize;
+        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[(o + 4 + 1)..]);
+        int totalLen = o + 4 + 1 + symbolLen;
+        WireFrame.WriteHeader(dest, totalLen, MessageType.Subscribe);
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[o..], (uint)flags);
+        dest[o + 4] = (byte)symbolLen;
         return totalLen;
     }
 
     /// <summary>Encode an <c>Unsubscribe</c> frame: <c>[securityId u64]</c>.</summary>
     public static int WriteUnsubscribe(Span<byte> dest, ulong securityId)
-    {
-        const ushort totalLen = FramingHeaderSize + 8;
-        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)MessageType.Unsubscribe);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[FramingHeaderSize..], securityId);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new SecurityIdFrame(MessageType.Unsubscribe, securityId));
 
-    public static (ulong SecurityId, byte Flags, string Symbol) ReadSubscribeOk(ReadOnlySpan<byte> payload)
+    public static (ulong SecurityId, uint Flags, string Symbol) ReadSubscribeOk(ReadOnlySpan<byte> payload)
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
-        byte flags = payload[8];
-        byte symLen = payload[9];
-        string sym = Encoding.UTF8.GetString(payload.Slice(10, symLen));
+        uint flags = BinaryPrimitives.ReadUInt32LittleEndian(payload[8..]);
+        byte symLen = payload[12];
+        string sym = Encoding.UTF8.GetString(payload.Slice(13, symLen));
         return (secId, flags, sym);
     }
 
@@ -608,9 +562,9 @@ internal static class WireFormat
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
         ulong orderId = BinaryPrimitives.ReadUInt64LittleEndian(payload[8..]);
-        byte side = payload[16];
-        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[17..]);
-        long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[25..]);
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[16..]);
+        long qty = BinaryPrimitives.ReadInt64LittleEndian(payload[24..]);
+        byte side = payload[32];
         return (secId, orderId, side, price, qty);
     }
 
@@ -635,9 +589,9 @@ internal static class WireFormat
     public static (ulong SecurityId, byte Side, long TotalQty, int OrderCount) ReadMarketTierUpdate(ReadOnlySpan<byte> payload)
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
-        byte side = payload[8];
-        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
-        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[17..]);
+        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
+        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[16..]);
+        byte side = payload[20];
         return (secId, side, totalQty, orderCount);
     }
 
@@ -699,10 +653,10 @@ internal static class WireFormat
     public static (ulong SecurityId, byte Side, long Price, long TotalQty, int OrderCount) ReadLevelUpdate(ReadOnlySpan<byte> payload)
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
-        byte side = payload[8];
-        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
-        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[17..]);
-        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[25..]);
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
+        long totalQty = BinaryPrimitives.ReadInt64LittleEndian(payload[16..]);
+        int orderCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(payload[24..]);
+        byte side = payload[28];
         return (secId, side, price, totalQty, orderCount);
     }
 
@@ -710,8 +664,8 @@ internal static class WireFormat
     public static (ulong SecurityId, byte Side, long Price) ReadLevelDeleted(ReadOnlySpan<byte> payload)
     {
         ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
-        byte side = payload[8];
-        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[9..]);
+        long price = BinaryPrimitives.ReadInt64LittleEndian(payload[8..]);
+        byte side = payload[16];
         return (secId, side, price);
     }
 

--- a/src/B3.MarketData.Wire/B3.MarketData.Wire.csproj
+++ b/src/B3.MarketData.Wire/B3.MarketData.Wire.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>B3.MarketData.Wire</RootNamespace>
+    <AssemblyName>B3.MarketData.Wire</AssemblyName>
+
+    <!-- Packaging: this is the canonical, versioned wire-protocol definition.
+         Published so third parties (and the SDK) can implement v2 against it. -->
+    <IsPackable>true</IsPackable>
+    <PackageId>B3.MarketData.Wire</PackageId>
+    <Version Condition="'$(PackageVersion)' == ''">0.4.0</Version>
+    <Authors>pedrosakuma</Authors>
+    <Description>Canonical binary wire-protocol definition (v2) for the B3MarketDataPlatform WebSocket distribution layer: framing, message types, data-channel flags, and blittable frame structs.</Description>
+    <PackageTags>b3;marketdata;websocket;protocol;wire</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/pedrosakuma/B3MarketDataPlatform</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pedrosakuma/B3MarketDataPlatform</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <DebugType>portable</DebugType>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.MarketData.WebSocketClient.Tests" />
+    <InternalsVisibleTo Include="B3.Umdf.Server.Tests" />
+    <InternalsVisibleTo Include="B3.Umdf.Fuzz.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/B3.MarketData.Wire/Frames.Fixed.cs
+++ b/src/B3.MarketData.Wire/Frames.Fixed.cs
@@ -1,0 +1,294 @@
+using System.Runtime.InteropServices;
+
+namespace B3.MarketData.Wire;
+
+// Fixed-layout ("v2 core") frames. Each struct embeds the 8-byte framing header
+// at offsets 0/4/6 and lays payload fields out largest-first with natural
+// internal alignment and NO tail padding. The published WireSize is a MINIMUM
+// length: decoders must accept longer frames and ignore trailing bytes. Fields
+// are little-endian (host-LE fast path; see WireFrame.EnsureLittleEndian).
+
+/// <summary>Base helpers shared by fixed frame structs.</summary>
+internal static class FrameHeaderFields
+{
+    public const int LengthOffset = 0;
+    public const int TypeOffset = 4;
+    public const int HeaderFlagsOffset = 6;
+}
+
+/// <summary><see cref="MessageType.ClientHello"/> — 16 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct ClientHelloFrame
+{
+    public const int WireSize = 16;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly uint ProtocolVersion;
+    [FieldOffset(12)] public readonly uint ClientCapabilities;
+
+    public ClientHelloFrame(uint protocolVersion, ClientCapabilities capabilities)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.ClientHello;
+        HeaderFlagsRaw = 0;
+        ProtocolVersion = protocolVersion;
+        ClientCapabilities = (uint)capabilities;
+    }
+}
+
+/// <summary><see cref="MessageType.ServerStatus"/> — 9 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct ServerStatusFrame
+{
+    public const int WireSize = 9;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly byte Ready;
+
+    public ServerStatusFrame(bool ready)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.ServerStatus;
+        HeaderFlagsRaw = 0;
+        Ready = ready ? (byte)1 : (byte)0;
+    }
+}
+
+/// <summary><see cref="MessageType.Unsubscribe"/> / <see cref="MessageType.Unsubscribed"/>
+/// / <see cref="MessageType.SymbolDelisted"/> — 16 bytes, single securityId.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct SecurityIdFrame
+{
+    public const int WireSize = 16;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+
+    public SecurityIdFrame(MessageType type, ulong securityId)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)type;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+    }
+}
+
+/// <summary><see cref="MessageType.SymbolStaleStatus"/> — 17 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct SymbolStaleStatusFrame
+{
+    public const int WireSize = 17;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly byte IsStale;
+
+    public SymbolStaleStatusFrame(ulong securityId, bool isStale)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.SymbolStaleStatus;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        IsStale = isStale ? (byte)1 : (byte)0;
+    }
+}
+
+/// <summary><see cref="MessageType.OrderAdded"/> / <see cref="MessageType.OrderUpdated"/> — 41 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct OrderEventFrame
+{
+    public const int WireSize = 41;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly ulong OrderId;
+    [FieldOffset(24)] public readonly long Price;
+    [FieldOffset(32)] public readonly long Quantity;
+    [FieldOffset(40)] public readonly byte Side;
+
+    public OrderEventFrame(MessageType type, ulong securityId, ulong orderId, long price, long qty, byte side)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)type;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        OrderId = orderId;
+        Price = price;
+        Quantity = qty;
+        Side = side;
+    }
+
+    public MessageType Type => (MessageType)TypeRaw;
+}
+
+/// <summary><see cref="MessageType.OrderDeleted"/> — 25 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct OrderDeletedFrame
+{
+    public const int WireSize = 25;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly ulong OrderId;
+    [FieldOffset(24)] public readonly byte Side;
+
+    public OrderDeletedFrame(ulong securityId, ulong orderId, byte side)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.OrderDeleted;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        OrderId = orderId;
+        Side = side;
+    }
+}
+
+/// <summary><see cref="MessageType.Trade"/> — 41 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct TradeFrame
+{
+    public const int WireSize = 41;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly long Price;
+    [FieldOffset(24)] public readonly long Quantity;
+    [FieldOffset(32)] public readonly long TradeId;
+    [FieldOffset(40)] public readonly byte Flags;
+
+    public TradeFrame(ulong securityId, long price, long qty, long tradeId, byte flags)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.Trade;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        Price = price;
+        Quantity = qty;
+        TradeId = tradeId;
+        Flags = flags;
+    }
+}
+
+/// <summary><see cref="MessageType.TradeBust"/> — 24 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct TradeBustFrame
+{
+    public const int WireSize = 24;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly long TradeId;
+
+    public TradeBustFrame(ulong securityId, long tradeId)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.TradeBust;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        TradeId = tradeId;
+    }
+}
+
+/// <summary><see cref="MessageType.BookCleared"/> — 17 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct BookClearedFrame
+{
+    public const int WireSize = 17;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly byte ClearSide;
+
+    public BookClearedFrame(ulong securityId, byte clearSide)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.BookCleared;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        ClearSide = clearSide;
+    }
+}
+
+/// <summary><see cref="MessageType.MarketTierUpdate"/> — 29 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct MarketTierUpdateFrame
+{
+    public const int WireSize = 29;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly long TotalQty;
+    [FieldOffset(24)] public readonly uint OrderCount;
+    [FieldOffset(28)] public readonly byte Side;
+
+    public MarketTierUpdateFrame(ulong securityId, byte side, long totalQty, uint orderCount)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.MarketTierUpdate;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        TotalQty = totalQty;
+        OrderCount = orderCount;
+        Side = side;
+    }
+}
+
+/// <summary><see cref="MessageType.LevelUpdate"/> — 37 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct LevelUpdateFrame
+{
+    public const int WireSize = 37;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly long Price;
+    [FieldOffset(24)] public readonly long TotalQty;
+    [FieldOffset(32)] public readonly uint OrderCount;
+    [FieldOffset(36)] public readonly byte Side;
+
+    public LevelUpdateFrame(ulong securityId, byte side, long price, long totalQty, uint orderCount)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.LevelUpdate;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        Price = price;
+        TotalQty = totalQty;
+        OrderCount = orderCount;
+        Side = side;
+    }
+}
+
+/// <summary><see cref="MessageType.LevelDeleted"/> — 25 bytes.</summary>
+[StructLayout(LayoutKind.Explicit, Size = WireSize)]
+public readonly struct LevelDeletedFrame
+{
+    public const int WireSize = 25;
+    [FieldOffset(0)] public readonly uint Length;
+    [FieldOffset(4)] public readonly ushort TypeRaw;
+    [FieldOffset(6)] public readonly ushort HeaderFlagsRaw;
+    [FieldOffset(8)] public readonly ulong SecurityId;
+    [FieldOffset(16)] public readonly long Price;
+    [FieldOffset(24)] public readonly byte Side;
+
+    public LevelDeletedFrame(ulong securityId, byte side, long price)
+    {
+        Length = WireSize;
+        TypeRaw = (ushort)MessageType.LevelDeleted;
+        HeaderFlagsRaw = 0;
+        SecurityId = securityId;
+        Price = price;
+        Side = side;
+    }
+}

--- a/src/B3.MarketData.Wire/WireV2.cs
+++ b/src/B3.MarketData.Wire/WireV2.cs
@@ -1,0 +1,217 @@
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace B3.MarketData.Wire;
+
+/// <summary>
+/// Single canonical definition of the B3MarketDataPlatform WebSocket binary
+/// protocol, version 2. This file is <b>compile-linked into both</b> the server
+/// (<c>B3.Umdf.Server</c>) and the published SDK
+/// (<c>B3.MarketData.WebSocketClient</c>) so the two C# sides can never drift.
+/// The frontend JS mirror (<c>frontend/js/protocol.js</c>) is guarded against
+/// drift by committed golden hex vectors decoded identically in C# and JS.
+///
+/// <para><b>Framing.</b> Every frame starts with an 8-byte header:
+/// <c>[u32 length][u16 type][u16 headerFlags]</c>, little-endian, where
+/// <c>length</c> includes the header. The payload therefore starts at byte 8.</para>
+///
+/// <para><b>Endianness.</b> The wire is little-endian only. The zero-copy
+/// blittable fast path (<see cref="WireFrame.Write{T}"/> /
+/// <see cref="WireFrame.Read{T}"/>) is valid only on little-endian runtimes; a
+/// guard throws otherwise. See <see cref="WireFrame.EnsureLittleEndian"/>.</para>
+///
+/// <para><b>Forward-compatibility contract.</b> Fixed frames publish a
+/// <c>WireSize</c> that is a <i>minimum</i> length: decoders MUST accept frames
+/// whose <c>length</c> is greater than that size and MUST ignore trailing bytes,
+/// never validating an exact length. New fields may only be appended after the
+/// published core and only read after checking
+/// <c>length &gt;= fieldEndOffset</c>. Existing offsets and meanings are
+/// immutable. Message types and flag bits are append-only and never reused or
+/// renumbered. Unknown <see cref="DataFlags"/> / capability bits are ignored;
+/// unknown <b>non-zero</b> <c>headerFlags</c> MUST cause the frame to be rejected
+/// (they may change payload interpretation, e.g. compression).</para>
+/// </summary>
+public static class WireV2
+{
+    /// <summary>Size of the fixed framing header: <c>[u32 length][u16 type][u16 headerFlags]</c>.</summary>
+    public const int HeaderSize = 8;
+
+    /// <summary>Current wire protocol version.</summary>
+    public const uint ProtocolVersion = 2;
+
+    /// <summary>Lowest protocol version this build can speak.</summary>
+    public const uint SupportedProtocolVersionMin = 2;
+
+    /// <summary>Highest protocol version this build can speak.</summary>
+    public const uint SupportedProtocolVersionMax = 2;
+
+    /// <summary>
+    /// Hard cap on a single frame's advertised <c>length</c>. Guards against a
+    /// malformed/hostile header claiming a huge length and forcing an unbounded
+    /// buffer allocation. 16 MiB comfortably exceeds any legitimate frame
+    /// (deep snapshots, news bodies) while bounding worst-case memory.
+    /// </summary>
+    public const int MaxFrameLength = 16 * 1024 * 1024;
+}
+
+/// <summary>Message type discriminator (u16 on the wire, header offset 4).</summary>
+public enum MessageType : ushort
+{
+    // Client -> Server
+    ClientHello = 0x00A1,
+    Subscribe = 0x0001,
+    Unsubscribe = 0x0002,
+    Get = 0x0003,
+
+    // Server -> Client: handshake / lifecycle
+    ServerHello = 0x00A0,
+    ServerStatus = 0x0050,
+    SubscribeOk = 0x0010,
+    SubscribeError = 0x0011,
+    Unsubscribed = 0x0012,
+    SymbolStaleStatus = 0x0070,
+    SymbolDelisted = 0x0071,
+    RecoveryProgress = 0x0080,
+
+    // Server -> Client: snapshots
+    BookSnapshot = 0x0020,
+    InfoSnapshot = 0x0021,
+    LevelSnapshot = 0x0022,
+
+    // Server -> Client: incrementals
+    OrderAdded = 0x0030,
+    OrderUpdated = 0x0031,
+    OrderDeleted = 0x0032,
+    Trade = 0x0033,
+    BookCleared = 0x0034,
+    TradeBust = 0x0035,
+    MarketTierUpdate = 0x0036,
+    LevelUpdate = 0x0037,
+    LevelDeleted = 0x0038,
+
+    // Server -> Client: aggregates / metadata
+    RankingsUpdate = 0x0040,
+    CandleSnapshot = 0x0060,
+    CandleUpdate = 0x0061,
+    SecurityDefinition = 0x00B0,
+    PriceBand = 0x00B1,
+    Auction = 0x00B2,
+
+    // Server -> Client: news (fragmented)
+    NewsBegin = 0x0090,
+    NewsChunk = 0x0091,
+    NewsEnd = 0x0092,
+}
+
+/// <summary>
+/// Data channels a client can subscribe to (u32 bitmask). Append-only; bits are
+/// never reused. Do not publish an all-ones "everything" constant — that would
+/// implicitly opt legacy clients into future channels. Use
+/// <see cref="AllKnown"/>; the server masks off unknown requested bits and
+/// echoes only the accepted set in <see cref="MessageType.SubscribeOk"/>.
+/// </summary>
+[Flags]
+public enum DataFlags : uint
+{
+    None = 0,
+    Book = 0x0001,
+    Info = 0x0002,
+    News = 0x0004,
+    Mbp = 0x0008,
+    Trades = 0x0010,
+    SecurityDefinition = 0x0020,
+    PriceBand = 0x0040,
+    Auction = 0x0080,
+
+    /// <summary>Legacy convenience: Book + Info.</summary>
+    All = Book | Info,
+
+    /// <summary>Every channel this build knows about. NOT all-ones — new
+    /// channels are added here explicitly so unknown bits stay unrequested.</summary>
+    AllKnown = Book | Info | News | Mbp | Trades | SecurityDefinition | PriceBand | Auction,
+}
+
+/// <summary>Optional server features advertised in <see cref="MessageType.ServerHello"/>. Append-only.</summary>
+[Flags]
+public enum ServerCapabilities : uint
+{
+    None = 0,
+    SnapshotOnSubscribe = 0x0001,
+    SymbolDelistedNotification = 0x0002,
+}
+
+/// <summary>Optional client features advertised in <see cref="MessageType.ClientHello"/>. Append-only; 0 today.</summary>
+[Flags]
+public enum ClientCapabilities : uint
+{
+    None = 0,
+}
+
+/// <summary>Header-flag bits (u16 at header offset 6). All zero in v2 base.
+/// Receivers MUST reject frames carrying any bit they do not understand — such
+/// a bit may change how the payload is interpreted (e.g. compression).</summary>
+[Flags]
+public enum HeaderFlags : ushort
+{
+    None = 0,
+}
+
+/// <summary><see cref="MessageType.SubscribeError"/> reason codes.</summary>
+public enum SubscribeErrorCode : byte
+{
+    UnknownSymbol = 0x01,
+    NotReady = 0x02,
+}
+
+/// <summary>Framing-header read/write helpers and the blittable fast path.</summary>
+public static class WireFrame
+{
+    /// <summary>Throws if the current runtime is big-endian, where the blittable
+    /// struct fast path would produce/consume the wrong byte order.</summary>
+    public static void EnsureLittleEndian()
+    {
+        if (!BitConverter.IsLittleEndian)
+            throw new PlatformNotSupportedException(
+                "B3 WS wire protocol v2 requires a little-endian runtime for the blittable fast path.");
+    }
+
+    /// <summary>Write the 8-byte framing header. <paramref name="length"/> is the
+    /// total frame length including this header.</summary>
+    public static void WriteHeader(Span<byte> dest, int length, MessageType type, HeaderFlags flags = HeaderFlags.None)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(dest, (uint)length);
+        BinaryPrimitives.WriteUInt16LittleEndian(dest[4..], (ushort)type);
+        BinaryPrimitives.WriteUInt16LittleEndian(dest[6..], (ushort)flags);
+    }
+
+    /// <summary>Try to read the framing header. Returns false if fewer than
+    /// <see cref="WireV2.HeaderSize"/> bytes are available.</summary>
+    public static bool TryReadHeader(ReadOnlySpan<byte> src, out uint length, out MessageType type, out HeaderFlags flags)
+    {
+        if (src.Length < WireV2.HeaderSize)
+        {
+            length = 0; type = 0; flags = HeaderFlags.None;
+            return false;
+        }
+        length = BinaryPrimitives.ReadUInt32LittleEndian(src);
+        type = (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(src[4..]);
+        flags = (HeaderFlags)BinaryPrimitives.ReadUInt16LittleEndian(src[6..]);
+        return true;
+    }
+
+    /// <summary>Write a fixed blittable frame struct (header embedded) and return
+    /// its size in bytes. Little-endian runtime required.</summary>
+    public static int Write<T>(Span<byte> dest, in T frame) where T : unmanaged
+    {
+        MemoryMarshal.Write(dest, in frame);
+        return Unsafe.SizeOf<T>();
+    }
+
+    /// <summary>Read a fixed blittable frame struct from the start of
+    /// <paramref name="src"/>. The caller must have already validated that the
+    /// frame's advertised length is at least <c>sizeof(T)</c> (min-length rule);
+    /// trailing bytes beyond <c>sizeof(T)</c> are ignored.</summary>
+    public static T Read<T>(ReadOnlySpan<byte> src) where T : unmanaged
+        => MemoryMarshal.Read<T>(src);
+}

--- a/src/B3.Umdf.Server/B3.Umdf.Server.csproj
+++ b/src/B3.Umdf.Server/B3.Umdf.Server.csproj
@@ -14,6 +14,8 @@
     <ProjectReference Include="..\B3.Umdf.Transport\B3.Umdf.Transport.csproj" />
     <ProjectReference Include="..\B3.Umdf.Feed\B3.Umdf.Feed.csproj" />
     <ProjectReference Include="..\B3.Umdf.Book\B3.Umdf.Book.csproj" />
+    <!-- Single canonical wire-protocol definition, shared with the SDK. -->
+    <ProjectReference Include="..\B3.MarketData.Wire\B3.MarketData.Wire.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Umdf.Server/ClientSession.cs
+++ b/src/B3.Umdf.Server/ClientSession.cs
@@ -798,7 +798,7 @@ public sealed class ClientSession : IDisposable
     public async IAsyncEnumerable<(MessageType type, ReadOnlyMemory<byte> payload)> ReadMessagesAsync(
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        // Max client message: header(4) + flags(1) + symbolLen(1) + symbol(255) = 261
+        // Max client message: header(8) + flags(4) + symbolLen(1) + symbol(255) = 268
         var buffer = new byte[512];
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _cts.Token);
 
@@ -823,9 +823,10 @@ public sealed class ClientSession : IDisposable
 
             var span = buffer.AsSpan(0, result.Count);
             if (!WireProtocol.TryReadFramingHeader(span, out var length, out var type)) continue;
-            if (length > result.Count) continue;
+            if (length > (uint)result.Count) continue;
 
-            var payload = buffer.AsMemory(WireProtocol.FramingHeaderSize, length - WireProtocol.FramingHeaderSize);
+            int payloadLen = (int)length - WireProtocol.FramingHeaderSize;
+            var payload = buffer.AsMemory(WireProtocol.FramingHeaderSize, payloadLen);
             yield return (type, payload);
         }
     }

--- a/src/B3.Umdf.Server/GlobalUsings.cs
+++ b/src/B3.Umdf.Server/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using B3.MarketData.Wire;

--- a/src/B3.Umdf.Server/GroupConflationHandler.cs
+++ b/src/B3.Umdf.Server/GroupConflationHandler.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using B3.Umdf.Book;
 using B3.Umdf.Mbo.Sbe.V16;
+using MessageType = B3.MarketData.Wire.MessageType;
 
 namespace B3.Umdf.Server;
 
@@ -394,7 +395,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
             }
         }
 
-        Span<byte> tmp = stackalloc byte[20];
+        Span<byte> tmp = stackalloc byte[24];
         int len = WireProtocol.WriteTradeBust(tmp, securityId, tradeId);
         AppendTradeEventToBatch(securityId, tmp[..len], logicalCount: 1);
         _eventsReceived++;
@@ -983,7 +984,7 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
 
         if (_staleStatusBuffer.Count > 0)
         {
-            Span<byte> staleTmp = stackalloc byte[16];
+            Span<byte> staleTmp = stackalloc byte[17];
             foreach (var (secId, isStale) in _staleStatusBuffer)
             {
                 int len = WireProtocol.WriteSymbolStaleStatus(staleTmp, secId, isStale);

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -53,7 +53,7 @@ internal static class SnapshotEmitter
     /// </summary>
     public static bool SendServerStatus(ClientSession session, bool ready)
     {
-        var buf = new byte[5];
+        var buf = new byte[9];
         WireProtocol.WriteServerStatus(buf, ready);
         return session.TryEnqueue(buf);
     }
@@ -225,7 +225,7 @@ internal static class SnapshotEmitter
             // subscribers must not see busted trades in their initial history;
             // live subscribers receive the bust via MessageType.TradeBust.
             if (slot.Busted != 0) continue;
-            var buf = new byte[37];
+            var buf = new byte[41];
             int len = WireProtocol.WriteTrade(buf, securityId, slot.Price, slot.Qty, slot.TradeId, slot.Flags);
             if (!session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len)))
                 return false;

--- a/src/B3.Umdf.Server/SubscriptionManager.cs
+++ b/src/B3.Umdf.Server/SubscriptionManager.cs
@@ -179,7 +179,7 @@ public sealed class SubscriptionManager : IDisposable
             foreach (var k in subs.Keys) clientIds[i++] = k;
         }
 
-        var buf = new byte[12];
+        var buf = new byte[16];
         int len = WireProtocol.WriteSymbolDelisted(buf, securityId);
         var payload = new ReadOnlyMemory<byte>(buf, 0, len);
 
@@ -977,7 +977,7 @@ public sealed class SubscriptionManager : IDisposable
         }
 
         if (!enqueueAck) return;
-        var buf = new byte[12];
+        var buf = new byte[16];
         int len = WireProtocol.WriteUnsubscribed(buf, securityId);
         session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len));
     }
@@ -1080,7 +1080,7 @@ public sealed class SubscriptionManager : IDisposable
 
     private void BroadcastServerStatus(bool ready)
     {
-        var buf = new byte[5];
+        var buf = new byte[9];
         WireProtocol.WriteServerStatus(buf, ready);
         var payload = new ReadOnlyMemory<byte>(buf);
         foreach (var (_, client) in _clients)

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -1,290 +1,55 @@
 using System.Buffers.Binary;
 using System.Text;
 using B3.Umdf.Book;
+using B3.MarketData.Wire;
 
 namespace B3.Umdf.Server;
 
-/// <summary>Message type identifiers for the binary WebSocket protocol.</summary>
-public enum MessageType : ushort
-{
-    // Client → Server
-    Subscribe = 0x0001,
-    Unsubscribe = 0x0002,
-    Get = 0x0003,
-
-    // Server → Client
-    SubscribeOk = 0x0010,
-    SubscribeError = 0x0011,
-    Unsubscribed = 0x0012,
-    BookSnapshot = 0x0020,
-    InfoSnapshot = 0x0021,
-    /// <summary>Server → Client: aggregated price-level snapshot (MBP) for a security.
-    /// Carries every live price level as (price, totalQty, orderCount). Sent on
-    /// initial subscribe when <see cref="DataFlags.Mbp"/> is requested. Paired
-    /// with incremental <see cref="LevelUpdate"/> / <see cref="LevelDeleted"/>.</summary>
-    LevelSnapshot = 0x0022,
-    OrderAdded = 0x0030,
-    OrderUpdated = 0x0031,
-    OrderDeleted = 0x0032,
-    Trade = 0x0033,
-    BookCleared = 0x0034,
-    /// <summary>Server → Client: cancellation of a previously-broadcast trade
-    /// (TradeBust_57 from B3 spec §10). Carries securityId + tradeId so the
-    /// frontend can mark the corresponding entry in the trade history as
-    /// cancelled. Sent exactly once per bust observed on the wire.</summary>
-    TradeBust = 0x0035,
-    /// <summary>Server → Client: aggregate null-price MOA/MOC market tier for one side.
-    /// Carries total quantity and order count; it is deliberately separate from
-    /// OrderAdded/Updated so no sentinel price is needed.</summary>
-    MarketTierUpdate = 0x0036,
-    /// <summary>Server → Client: incremental MBP price-level update.
-    /// Carries (securityId, side, price, totalQty, orderCount) for a level whose
-    /// aggregate just changed. Conflated last-write-wins by (secId, side, price)
-    /// in the per-group MBP buffer so a level touched many times in one packet
-    /// still emits at most one frame per packet.</summary>
-    LevelUpdate = 0x0037,
-    /// <summary>Server → Client: incremental MBP level removal.
-    /// Sent when a price level was fully drained (last order deleted/moved away).
-    /// Carries (securityId, side, price). Frontend MUST drop the level from its
-    /// per-symbol map.</summary>
-    LevelDeleted = 0x0038,
-    RankingsUpdate = 0x0040,
-
-    /// <summary>Server → Client: broadcast of server feed status (ready / not ready).</summary>
-    ServerStatus = 0x0050,
-
-    /// <summary>Server → Client: full candle history for a security on subscribe.</summary>
-    CandleSnapshot = 0x0060,
-
-    /// <summary>Server → Client: single candle update (latest candle changed or new candle).</summary>
-    CandleUpdate = 0x0061,
-
-    /// <summary>Server → Client: per-symbol stale-status transition.
-    /// Sent when a subscribed security flips between Healthy and Stale so the UI can dim
-    /// rows / show a stale indicator. Coalesced per security in the conflation buffer:
-    /// the last value within a packet wins.</summary>
-    SymbolStaleStatus = 0x0070,
-
-    /// <summary>Server → Client: terminal notification that a previously-subscribed
-    /// security has been delisted by the venue. Carries only the securityId; clients
-    /// MUST stop expecting further data for that symbol and SHOULD remove it from
-    /// their UI. The server cleans up the per-symbol subscription map after sending,
-    /// so subsequent <c>Subscribe</c> attempts for the same symbol will fail with
-    /// <see cref="SubscribeErrorCode.UnknownSymbol"/>.
-    /// Issued via <c>SubscriptionManager.NotifyDelisted</c>; integration with the
-    /// upstream SBE delisting trigger is intentionally a follow-up.</summary>
-    SymbolDelisted = 0x0071,
-
-    /// <summary>Server → Client: aggregate recovery progress.
-    /// Periodic broadcast (~250ms) of total stale symbols and per-kind breakdown across
-    /// all channel groups. Stops after totalStale=0 has been broadcast once so clients
-    /// can clear the dashboard banner. Independent of <see cref="SymbolStaleStatus"/>:
-    /// that message targets per-row dimming for subscribed symbols, this one drives the
-    /// global "Recovering N/M symbols" banner.</summary>
-    RecoveryProgress = 0x0080,
-
-    /// <summary>Server → Client: start of a News delivery (template SBE 5).
-    /// Carries the metadata header (securityId, newsId, source, lang, origTime,
-    /// total lengths) but NOT the variable-length text payloads — those follow
-    /// as zero or more <see cref="NewsChunk"/> messages and a final
-    /// <see cref="NewsEnd"/>. Fragmentation is required because the framing
-    /// header uses u16 length (max ~65 KB) but a reassembled News may exceed
-    /// that. All News fragments for a given delivery share the same newsId.</summary>
-    NewsBegin = 0x0090,
-    /// <summary>Server → Client: a single payload fragment for an in-flight News
-    /// delivery. Carries newsId + field discriminator (0=Headline,1=Text,2=URL)
-    /// + bytes. Up to 60 KB per fragment.</summary>
-    NewsChunk = 0x0091,
-    /// <summary>Server → Client: explicit terminator for a News delivery.
-    /// Lets clients release per-news buffers and surface the assembled news to
-    /// the UI exactly once.</summary>
-    NewsEnd = 0x0092,
-
-    /// <summary>Server → Client: protocol/version handshake. Sent as the very first
-    /// frame after a client connects (before <see cref="ServerStatus"/>) so consumers
-    /// can negotiate features and surface the server build to operators.
-    /// Payload: <c>[u32 protocolVersion][u32 capabilities][u8 buildVerLen][buildVer UTF-8]</c>.
-    /// The MessageType is purely additive — older clients that don't recognise it MUST
-    /// skip the frame (length-prefixed) and continue parsing the next message.</summary>
-    ServerHello = 0x00A0,
-
-    /// <summary>Client → Server: optional version-negotiation handshake. If sent it MUST
-    /// arrive before any <see cref="Subscribe"/> / <see cref="Get"/> / <see cref="Unsubscribe"/>
-    /// frame. Payload: <c>[u32 protocolVersion]</c> — the version the client intends to
-    /// speak. Servers reject (WS close 1003 "protocol_version_unsupported") any value
-    /// outside <see cref="WireProtocol.SupportedProtocolVersionMin"/>..<see cref="WireProtocol.SupportedProtocolVersionMax"/>.
-    /// Backwards compatible: clients that never send ClientHello are assumed to speak
-    /// the current <see cref="WireProtocol.ProtocolVersion"/>.</summary>
-    ClientHello = 0x00A1,
-
-    /// <summary>Server → Client: full <c>SecurityDefinition</c> (static instrument metadata
-    /// — tick, lot, identity, classification) for a single security. Pushed (a) on
-    /// initial Subscribe when <see cref="DataFlags.SecurityDefinition"/> is set and
-    /// the server already has the definition cached, and (b) on every subsequent
-    /// real change (identity, tick, lot, …). Re-broadcasts that don't change any
-    /// field are short-circuited upstream by
-    /// <c>MarketDataManager.HandleSecurityDefinition</c>'s validity-timestamp
-    /// fast-path, so this frame only flows on true deltas.
-    /// Payload (little-endian, after the 4-byte framing header):
-    /// <c>[u64 securityId][u8 symbolLen][symbol UTF-8][u32 numericFieldMask]
-    /// [i64 values for set bits in bit order][u32 stringFieldMask][per set bit: u16 len][bytes]</c>.
-    /// Field mask bit positions are defined by <c>SecurityDefinitionField*</c>
-    /// constants on <see cref="WireProtocol"/>. New fields are append-only at
-    /// new bit positions; older SDKs MUST consume slots for unknown bits without
-    /// alignment damage.</summary>
-    SecurityDefinition = 0x00B0,
-
-    /// <summary>Server → Client: dynamic per-symbol price band (tunnel) snapshot
-    /// for a single security. Pushed (a) on initial Subscribe when
-    /// <see cref="DataFlags.PriceBand"/> is set and the server has already
-    /// observed at least one <c>PriceBand_22</c>, and (b) on every real change
-    /// to low/high limits, limit-type, midpoint-type, or trading reference
-    /// price. Idempotent re-broadcasts (the venue may emit the same band
-    /// periodically) are short-circuited upstream by
-    /// <c>MarketDataManager.HandlePriceBand</c>'s diff check, so this frame
-    /// only flows when the band actually moves.
-    /// Payload (little-endian, after the 4-byte framing header):
-    /// <c>[u64 securityId][u8 symbolLen][symbol UTF-8][u32 fieldMask][i64 values
-    /// for set bits in bit order]</c>.
-    /// Field mask bit positions are defined by <c>PriceBandField*</c>
-    /// constants on <see cref="WireProtocol"/>. New fields are append-only at
-    /// new bit positions; older SDKs MUST consume slots for unknown bits without
-    /// alignment damage.</summary>
-    PriceBand = 0x00B1,
-
-    /// <summary>Server → Client: auction state for one security (imbalance +
-    /// trading phase). Pushed on Subscribe (when the server has observed
-    /// imbalance or group-phase data) and on every subsequent real delta.
-    /// Layout: <c>[securityId u64][symLen u8][symbol ...][fieldMask u8][i64 values
-    /// for set bits in bit order]</c>.
-    /// Field mask bit positions are defined by <c>AuctionField*</c>
-    /// constants on <see cref="WireProtocol"/>. New fields are append-only at
-    /// new bit positions.</summary>
-    Auction = 0x00B2,
-}
-
 /// <summary>
-/// Bitfield of optional server-side features advertised in <see cref="MessageType.ServerHello"/>.
-/// Clients MUST treat unknown bits as reserved (ignore + log). New flags are appended
-/// only — bits MUST NOT be reused or repurposed once shipped.
-/// </summary>
-[Flags]
-public enum ServerCapabilities : uint
-{
-    None = 0,
-    /// <summary>Server pushes initial book/info/MBP snapshot frames immediately on
-    /// successful Subscribe. Always set today; documented as a flag so clients can
-    /// branch cleanly once a future server might allow snapshot opt-out.</summary>
-    SnapshotOnSubscribe = 0x0001,
-    /// <summary>Server emits <see cref="MessageType.SymbolDelisted"/> as the terminal
-    /// notification when a subscribed security is delisted mid-session.</summary>
-    SymbolDelistedNotification = 0x0002,
-}
-
-public enum SubscribeErrorCode : byte
-{
-    UnknownSymbol = 0x01,
-    NotReady = 0x02,
-}
-
-/// <summary>
-/// Bitmask for the data channels a client wants to receive.
-/// Sent in the Subscribe message; echoed back in SubscribeOk.
-/// </summary>
-[Flags]
-public enum DataFlags : byte
-{
-    None = 0x00,
-    /// <summary>BookSnapshot + order incrementals (OrderAdded/Updated/Deleted, Trade, BookCleared).</summary>
-    Book = 0x01,
-    /// <summary>InfoSnapshot + incremental market data / security status updates.</summary>
-    Info = 0x02,
-    /// <summary>News deliveries (NewsBegin/Chunk/End). Opt-in: clients without this
-    /// bit receive no news, even for symbols they're subscribed to. Both
-    /// instrument-scoped and global news flow through this flag.</summary>
-    News = 0x04,
-    /// <summary>Aggregated price-level (MBP) stream: <see cref="MessageType.LevelSnapshot"/>
-    /// + incremental <see cref="MessageType.LevelUpdate"/>/<see cref="MessageType.LevelDeleted"/>.
-    /// Independent of <see cref="Book"/>: a client may request only MBP, only
-    /// MBO (Book), or both. MBP is the recommended default for UI consumers
-    /// since the wire is conflated per (secId, side, price) instead of per
-    /// orderId, dramatically reducing bandwidth on hot levels.</summary>
-    Mbp = 0x08,
-    /// <summary>Trade prints (live <see cref="MessageType.Trade"/>) and corrections
-    /// (<see cref="MessageType.TradeBust"/>), plus the per-symbol recent-trades
-    /// history sent on subscribe. Opt-in (default OFF): clients that only want
-    /// quotes (Book and/or Mbp) avoid trade-stream bandwidth entirely. Note that
-    /// <c>LastTradePrice</c> in <see cref="MessageType.InfoSnapshot"/> is part of
-    /// <see cref="Info"/> and is not gated by this flag.</summary>
-    Trades = 0x10,
-    /// <summary>Static instrument metadata stream
-    /// (<see cref="MessageType.SecurityDefinition"/>): tick, lot, identity,
-    /// classification fields from <c>SecurityDefinition_12</c>. Pushed on
-    /// Subscribe (when the server already has the definition cached) and on
-    /// every subsequent real delta. Opt-in so legacy clients that only need
-    /// price data don't pay metadata-frame bandwidth.</summary>
-    SecurityDefinition = 0x20,
-    /// <summary>Dynamic per-symbol price band (tunnel) stream
-    /// (<see cref="MessageType.PriceBand"/>): low/high limits, limit-type,
-    /// midpoint-type, and trading reference price from <c>PriceBand_22</c>.
-    /// Pushed on Subscribe (when the server has already observed the band)
-    /// and on every subsequent real delta. Opt-in so legacy clients that
-    /// don't enforce pre-trade band checks don't pay the bandwidth.</summary>
-    PriceBand = 0x40,
-    /// <summary>Auction state stream (<see cref="MessageType.Auction"/>):
-    /// imbalance quantity/condition from <c>AuctionImbalance_19</c> and
-    /// group trading phase from <c>SecurityGroupPhase_10</c>. Pushed on
-    /// Subscribe (when the server has observed imbalance or phase data)
-    /// and on every subsequent real delta. Opt-in so legacy clients that
-    /// don't trade in auctions don't pay the bandwidth.</summary>
-    Auction = 0x80,
-    /// <summary>Legacy convenience: Book + Info. Kept stable for compatibility;
-    /// does NOT include News, MBP, Trades, SecurityDefinition, PriceBand, or Auction.</summary>
-    All = Book | Info,
-    /// <summary>Convenience alias for "every data class": Book + Info + News + MBP + Trades + SecurityDefinition + PriceBand + Auction.</summary>
-    Everything = Book | Info | News | Mbp | Trades | SecurityDefinition | PriceBand | Auction,
-}
-
-/// <summary>
-/// Binary serialization for the WebSocket protocol.
-/// All messages have a 4-byte framing header: [u16 messageLength][u16 messageType].
-/// messageLength includes the header itself.
+/// Binary serialization for the WebSocket protocol v2. Every message begins with
+/// the shared 8-byte framing header <c>[u32 length][u16 type][u16 headerFlags]</c>
+/// (see <see cref="WireFrame"/>); <c>length</c> includes the header itself.
+/// Enums (<see cref="MessageType"/>, <see cref="DataFlags"/>,
+/// <see cref="ServerCapabilities"/>, <see cref="SubscribeErrorCode"/>) live in the
+/// shared <c>B3.MarketData.Wire</c> assembly so the server and SDK cannot drift.
 /// </summary>
 public static class WireProtocol
 {
-    public const int FramingHeaderSize = 4;
+    public const int FramingHeaderSize = WireV2.HeaderSize;
 
-    public static void WriteFramingHeader(Span<byte> dest, ushort totalLength, MessageType type)
-    {
-        BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLength);
-        BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)type);
-    }
+    public static void WriteFramingHeader(Span<byte> dest, int totalLength, MessageType type)
+        => WireFrame.WriteHeader(dest, totalLength, type);
 
-    public static bool TryReadFramingHeader(ReadOnlySpan<byte> src, out ushort length, out MessageType type)
+    /// <summary>Read the v2 framing header. Returns false when the buffer is too
+    /// short OR the frame carries any header flag this build does not understand
+    /// (an unknown flag may change payload interpretation, e.g. compression, so it
+    /// MUST NOT be parsed as a plain frame).</summary>
+    public static bool TryReadFramingHeader(ReadOnlySpan<byte> src, out uint length, out MessageType type)
     {
-        if (src.Length < FramingHeaderSize)
+        if (!WireFrame.TryReadHeader(src, out length, out type, out var headerFlags)
+            || headerFlags != HeaderFlags.None)
         {
             length = 0;
             type = 0;
             return false;
         }
-        length = BinaryPrimitives.ReadUInt16LittleEndian(src);
-        type = (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(src[2..]);
         return true;
     }
 
     // --- Client → Server ---
 
     /// <summary>
-    /// Parse a Subscribe message. Returns symbol and data flags.
-    /// Format: [flags 1B][symbolLen 1B][symbol...].
+    /// Parse a Subscribe message (payload = everything after the 8-byte header).
+    /// Format: <c>[flags u32][symbolLen u8][symbol…]</c>. Unknown flag bits are
+    /// masked off (skip-unknown): the server only honours channels it knows about
+    /// and echoes the accepted set back in <see cref="MessageType.SubscribeOk"/>.
     /// </summary>
     public static (string symbol, DataFlags flags) ReadSubscribe(ReadOnlySpan<byte> payload)
     {
-        var flags = (DataFlags)payload[0];
+        var flags = (DataFlags)BinaryPrimitives.ReadUInt32LittleEndian(payload) & DataFlags.AllKnown;
         if (flags == DataFlags.None) flags = DataFlags.All; // treat 0 as "all"
-        byte symbolLen = payload[1];
-        var symbol = Encoding.UTF8.GetString(payload.Slice(2, symbolLen));
+        byte symbolLen = payload[4];
+        var symbol = Encoding.UTF8.GetString(payload.Slice(5, symbolLen));
         return (symbol, flags);
     }
 
@@ -296,151 +61,76 @@ public static class WireProtocol
 
     // --- Server → Client ---
 
-    /// <summary>Write ServerStatus: 1-byte ready flag. Total: 5 bytes.</summary>
+    /// <summary>Write ServerStatus: 1-byte ready flag. Total: 9 bytes.</summary>
     public static int WriteServerStatus(Span<byte> dest, bool ready)
-    {
-        const ushort totalLen = FramingHeaderSize + 1;
-        WriteFramingHeader(dest, totalLen, MessageType.ServerStatus);
-        dest[4] = ready ? (byte)1 : (byte)0;
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new ServerStatusFrame(ready));
 
-    /// <summary>Write SubscribeOk: securityId + flags + symbol.</summary>
+    /// <summary>Write SubscribeOk: <c>[secId u64][flags u32][symLen u8][symbol…]</c>.</summary>
     public static int WriteSubscribeOk(Span<byte> dest, ulong securityId, DataFlags flags, string symbol)
     {
-        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[14..]);
-        ushort totalLen = (ushort)(FramingHeaderSize + 8 + 1 + 1 + symbolLen);
+        int o = FramingHeaderSize;
+        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[(o + 8 + 4 + 1)..]);
+        int totalLen = o + 8 + 4 + 1 + symbolLen;
         WriteFramingHeader(dest, totalLen, MessageType.SubscribeOk);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        dest[12] = (byte)flags;
-        dest[13] = (byte)symbolLen;
+        BinaryPrimitives.WriteUInt64LittleEndian(dest[o..], securityId); o += 8;
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[o..], (uint)flags); o += 4;
+        dest[o] = (byte)symbolLen;
         return totalLen;
     }
 
-    /// <summary>Write SubscribeError: errorCode + symbol.</summary>
+    /// <summary>Write SubscribeError: <c>[errCode u8][symLen u8][symbol…]</c>.</summary>
     public static int WriteSubscribeError(Span<byte> dest, SubscribeErrorCode errorCode, string symbol)
     {
-        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[6..]);
-        ushort totalLen = (ushort)(FramingHeaderSize + 1 + 1 + symbolLen);
+        int o = FramingHeaderSize;
+        int symbolLen = Encoding.UTF8.GetBytes(symbol, dest[(o + 2)..]);
+        int totalLen = o + 2 + symbolLen;
         WriteFramingHeader(dest, totalLen, MessageType.SubscribeError);
-        dest[4] = (byte)errorCode;
-        dest[5] = (byte)symbolLen;
+        dest[o] = (byte)errorCode;
+        dest[o + 1] = (byte)symbolLen;
         return totalLen;
     }
 
     /// <summary>Write Unsubscribed: securityId.</summary>
     public static int WriteUnsubscribed(Span<byte> dest, ulong securityId)
-    {
-        const ushort totalLen = FramingHeaderSize + 8;
-        WriteFramingHeader(dest, totalLen, MessageType.Unsubscribed);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new SecurityIdFrame(MessageType.Unsubscribed, securityId));
 
     /// <summary>Write OrderAdded/Updated: securityId, orderId, side, price, qty.</summary>
     public static int WriteOrderEvent(Span<byte> dest, MessageType type, ulong securityId, ulong orderId, byte side, long price, long qty)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 8 + 1 + 8 + 8; // 37
-        WriteFramingHeader(dest, totalLen, type);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], orderId); offset += 8;
-        dest[offset++] = side;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], price); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], qty);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new OrderEventFrame(type, securityId, orderId, price, qty, side));
 
     /// <summary>Write OrderDeleted: securityId, orderId, side.</summary>
     public static int WriteOrderDeleted(Span<byte> dest, ulong securityId, ulong orderId, byte side)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 8 + 1; // 21
-        WriteFramingHeader(dest, totalLen, MessageType.OrderDeleted);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], orderId); offset += 8;
-        dest[offset] = side;
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new OrderDeletedFrame(securityId, orderId, side));
 
     /// <summary>
     /// Write Trade: securityId, price, qty, tradeId, flags.
-    /// Wire layout: <c>[hdr 4][secId 8][price 8][qty 8][tradeId 8][flags 1]</c> = 37 bytes.
-    /// The trailing <paramref name="flags"/> byte (default 0) carries
-    /// <see cref="B3.Umdf.Book.TradeFlags"/> bits. Older clients that read the
-    /// previous 36-byte layout simply ignore the trailing byte — the framing
-    /// header always reports the true length so frame alignment stays intact.
+    /// Wire layout (v2): <c>[hdr 8][secId 8][price 8][qty 8][tradeId 8][flags 1]</c> = 41 bytes.
+    /// The trailing <paramref name="flags"/> byte carries <see cref="B3.Umdf.Book.TradeFlags"/>
+    /// bits. Per the min-length rule, future fields are appended and older decoders
+    /// ignore trailing bytes.
     /// </summary>
     public static int WriteTrade(Span<byte> dest, ulong securityId, long price, long qty, long tradeId, byte flags = 0)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 8 + 8 + 8 + 1; // 37
-        WriteFramingHeader(dest, totalLen, MessageType.Trade);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], price); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], qty); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], tradeId); offset += 8;
-        dest[offset] = flags;
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new TradeFrame(securityId, price, qty, tradeId, flags));
 
     /// <summary>Write TradeBust: securityId + tradeId.</summary>
     public static int WriteTradeBust(Span<byte> dest, ulong securityId, long tradeId)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 8; // 20
-        WriteFramingHeader(dest, totalLen, MessageType.TradeBust);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], tradeId);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new TradeBustFrame(securityId, tradeId));
 
     /// <summary>Write MarketTierUpdate: securityId + side + aggregate qty + order count.</summary>
     public static int WriteMarketTierUpdate(Span<byte> dest, ulong securityId, byte side, long totalQty, int orderCount)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 1 + 8 + 4; // 25
-        WriteFramingHeader(dest, totalLen, MessageType.MarketTierUpdate);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        dest[offset++] = side;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], totalQty); offset += 8;
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], checked((uint)orderCount));
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new MarketTierUpdateFrame(securityId, side, totalQty, checked((uint)orderCount)));
 
-    /// <summary>
-    /// Write LevelUpdate (MBP incremental). Layout:
-    /// header(4) + securityId(8) + side(1) + price(8) + totalQty(8) + orderCount(4) = 33 bytes.
-    /// </summary>
-    public const int LevelUpdateSize = FramingHeaderSize + 8 + 1 + 8 + 8 + 4;
+    /// <summary>Total bytes of a <see cref="MessageType.LevelUpdate"/> frame.</summary>
+    public const int LevelUpdateSize = LevelUpdateFrame.WireSize;
+    /// <summary>Write LevelUpdate (MBP incremental).</summary>
     public static int WriteLevelUpdate(Span<byte> dest, ulong securityId, byte side, long price, long totalQty, int orderCount)
-    {
-        const ushort totalLen = LevelUpdateSize;
-        WriteFramingHeader(dest, totalLen, MessageType.LevelUpdate);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        dest[offset++] = side;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], price); offset += 8;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], totalQty); offset += 8;
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], checked((uint)orderCount));
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new LevelUpdateFrame(securityId, side, price, totalQty, checked((uint)orderCount)));
 
-    /// <summary>
-    /// Write LevelDeleted (MBP incremental). Layout:
-    /// header(4) + securityId(8) + side(1) + price(8) = 21 bytes.
-    /// </summary>
-    public const int LevelDeletedSize = FramingHeaderSize + 8 + 1 + 8;
+    /// <summary>Total bytes of a <see cref="MessageType.LevelDeleted"/> frame.</summary>
+    public const int LevelDeletedSize = LevelDeletedFrame.WireSize;
+    /// <summary>Write LevelDeleted (MBP incremental).</summary>
     public static int WriteLevelDeleted(Span<byte> dest, ulong securityId, byte side, long price)
-    {
-        const ushort totalLen = LevelDeletedSize;
-        WriteFramingHeader(dest, totalLen, MessageType.LevelDeleted);
-        int offset = FramingHeaderSize;
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
-        dest[offset++] = side;
-        BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], price);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new LevelDeletedFrame(securityId, side, price));
 
     /// <summary>
     /// Per-level entry size inside <see cref="MessageType.LevelSnapshot"/>:
@@ -460,7 +150,7 @@ public static class WireProtocol
     /// </summary>
     public static int WriteLevelSnapshotHeader(Span<byte> dest, ulong securityId, ushort bidCount, ushort askCount)
     {
-        ushort totalLen = (ushort)LevelSnapshotSize(bidCount, askCount);
+        int totalLen = LevelSnapshotSize(bidCount, askCount);
         WriteFramingHeader(dest, totalLen, MessageType.LevelSnapshot);
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
@@ -480,20 +170,14 @@ public static class WireProtocol
 
     /// <summary>Write BookCleared: securityId + clearSide byte.</summary>
     public static int WriteBookCleared(Span<byte> dest, ulong securityId, byte clearSide)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 1; // 13
-        WriteFramingHeader(dest, totalLen, MessageType.BookCleared);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        dest[12] = clearSide;
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new BookClearedFrame(securityId, clearSide));
 
     /// <summary>
     /// Current server-side wire protocol version. Bumped only on a breaking change to
     /// the framing or to the semantics of an existing <see cref="MessageType"/>.
     /// Additive new MessageTypes do NOT bump this field.
     /// </summary>
-    public const uint ProtocolVersion = 1;
+    public const uint ProtocolVersion = WireV2.ProtocolVersion;
 
     /// <summary>
     /// Minimum protocol version the server can speak with a client. A
@@ -503,35 +187,33 @@ public static class WireProtocol
     /// distinct constant so the negotiation path is shaped correctly for the day
     /// the server bumps <see cref="SupportedProtocolVersionMax"/>.
     /// </summary>
-    public const uint SupportedProtocolVersionMin = 1;
+    public const uint SupportedProtocolVersionMin = WireV2.SupportedProtocolVersionMin;
 
     /// <summary>
     /// Maximum protocol version the server can speak with a client. Mirrors
     /// <see cref="ProtocolVersion"/> today; future server releases that gain a new
     /// wire format should bump <see cref="ProtocolVersion"/> + this constant.
     /// </summary>
-    public const uint SupportedProtocolVersionMax = ProtocolVersion;
+    public const uint SupportedProtocolVersionMax = WireV2.SupportedProtocolVersionMax;
 
     /// <summary>
-    /// Total bytes of a <see cref="MessageType.ClientHello"/> frame: header(4) + version(4).
+    /// Total bytes of a <see cref="MessageType.ClientHello"/> frame:
+    /// header(8) + protocolVersion(4) + clientCapabilities(4) = 16.
     /// </summary>
-    public const int ClientHelloSize = FramingHeaderSize + 4;
+    public const int ClientHelloSize = ClientHelloFrame.WireSize;
 
     /// <summary>
-    /// Write a <see cref="MessageType.ClientHello"/> frame: <c>[u32 protocolVersion]</c>.
-    /// Used by the C# SDK (and tests) to advertise the version the client intends to speak.
+    /// Write a <see cref="MessageType.ClientHello"/> frame:
+    /// <c>[u32 protocolVersion][u32 clientCapabilities]</c>. Used by the C# SDK
+    /// (and tests) to advertise the version and features the client speaks.
     /// </summary>
-    public static int WriteClientHello(Span<byte> dest, uint protocolVersion)
-    {
-        const ushort totalLen = ClientHelloSize;
-        WriteFramingHeader(dest, totalLen, MessageType.ClientHello);
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[FramingHeaderSize..], protocolVersion);
-        return totalLen;
-    }
+    public static int WriteClientHello(Span<byte> dest, uint protocolVersion, ClientCapabilities capabilities = ClientCapabilities.None)
+        => WireFrame.Write(dest, new ClientHelloFrame(protocolVersion, capabilities));
 
     /// <summary>
-    /// Parse a <see cref="MessageType.ClientHello"/> payload (everything after the 4-byte
-    /// framing header). Returns the version the client claims to support.
+    /// Parse a <see cref="MessageType.ClientHello"/> payload (everything after the
+    /// 8-byte framing header). Returns the version the client claims to support;
+    /// trailing capability bytes are read separately / ignored (min-length rule).
     /// </summary>
     public static uint ReadClientHello(ReadOnlySpan<byte> payload)
         => BinaryPrimitives.ReadUInt32LittleEndian(payload);
@@ -539,7 +221,7 @@ public static class WireProtocol
 
     /// <summary>
     /// Maximum buffer needed for a <see cref="MessageType.ServerHello"/> frame:
-    /// header(4) + protocolVersion(4) + capabilities(4) + buildVerLen(1) + 255 UTF-8 bytes.
+    /// header(8) + protocolVersion(4) + capabilities(4) + buildVerLen(1) + 255 UTF-8 bytes.
     /// </summary>
     public const int ServerHelloMaxSize = FramingHeaderSize + 4 + 4 + 1 + 255;
 
@@ -566,18 +248,19 @@ public static class WireProtocol
             Array.Copy(encoded, trimmed, 255);
             encoded = trimmed;
         }
-        ushort totalLen = (ushort)(FramingHeaderSize + 4 + 4 + 1 + encoded.Length);
+        int o = FramingHeaderSize;
+        int totalLen = o + 4 + 4 + 1 + encoded.Length;
         WriteFramingHeader(dest, totalLen, MessageType.ServerHello);
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[4..], protocolVersion);
-        BinaryPrimitives.WriteUInt32LittleEndian(dest[8..], (uint)capabilities);
-        dest[12] = (byte)encoded.Length;
-        encoded.CopyTo(dest[13..]);
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[o..], protocolVersion); o += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[o..], (uint)capabilities); o += 4;
+        dest[o] = (byte)encoded.Length; o += 1;
+        encoded.CopyTo(dest[o..]);
         return totalLen;
     }
 
     /// <summary>
     /// Parse a <see cref="MessageType.ServerHello"/> payload (everything after the
-    /// 4-byte framing header). Returns the negotiated tuple. Used by the C# client
+    /// 8-byte framing header). Returns the negotiated tuple. Used by the C# client
     /// SDK and useful to round-trip in tests.
     /// </summary>
     public static (uint ProtocolVersion, ServerCapabilities Capabilities, string BuildVersion) ReadServerHello(
@@ -592,29 +275,17 @@ public static class WireProtocol
 
     /// <summary>
     /// Write a <see cref="MessageType.SymbolDelisted"/> frame: <c>[securityId u64]</c>.
-    /// Total: 12 bytes. Sent once per subscriber when a security is delisted.
+    /// Total: 16 bytes. Sent once per subscriber when a security is delisted.
     /// </summary>
     public static int WriteSymbolDelisted(Span<byte> dest, ulong securityId)
-    {
-        const ushort totalLen = FramingHeaderSize + 8; // 12
-        WriteFramingHeader(dest, totalLen, MessageType.SymbolDelisted);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new SecurityIdFrame(MessageType.SymbolDelisted, securityId));
 
     /// <summary>
-    /// Write SymbolStaleStatus: securityId + isStale byte.
-    /// Total: 13 bytes. Pushed when a subscribed security flips between
-    /// Healthy and Stale.
+    /// Write SymbolStaleStatus: securityId + isStale byte. Total: 17 bytes. Pushed
+    /// when a subscribed security flips between Healthy and Stale.
     /// </summary>
     public static int WriteSymbolStaleStatus(Span<byte> dest, ulong securityId, bool isStale)
-    {
-        const ushort totalLen = FramingHeaderSize + 8 + 1; // 13
-        WriteFramingHeader(dest, totalLen, MessageType.SymbolStaleStatus);
-        BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        dest[12] = isStale ? (byte)1 : (byte)0;
-        return totalLen;
-    }
+        => WireFrame.Write(dest, new SymbolStaleStatusFrame(securityId, isStale));
 
     /// <summary>
     /// Max buffer size for RecoveryProgress: header(4) + totals(8) + kindCount(1)
@@ -649,7 +320,7 @@ public static class WireProtocol
             kindCount++;
         }
         dest[kindCountOffset] = kindCount;
-        WriteFramingHeader(dest, (ushort)offset, MessageType.RecoveryProgress);
+        WriteFramingHeader(dest, offset, MessageType.RecoveryProgress);
         return offset;
     }
 
@@ -730,7 +401,7 @@ public static class WireProtocol
         if (info.AuctionImbalanceCondition is { } v24) { mask |= 1u << FieldAuctionImbalanceCondition; BinaryPrimitives.WriteInt64LittleEndian(dest[offset..], v24); offset += 8; }
 
         // Write framing header, securityId, and mask
-        ushort totalLen = (ushort)offset;
+        int totalLen = offset;
         WriteFramingHeader(dest, totalLen, MessageType.InfoSnapshot);
         BinaryPrimitives.WriteUInt64LittleEndian(dest[FramingHeaderSize..], securityId);
         BinaryPrimitives.WriteUInt32LittleEndian(dest[(FramingHeaderSize + 8)..], mask);
@@ -754,7 +425,7 @@ public static class WireProtocol
     /// </summary>
     public static int WriteBookSnapshotHeader(Span<byte> dest, ulong securityId, uint rptSeq, ushort bidCount, ushort askCount)
     {
-        ushort totalLen = (ushort)BookSnapshotSize(bidCount, askCount);
+        int totalLen = BookSnapshotSize(bidCount, askCount);
         WriteFramingHeader(dest, totalLen, MessageType.BookSnapshot);
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
@@ -791,7 +462,7 @@ public static class WireProtocol
         offset = WriteRankingCategory(dest, offset, gainers);
         offset = WriteRankingCategory(dest, offset, losers);
 
-        ushort totalLen = (ushort)offset;
+        int totalLen = offset;
         WriteFramingHeader(dest, totalLen, MessageType.RankingsUpdate);
         return totalLen;
     }
@@ -835,7 +506,7 @@ public static class WireProtocol
     /// </summary>
     internal static int WriteCandleSnapshot(Span<byte> dest, ulong securityId, int resolution, byte flags, ReadOnlySpan<Candle> candles)
     {
-        ushort totalLen = (ushort)(CandleSnapshotHeaderSize + candles.Length * CandleSize);
+        int totalLen = (CandleSnapshotHeaderSize + candles.Length * CandleSize);
         WriteFramingHeader(dest, totalLen, MessageType.CandleSnapshot);
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
@@ -856,7 +527,7 @@ public static class WireProtocol
     /// </summary>
     internal static int WriteCandleUpdate(Span<byte> dest, ulong securityId, int resolution, in Candle candle)
     {
-        const ushort totalLen = (ushort)CandleUpdateMessageSize;
+        const int totalLen = CandleUpdateMessageSize;
         WriteFramingHeader(dest, totalLen, MessageType.CandleUpdate);
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
@@ -927,7 +598,7 @@ public static class WireProtocol
         uint totalTextLen,
         uint totalUrlLen)
     {
-        const ushort totalLen = (ushort)NewsBeginTotalSize;
+        const int totalLen = NewsBeginTotalSize;
         WriteFramingHeader(dest, totalLen, MessageType.NewsBegin);
         int o = FramingHeaderSize;
         dest[o++] = NewsFrameVersion;
@@ -957,7 +628,7 @@ public static class WireProtocol
     {
         if (fragment.Length > NewsChunkMaxFragment)
             throw new ArgumentOutOfRangeException(nameof(fragment), $"News fragment exceeds {NewsChunkMaxFragment} bytes");
-        ushort totalLen = (ushort)(FramingHeaderSize + NewsChunkHeaderSize + fragment.Length);
+        int totalLen = (FramingHeaderSize + NewsChunkHeaderSize + fragment.Length);
         WriteFramingHeader(dest, totalLen, isFinal ? MessageType.NewsEnd : MessageType.NewsChunk);
         int o = FramingHeaderSize;
         dest[o++] = NewsFrameVersion;
@@ -1150,7 +821,7 @@ public static class WireProtocol
 
         BinaryPrimitives.WriteUInt32LittleEndian(dest[stringMaskOffset..], stringMask);
 
-        ushort totalLen = (ushort)offset;
+        int totalLen = offset;
         WriteFramingHeader(dest, totalLen, MessageType.SecurityDefinition);
         return totalLen;
     }
@@ -1255,7 +926,7 @@ public static class WireProtocol
 
         BinaryPrimitives.WriteUInt32LittleEndian(dest[maskOffset..], mask);
 
-        ushort totalLen = (ushort)offset;
+        int totalLen = offset;
         WriteFramingHeader(dest, totalLen, MessageType.PriceBand);
         return totalLen;
     }
@@ -1325,7 +996,7 @@ public static class WireProtocol
 
         dest[maskOffset] = mask;
 
-        ushort totalLen = (ushort)offset;
+        int totalLen = offset;
         WriteFramingHeader(dest, totalLen, MessageType.Auction);
         return totalLen;
     }

--- a/tests/B3.MarketData.WebSocketClient.Tests/AuctionWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/AuctionWireRoundTripTests.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using B3.Umdf.Book;
 using B3.Umdf.Server;
 
@@ -29,8 +30,8 @@ public class AuctionWireRoundTripTests
         int len = B3.Umdf.Server.WireProtocol.WriteAuction(buf, securityId: 42UL, info);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var hLen, out var type));
-        Assert.Equal(len, hLen);
-        Assert.Equal(WireFormat.MessageType.Auction, type);
+        Assert.Equal((uint)len, hLen);
+        Assert.Equal(MessageType.Auction, type);
 
         var ev = WireFormat.ReadAuction(
             buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize),

--- a/tests/B3.MarketData.WebSocketClient.Tests/BookFeedTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/BookFeedTests.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Net.WebSockets;
 using System.Text;
 using ServerWire = B3.Umdf.Server.WireProtocol;
-using ServerMsg = B3.Umdf.Server.MessageType;
+using ServerMsg = B3.MarketData.Wire.MessageType;
 
 namespace B3.MarketData.WebSocketClient.Tests;
 

--- a/tests/B3.MarketData.WebSocketClient.Tests/GlobalUsings.WireV2.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/GlobalUsings.WireV2.cs
@@ -1,0 +1,1 @@
+global using B3.MarketData.Wire;

--- a/tests/B3.MarketData.WebSocketClient.Tests/GoldenVectorTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/GoldenVectorTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using B3.MarketData.Wire;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+/// <summary>
+/// Cross-language forward-compatibility contract: decode the committed,
+/// implementation-independent golden vectors in <c>tests/golden/wire-v2-vectors.json</c>
+/// with the production <see cref="WireFormat"/> readers and assert the decoded
+/// fields. The JS half of this contract lives in
+/// <c>tests/golden/decode.test.mjs</c>; both decode the identical hex bytes.
+/// </summary>
+public class GoldenVectorTests
+{
+    private static JsonDocument LoadGolden()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "tests", "golden", "wire-v2-vectors.json");
+            if (File.Exists(candidate))
+                return JsonDocument.Parse(File.ReadAllText(candidate));
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException("Could not locate tests/golden/wire-v2-vectors.json above " + AppContext.BaseDirectory);
+    }
+
+    private static byte[] HexToBytes(string hex)
+    {
+        var bytes = new byte[hex.Length / 2];
+        for (int i = 0; i < bytes.Length; i++)
+            bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+        return bytes;
+    }
+
+    [Fact]
+    public void GoldenHeaderConstants_Match()
+    {
+        using var doc = LoadGolden();
+        Assert.Equal(2, doc.RootElement.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(WireV2.HeaderSize, doc.RootElement.GetProperty("headerSize").GetInt32());
+    }
+
+    [Fact]
+    public void AllGoldenVectors_DecodeToExpectedFields()
+    {
+        using var doc = LoadGolden();
+        var receivedUtc = DateTime.UtcNow;
+
+        foreach (var vec in doc.RootElement.GetProperty("vectors").EnumerateArray())
+        {
+            string name = vec.GetProperty("name").GetString()!;
+            string type = vec.GetProperty("type").GetString()!;
+            var bytes = HexToBytes(vec.GetProperty("hex").GetString()!);
+            var expected = vec.GetProperty("expected");
+
+            Assert.True(WireFrame.TryReadHeader(bytes, out uint length, out var msgType, out var headerFlags),
+                $"{name}: header must parse");
+            Assert.Equal((uint)bytes.Length, length);
+            Assert.Equal(HeaderFlags.None, headerFlags);
+
+            var payload = bytes.AsSpan(WireV2.HeaderSize, (int)length - WireV2.HeaderSize);
+
+            switch (type)
+            {
+                case "SubscribeOk":
+                {
+                    var (secId, flags, symbol) = WireFormat.ReadSubscribeOk(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal((uint)expected.GetProperty("flags").GetInt64(), flags);
+                    Assert.Equal(expected.GetProperty("symbol").GetString(), symbol);
+                    break;
+                }
+                case "OrderAdded":
+                {
+                    var (secId, orderId, side, price, qty) = WireFormat.ReadOrderEvent(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal(ExpectedU64(expected, "orderId"), orderId);
+                    Assert.Equal(expected.GetProperty("side").GetInt64(), side);
+                    Assert.Equal(expected.GetProperty("price").GetInt64(), price);
+                    Assert.Equal(expected.GetProperty("qty").GetInt64(), qty);
+                    break;
+                }
+                case "Trade":
+                {
+                    var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal(expected.GetProperty("price").GetInt64(), price);
+                    Assert.Equal(expected.GetProperty("qty").GetInt64(), qty);
+                    Assert.Equal(expected.GetProperty("tradeId").GetInt64(), tradeId);
+                    Assert.Equal((byte)expected.GetProperty("flags").GetInt64(), (byte)flags);
+                    break;
+                }
+                case "MarketTierUpdate":
+                {
+                    var (secId, side, totalQty, orderCount) = WireFormat.ReadMarketTierUpdate(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal(expected.GetProperty("side").GetInt64(), side);
+                    Assert.Equal(expected.GetProperty("qty").GetInt64(), totalQty);
+                    Assert.Equal(expected.GetProperty("count").GetInt64(), orderCount);
+                    break;
+                }
+                case "LevelUpdate":
+                {
+                    var (secId, side, price, totalQty, orderCount) = WireFormat.ReadLevelUpdate(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal(expected.GetProperty("side").GetInt64(), side);
+                    Assert.Equal(expected.GetProperty("price").GetInt64(), price);
+                    Assert.Equal(expected.GetProperty("qty").GetInt64(), totalQty);
+                    Assert.Equal(expected.GetProperty("count").GetInt64(), orderCount);
+                    break;
+                }
+                case "LevelDeleted":
+                {
+                    var (secId, side, price) = WireFormat.ReadLevelDeleted(payload);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), secId);
+                    Assert.Equal(expected.GetProperty("side").GetInt64(), side);
+                    Assert.Equal(expected.GetProperty("price").GetInt64(), price);
+                    break;
+                }
+                case "ServerStatus":
+                {
+                    Assert.Equal(expected.GetProperty("ready").GetBoolean(), WireFormat.ReadServerStatus(payload));
+                    break;
+                }
+                case "InfoSnapshot":
+                {
+                    var ev = WireFormat.ReadInfoSnapshot(payload, "PETR4", receivedUtc);
+                    Assert.Equal(ExpectedU64(expected, "securityId"), ev.SecurityId);
+                    var fields = expected.GetProperty("fields");
+                    // JS returns raw i64; C# scales price fields by PriceScale (1e4).
+                    Assert.Equal(fields.GetProperty("OpeningPrice").GetInt64() / WireFormat.PriceScale, ev.OpeningPrice);
+                    Assert.Equal(fields.GetProperty("HighPrice").GetInt64() / WireFormat.PriceScale, ev.HighPrice);
+                    Assert.Equal(fields.GetProperty("LowPrice").GetInt64() / WireFormat.PriceScale, ev.LowPrice);
+                    break;
+                }
+                case "ServerHello":
+                {
+                    var (protocolVersion, capabilities, buildVersion) = WireFormat.ReadServerHello(payload);
+                    Assert.Equal((uint)expected.GetProperty("protocolVersion").GetInt64(), protocolVersion);
+                    Assert.Equal((uint)expected.GetProperty("capabilities").GetInt64(), (uint)capabilities);
+                    Assert.Equal(expected.GetProperty("buildVersion").GetString(), buildVersion);
+                    break;
+                }
+                default:
+                    Assert.Fail($"Unhandled golden vector type: {type} ({name})");
+                    break;
+            }
+        }
+    }
+
+    private static ulong ExpectedU64(JsonElement expected, string key) =>
+        ulong.Parse(expected.GetProperty(key).GetString()!);
+}

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -67,6 +67,41 @@ public class MarketDataClientIntegrationTests
     }
 
     [Fact]
+    public async Task CoalescedBatch_LargerThan64KiB_GrowsBufferAndDecodesAll()
+    {
+        // 2000 × 40-byte Trade frames = 80 000 bytes in a SINGLE WS message,
+        // exceeding the client's initial 64 KiB receive buffer and forcing a grow.
+        const int tradeCount = 2000;
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var sym = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 555, sym, ct);
+            await TestWsServer.SendCoalescedTradesAsync(ws, securityId: 555, tradeCount, ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        int received = 0;
+        var all = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.Trade += _ =>
+        {
+            if (Interlocked.Increment(ref received) == tradeCount)
+                all.TrySetResult(true);
+        };
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4");
+
+        await all.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(tradeCount, Volatile.Read(ref received));
+    }
+
+    [Fact]
     public async Task SubscribeError_IsSurfacedAsTypedEvent()
     {
         var port = FindFreePort();
@@ -194,11 +229,11 @@ public class MarketDataClientIntegrationTests
 
             // Send an unknown opcode (0xFFFE) — payload is 4 trailing bytes — then a
             // valid Trade frame to assert the decoder kept going.
-            const ushort unknownTotal = 4 + 4;
+            const ushort unknownTotal = 8 + 4;
             var unknown = new byte[unknownTotal];
-            BinaryPrimitives.WriteUInt16LittleEndian(unknown, unknownTotal);
-            BinaryPrimitives.WriteUInt16LittleEndian(unknown.AsSpan(2), 0xFFFE);
-            BinaryPrimitives.WriteUInt32LittleEndian(unknown.AsSpan(4), 0xDEADBEEF);
+            BinaryPrimitives.WriteUInt32LittleEndian(unknown, unknownTotal);
+            BinaryPrimitives.WriteUInt16LittleEndian(unknown.AsSpan(4), 0xFFFE);
+            BinaryPrimitives.WriteUInt32LittleEndian(unknown.AsSpan(8), 0xDEADBEEF);
             await ws.SendAsync(unknown, WebSocketMessageType.Binary, true, ct);
 
             await TestWsServer.SendTradeAsync(ws, securityId: 42, price: 12345, qty: 100, tradeId: 1, ct);
@@ -330,71 +365,93 @@ internal sealed class TestWsServer : IAsyncDisposable
                 filled += result.Count;
             } while (!result.EndOfMessage);
 
-            // [len u16][type u16=0x0001][flags u8][symLen u8][symbol]
-            ushort len = BinaryPrimitives.ReadUInt16LittleEndian(buffer);
-            ushort type = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(2));
+            // v2: [len u32][type u16][flags u16][flags u32][symLen u8][symbol]
+            ushort type = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(4));
             if (type == 0x00A1) continue; // ClientHello — ignore
             if (type != 0x0001) throw new InvalidOperationException($"expected Subscribe, got 0x{type:X4}");
-            byte symLen = buffer[5];
-            return Encoding.UTF8.GetString(buffer, 6, symLen);
+            byte symLen = buffer[12];
+            return Encoding.UTF8.GetString(buffer, 13, symLen);
         }
     }
 
     public static Task SendSubscribeOkAsync(WebSocket ws, ulong securityId, string symbol, CancellationToken ct)
     {
-        // [len u16][type u16=0x0010][secId u64][flags u8][symLen u8][symbol]
+        // v2: [len u32][type u16=0x0010][flags u16][secId u64][flags u32][symLen u8][symbol]
         var symBytes = Encoding.UTF8.GetBytes(symbol);
-        ushort total = (ushort)(4 + 8 + 1 + 1 + symBytes.Length);
+        ushort total = (ushort)(8 + 8 + 4 + 1 + symBytes.Length);
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0010);
-        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), securityId);
-        buf[12] = (byte)0x10; // Trades flag
-        buf[13] = (byte)symBytes.Length;
-        symBytes.CopyTo(buf, 14);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), 0x0010);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(8), securityId);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(16), 0x10); // Trades flag
+        buf[20] = (byte)symBytes.Length;
+        symBytes.CopyTo(buf, 21);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 
     public static Task SendSubscribeErrorAsync(WebSocket ws, string symbol, byte errorCode, CancellationToken ct)
     {
-        // [len u16][type u16=0x0011][errorCode u8][symLen u8][symbol]
+        // v2: [len u32][type u16=0x0011][flags u16][errorCode u8][symLen u8][symbol]
         var symBytes = Encoding.UTF8.GetBytes(symbol);
-        ushort total = (ushort)(4 + 1 + 1 + symBytes.Length);
+        ushort total = (ushort)(8 + 1 + 1 + symBytes.Length);
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0011);
-        buf[4] = errorCode;
-        buf[5] = (byte)symBytes.Length;
-        symBytes.CopyTo(buf, 6);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), 0x0011);
+        buf[8] = errorCode;
+        buf[9] = (byte)symBytes.Length;
+        symBytes.CopyTo(buf, 10);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 
     public static Task SendTradeAsync(WebSocket ws, ulong securityId, long price, long qty, long tradeId, CancellationToken ct)
     {
-        // [len u16][type u16=0x0033][secId u64][price i64][qty i64][tradeId i64]
-        const ushort total = 4 + 8 + 8 + 8 + 8;
+        // v2: [len u32][type u16=0x0033][flags u16][secId u64][price i64][qty i64][tradeId i64]
+        const ushort total = 8 + 8 + 8 + 8 + 8;
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0033);
-        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), securityId);
-        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(12), price);
-        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(20), qty);
-        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(28), tradeId);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), 0x0033);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(8), securityId);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(16), price);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(24), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(32), tradeId);
+        return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    /// <summary>
+    /// Concatenate <paramref name="count"/> Trade frames into ONE WebSocket
+    /// binary message (server-style coalescing) and send it in a single
+    /// <c>SendAsync</c>. Used to exercise the client's grow-on-demand receive
+    /// buffer when a coalesced batch exceeds the initial 64 KiB.
+    /// </summary>
+    public static Task SendCoalescedTradesAsync(WebSocket ws, ulong securityId, int count, CancellationToken ct)
+    {
+        const int frameSize = 8 + 8 + 8 + 8 + 8; // 40-byte v2 Trade (flags omitted, min-length)
+        var buf = new byte[frameSize * count];
+        for (int i = 0; i < count; i++)
+        {
+            var f = buf.AsSpan(i * frameSize, frameSize);
+            BinaryPrimitives.WriteUInt32LittleEndian(f, frameSize);
+            BinaryPrimitives.WriteUInt16LittleEndian(f[4..], 0x0033);
+            BinaryPrimitives.WriteUInt64LittleEndian(f[8..], securityId);
+            BinaryPrimitives.WriteInt64LittleEndian(f[16..], 100_000 + i);
+            BinaryPrimitives.WriteInt64LittleEndian(f[24..], 1);
+            BinaryPrimitives.WriteInt64LittleEndian(f[32..], i);
+        }
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 
     public static Task SendServerHelloAsync(WebSocket ws, uint protocolVersion, uint capabilities, string buildVersion, CancellationToken ct)
     {
-        // [len u16][type u16=0x00A0][protocolVersion u32][capabilities u32][buildVerLen u8][buildVer UTF-8…]
+        // v2: [len u32][type u16=0x00A0][flags u16][protocolVersion u32][capabilities u32][buildVerLen u8][buildVer UTF-8…]
         var buildBytes = Encoding.UTF8.GetBytes(buildVersion);
-        ushort total = (ushort)(4 + 4 + 4 + 1 + buildBytes.Length);
+        ushort total = (ushort)(8 + 4 + 4 + 1 + buildBytes.Length);
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x00A0);
-        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), protocolVersion);
-        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(8), capabilities);
-        buf[12] = (byte)buildBytes.Length;
-        buildBytes.CopyTo(buf, 13);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), 0x00A0);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(8), protocolVersion);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(12), capabilities);
+        buf[16] = (byte)buildBytes.Length;
+        buildBytes.CopyTo(buf, 17);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
     }
 
@@ -402,13 +459,13 @@ internal sealed class TestWsServer : IAsyncDisposable
         byte source, ushort language, long origTimeNanos,
         uint headlineLen, uint textLen, uint urlLen, CancellationToken ct)
     {
-        // [len u16][type u16=0x0090][version u8][secId u64][newsId u64][source u8][lang u16][origTime i64]
+        // v2: [len u32][type u16=0x0090][flags u16][version u8][secId u64][newsId u64][source u8][lang u16][origTime i64]
         // [hLen u32][tLen u32][uLen u32]
-        ushort total = (ushort)(4 + 1 + 8 + 8 + 1 + 2 + 8 + 4 + 4 + 4);
+        ushort total = (ushort)(8 + 1 + 8 + 8 + 1 + 2 + 8 + 4 + 4 + 4);
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), 0x0090);
-        int o = 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), 0x0090);
+        int o = 8;
         buf[o++] = 1; // version
         BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), securityIdOrZero); o += 8;
         BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), newsId); o += 8;
@@ -424,13 +481,13 @@ internal sealed class TestWsServer : IAsyncDisposable
     public static Task SendNewsChunkAsync(WebSocket ws, ulong newsId, byte fieldByte,
         byte[] fragment, bool isFinal, CancellationToken ct)
     {
-        // [len u16][type u16][version u8][newsId u64][field u8][fragLen u16][bytes]
+        // v2: [len u32][type u16][flags u16][version u8][newsId u64][field u8][fragLen u16][bytes]
         ushort opcode = isFinal ? (ushort)0x0092 : (ushort)0x0091;
-        ushort total = (ushort)(4 + 1 + 8 + 1 + 2 + fragment.Length);
+        ushort total = (ushort)(8 + 1 + 8 + 1 + 2 + fragment.Length);
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), opcode);
-        int o = 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), opcode);
+        int o = 8;
         buf[o++] = 1; // version
         BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(o), newsId); o += 8;
         buf[o++] = fieldByte;

--- a/tests/B3.MarketData.WebSocketClient.Tests/ParityWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/ParityWireRoundTripTests.cs
@@ -1,6 +1,7 @@
+using B3.MarketData.Wire;
 using System.Buffers.Binary;
 using ServerWire = B3.Umdf.Server.WireProtocol;
-using ServerMsg = B3.Umdf.Server.MessageType;
+using ServerMsg = B3.MarketData.Wire.MessageType;
 
 namespace B3.MarketData.WebSocketClient.Tests;
 
@@ -21,8 +22,8 @@ public class ParityWireRoundTripTests
             price: 12_3456, qty: 250);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var totalLen, out var type));
-        Assert.Equal(len, totalLen);
-        Assert.Equal(WireFormat.MessageType.OrderAdded, type);
+        Assert.Equal((uint)len, totalLen);
+        Assert.Equal(MessageType.OrderAdded, type);
 
         var (secId, orderId, side, price, qty) = WireFormat.ReadOrderEvent(
             buf.AsSpan(WireFormat.FramingHeaderSize));
@@ -42,7 +43,7 @@ public class ParityWireRoundTripTests
             securityId: 7, orderId: 555, side: (byte)BookSide.Ask);
 
         WireFormat.TryReadHeader(buf, out _, out var type);
-        Assert.Equal(WireFormat.MessageType.OrderDeleted, type);
+        Assert.Equal(MessageType.OrderDeleted, type);
 
         var (secId, orderId, side) = WireFormat.ReadOrderDeleted(
             buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
@@ -54,7 +55,7 @@ public class ParityWireRoundTripTests
     [Fact]
     public void BookCleared_RoundTrips()
     {
-        var buf = new byte[16];
+        var buf = new byte[17];
         ServerWire.WriteBookCleared(buf, securityId: 1, clearSide: (byte)BookClearSide.Bid);
 
         var (secId, clearByte) = WireFormat.ReadBookCleared(
@@ -71,7 +72,7 @@ public class ParityWireRoundTripTests
             securityId: 11, side: (byte)BookSide.Bid, totalQty: 5_000, orderCount: 3);
 
         WireFormat.TryReadHeader(buf, out _, out var type);
-        Assert.Equal(WireFormat.MessageType.MarketTierUpdate, type);
+        Assert.Equal(MessageType.MarketTierUpdate, type);
 
         var (secId, side, qty, count) = WireFormat.ReadMarketTierUpdate(
             buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
@@ -89,7 +90,7 @@ public class ParityWireRoundTripTests
             securityId: 99, side: (byte)BookSide.Ask, price: 25_5000, totalQty: 1_200, orderCount: 4);
 
         WireFormat.TryReadHeader(buf, out _, out var type);
-        Assert.Equal(WireFormat.MessageType.LevelUpdate, type);
+        Assert.Equal(MessageType.LevelUpdate, type);
 
         var (secId, side, price, qty, count) = WireFormat.ReadLevelUpdate(
             buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize));
@@ -157,7 +158,7 @@ public class ParityWireRoundTripTests
     [Fact]
     public void SymbolStaleStatus_RoundTrips()
     {
-        var buf = new byte[16];
+        var buf = new byte[17];
         ServerWire.WriteSymbolStaleStatus(buf, securityId: 77, isStale: true);
 
         var (secId, isStale) = WireFormat.ReadSymbolStaleStatus(
@@ -267,14 +268,14 @@ public class ParityWireRoundTripTests
         const int candleCount = 1;
         int total = WireFormat.FramingHeaderSize + 8 + 2 + 1 + 2 + candleCount * 56;
         var buf = new byte[total];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)total);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), (ushort)WireFormat.MessageType.CandleSnapshot);
-        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4), secId);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(12), resolution);
-        buf[14] = flags;
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(15), (ushort)candleCount);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, (uint)total);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), (ushort)MessageType.CandleSnapshot);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(8), secId);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(16), resolution);
+        buf[18] = flags;
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(19), (ushort)candleCount);
         // Candle: time, open, high, low, close, volume, avg
-        int o = 17;
+        int o = 21;
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 1_700_000_000_000_000_000L); o += 8;
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 36_7000L); o += 8;          // open 36.70
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(o), 37_0000L); o += 8;          // high 37.00

--- a/tests/B3.MarketData.WebSocketClient.Tests/PriceBandWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/PriceBandWireRoundTripTests.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using System.Buffers.Binary;
 using B3.Umdf.Book;
 using B3.Umdf.Server;
@@ -33,8 +34,8 @@ public class PriceBandWireRoundTripTests
         int len = B3.Umdf.Server.WireProtocol.WritePriceBand(buf, securityId: 42UL, info);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var hLen, out var type));
-        Assert.Equal(len, hLen);
-        Assert.Equal(WireFormat.MessageType.PriceBand, type);
+        Assert.Equal((uint)len, hLen);
+        Assert.Equal(MessageType.PriceBand, type);
 
         var ev = WireFormat.ReadPriceBand(
             buf.AsSpan(WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize),

--- a/tests/B3.MarketData.WebSocketClient.Tests/SecurityDefinitionWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/SecurityDefinitionWireRoundTripTests.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using System.Buffers.Binary;
 using B3.Umdf.Book;
 using B3.Umdf.Server;
@@ -44,8 +45,8 @@ public class SecurityDefinitionWireRoundTripTests
         int len = B3.Umdf.Server.WireProtocol.WriteSecurityDefinition(buf, securityId: 12345UL, info);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var hLen, out var type));
-        Assert.Equal(len, hLen);
-        Assert.Equal(WireFormat.MessageType.SecurityDefinition, type);
+        Assert.Equal((uint)len, hLen);
+        Assert.Equal(MessageType.SecurityDefinition, type);
 
         var ev = WireFormat.ReadSecurityDefinition(
             new ReadOnlySpan<byte>(buf, WireFormat.FramingHeaderSize, len - WireFormat.FramingHeaderSize),

--- a/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/WireFormatTests.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using B3.MarketData.WebSocketClient;
 
 namespace B3.MarketData.WebSocketClient.Tests;
@@ -13,13 +14,13 @@ public class WireFormatTests
     [Fact]
     public void Trade_RoundTrip_ScalesPriceWithSbeExponent()
     {
-        // Encode a Trade frame the way the server would.
-        Span<byte> buf = stackalloc byte[37];
+        // Encode a Trade frame the way the server would (v2 blittable struct).
+        Span<byte> buf = stackalloc byte[TradeFrame.WireSize];
         WriteServerTradeFrame(buf, securityId: 42, price: 12_3456, qty: 100, tradeId: 7, flags: 0);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var len, out var type));
-        Assert.Equal(37, len);
-        Assert.Equal(WireFormat.MessageType.Trade, type);
+        Assert.Equal((uint)TradeFrame.WireSize, len);
+        Assert.Equal(MessageType.Trade, type);
 
         var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
         Assert.Equal(42UL, secId);
@@ -38,7 +39,7 @@ public class WireFormatTests
     [InlineData(1, TradeFlags.AuctionPrint)]
     public void Trade_DecodesFlagsByte(byte raw, TradeFlags expected)
     {
-        Span<byte> buf = stackalloc byte[37];
+        Span<byte> buf = stackalloc byte[TradeFrame.WireSize];
         WriteServerTradeFrame(buf, securityId: 99, price: 1000, qty: 7, tradeId: 123, flags: raw);
 
         var (_, _, _, _, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
@@ -46,19 +47,20 @@ public class WireFormatTests
     }
 
     [Fact]
-    public void Trade_LegacyServer_OmittedFlagsByte_DefaultsToNone()
+    public void Trade_ForwardCompat_TrailingExtensionBytes_AreIgnored()
     {
-        // Simulate an older server that wrote the 36-byte trade frame.
-        Span<byte> buf = stackalloc byte[36];
-        const ushort totalLen = 36;
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, totalLen);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.Trade);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 42UL);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[12..], 1000L);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[20..], 7L);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[28..], 123L);
+        // A future server appends fields after the v2 core; the min-length rule
+        // says older decoders read the known core and ignore the trailing bytes.
+        Span<byte> buf = stackalloc byte[TradeFrame.WireSize + 8];
+        WireFrame.Write(buf, new TradeFrame(42UL, 1000L, 7L, 123L, flags: 0));
+        // Re-stamp the framing length to advertise the longer frame.
+        WireFrame.WriteHeader(buf, TradeFrame.WireSize + 8, MessageType.Trade);
 
-        var (_, _, _, _, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        var (secId, price, qty, tradeId, flags) = WireFormat.ReadTrade(buf[WireFormat.FramingHeaderSize..]);
+        Assert.Equal(42UL, secId);
+        Assert.Equal(1000L, price);
+        Assert.Equal(7L, qty);
+        Assert.Equal(123L, tradeId);
         Assert.Equal(TradeFlags.None, flags);
     }
 
@@ -69,13 +71,14 @@ public class WireFormatTests
         int len = WireFormat.WriteSubscribe(buf, SubscribeFlags.Trades | SubscribeFlags.Info, "PETR4");
 
         Assert.True(WireFormat.TryReadHeader(buf, out var totalLen, out var type));
-        Assert.Equal(len, totalLen);
-        Assert.Equal(WireFormat.MessageType.Subscribe, type);
-        // [flags=0x12][symLen=5][PETR4]
-        Assert.Equal((byte)0x12, buf[4]);
-        Assert.Equal((byte)5, buf[5]);
-        Assert.Equal((byte)'P', buf[6]);
-        Assert.Equal((byte)'4', buf[10]);
+        Assert.Equal((uint)len, totalLen);
+        Assert.Equal(MessageType.Subscribe, type);
+        // Payload @8: [flags u32=0x12][symLen u8=5][PETR4]
+        Assert.Equal((byte)0x12, buf[8]);
+        Assert.Equal((byte)0x00, buf[9]);
+        Assert.Equal((byte)5, buf[12]);
+        Assert.Equal((byte)'P', buf[13]);
+        Assert.Equal((byte)'4', buf[17]);
     }
 
     [Fact]
@@ -87,7 +90,7 @@ public class WireFormatTests
         // header(4) + secId(8) + mask(4) + 2 * i64
         ushort total = 4 + 8 + 4 + 16;
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.InfoSnapshot);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)MessageType.InfoSnapshot);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 99UL);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf[12..], mask);
         System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(buf[16..], 25_5000L); // 25.5000
@@ -123,7 +126,7 @@ public class WireFormatTests
         // header(4) + secId(8) + mask(4) + 4 * i64
         ushort total = 4 + 8 + 4 + 32;
         System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf, total);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)WireFormat.MessageType.InfoSnapshot);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(buf[2..], (ushort)MessageType.InfoSnapshot);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(buf[4..], 7UL);
         System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf[12..], mask);
         // Bit-order on wire: 7, 8, 9, 24.
@@ -140,14 +143,5 @@ public class WireFormatTests
     }
 
     private static void WriteServerTradeFrame(Span<byte> dest, ulong securityId, long price, long qty, long tradeId, byte flags)
-    {
-        const ushort totalLen = 4 + 8 + 8 + 8 + 8 + 1;
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest, totalLen);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(dest[2..], (ushort)WireFormat.MessageType.Trade);
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(dest[4..], securityId);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[12..], price);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[20..], qty);
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(dest[28..], tradeId);
-        dest[36] = flags;
-    }
+        => WireFrame.Write(dest, new TradeFrame(securityId, price, qty, tradeId, flags));
 }

--- a/tests/B3.MarketData.WebSocketClient.Tests/WireV2LayoutTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/WireV2LayoutTests.cs
@@ -1,0 +1,88 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using B3.MarketData.Wire;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+/// <summary>
+/// Locks the v2 blittable wire layout: sizes, field offsets, and header framing.
+/// These assertions are the guardrail that keeps the on-wire layout from
+/// silently changing (Explicit layout can otherwise be edited by accident).
+/// </summary>
+public class WireV2LayoutTests
+{
+    [Fact]
+    public void Header_IsEightBytes()
+    {
+        Assert.Equal(8, WireV2.HeaderSize);
+    }
+
+    [Theory]
+    [InlineData(typeof(ClientHelloFrame), 16)]
+    [InlineData(typeof(ServerStatusFrame), 9)]
+    [InlineData(typeof(SecurityIdFrame), 16)]
+    [InlineData(typeof(SymbolStaleStatusFrame), 17)]
+    [InlineData(typeof(OrderEventFrame), 41)]
+    [InlineData(typeof(OrderDeletedFrame), 25)]
+    [InlineData(typeof(TradeFrame), 41)]
+    [InlineData(typeof(TradeBustFrame), 24)]
+    [InlineData(typeof(BookClearedFrame), 17)]
+    [InlineData(typeof(MarketTierUpdateFrame), 29)]
+    [InlineData(typeof(LevelUpdateFrame), 37)]
+    [InlineData(typeof(LevelDeletedFrame), 25)]
+    public void FrameSize_MatchesSpec(Type frameType, int expectedSize)
+    {
+        int size = Marshal.SizeOf(frameType);
+        Assert.Equal(expectedSize, size);
+    }
+
+    [Fact]
+    public void OrderEvent_FieldOffsets_AreAligned()
+    {
+        Assert.Equal(0, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.Length)));
+        Assert.Equal(4, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.TypeRaw)));
+        Assert.Equal(6, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.HeaderFlagsRaw)));
+        Assert.Equal(8, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.SecurityId)));
+        Assert.Equal(16, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.OrderId)));
+        Assert.Equal(24, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.Price)));
+        Assert.Equal(32, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.Quantity)));
+        Assert.Equal(40, (int)Marshal.OffsetOf<OrderEventFrame>(nameof(OrderEventFrame.Side)));
+    }
+
+    [Fact]
+    public void OrderEvent_WriteThenRead_RoundTrips()
+    {
+        Span<byte> buf = stackalloc byte[64];
+        var frame = new OrderEventFrame(MessageType.OrderAdded, 42, 9001, 12_3456, 250, side: 0);
+        int n = WireFrame.Write(buf, in frame);
+        Assert.Equal(OrderEventFrame.WireSize, n);
+
+        Assert.True(WireFrame.TryReadHeader(buf, out uint len, out var type, out var flags));
+        Assert.Equal((uint)OrderEventFrame.WireSize, len);
+        Assert.Equal(MessageType.OrderAdded, type);
+        Assert.Equal(HeaderFlags.None, flags);
+
+        var read = WireFrame.Read<OrderEventFrame>(buf);
+        Assert.Equal(42UL, read.SecurityId);
+        Assert.Equal(9001UL, read.OrderId);
+        Assert.Equal(12_3456L, read.Price);
+        Assert.Equal(250L, read.Quantity);
+        Assert.Equal((byte)0, read.Side);
+    }
+
+    [Fact]
+    public void Read_IgnoresTrailingBytes_MinLengthRule()
+    {
+        // A forward-compatible producer appended 8 unknown trailing bytes.
+        Span<byte> buf = stackalloc byte[OrderEventFrame.WireSize + 8];
+        var frame = new OrderEventFrame(MessageType.OrderUpdated, 7, 1, 100, 5, side: 1);
+        WireFrame.Write(buf, in frame);
+        // Simulate a longer advertised length.
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf, (uint)buf.Length);
+
+        // Old decoder still reads its known core without error.
+        var read = WireFrame.Read<OrderEventFrame>(buf);
+        Assert.Equal(7UL, read.SecurityId);
+        Assert.Equal(1UL, read.OrderId);
+    }
+}

--- a/tests/B3.Umdf.Fuzz.Tests/GlobalUsings.WireV2.cs
+++ b/tests/B3.Umdf.Fuzz.Tests/GlobalUsings.WireV2.cs
@@ -1,0 +1,1 @@
+global using B3.MarketData.Wire;

--- a/tests/B3.Umdf.Fuzz.Tests/MarketDataClientFramingFuzzTests.cs
+++ b/tests/B3.Umdf.Fuzz.Tests/MarketDataClientFramingFuzzTests.cs
@@ -1,3 +1,4 @@
+using B3.MarketData.Wire;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
@@ -91,7 +92,7 @@ public class MarketDataClientFramingFuzzTests
                 if (!WireFormat.TryReadHeader(buf.AsSpan(offset), out var len, out _) ||
                     len < WireFormat.FramingHeaderSize) break;
                 if (offset + len > buf.Length) break;
-                offset += len;
+                offset += (int)len;
             }
             Assert.True(offset <= buf.Length, $"DispatchFrames loop walked past end (offset={offset}, length={buf.Length})");
         });
@@ -102,14 +103,14 @@ public class MarketDataClientFramingFuzzTests
     /// The framing loop must reject the partial frame and stop, NOT slice past the end.
     /// </summary>
     [Theory]
-    [InlineData(5)]      // claims one byte beyond a 4-byte header buffer
+    [InlineData(9)]      // claims one byte beyond an 8-byte header buffer
     [InlineData(255)]
-    [InlineData(0xFFFF)] // u16 max
+    [InlineData(0xFFFF)]
     public void OversizedClaimedLength_DoesNotCausePastEndRead(int claimedLen)
     {
-        var buf = new byte[4];
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)claimedLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), (ushort)WireFormat.MessageType.ServerStatus);
+        var buf = new byte[8];
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, (uint)claimedLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), (ushort)MessageType.ServerStatus);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var len, out _));
         // Same loop the SDK runs:
@@ -133,14 +134,13 @@ public class MarketDataClientFramingFuzzTests
     {
         var buf = new byte[10];
         // Claim a 16-byte ServerHello frame but only deliver 10 bytes.
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, 16);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), (ushort)WireFormat.MessageType.ServerHello);
+        WireFrame.WriteHeader(buf, 16, MessageType.ServerHello);
 
         Assert.True(WireFormat.TryReadHeader(buf, out var len, out var type));
-        Assert.Equal(16, len);
-        Assert.Equal(WireFormat.MessageType.ServerHello, type);
-        // Loop must NOT slice into a 12-byte payload from a 6-byte tail; the bounds check
+        Assert.Equal(16u, len);
+        Assert.Equal(MessageType.ServerHello, type);
+        // Loop must NOT slice into a payload from a short tail; the bounds check
         // (offset + len > buf.Length) is the exact gate exercised here.
-        Assert.True(0 + len > buf.Length);
+        Assert.True(0 + len > (uint)buf.Length);
     }
 }

--- a/tests/B3.Umdf.Fuzz.Tests/WireProtocolFramingFuzzTests.cs
+++ b/tests/B3.Umdf.Fuzz.Tests/WireProtocolFramingFuzzTests.cs
@@ -119,7 +119,7 @@ public class WireProtocolFramingFuzzTests
                 // Reject obviously malformed framing per server contract.
                 if (len < WireProtocol.FramingHeaderSize) break;
                 if (offset + len > buf.Length) break;
-                offset += len;
+                offset += (int)len;
             }
             // Must never advance past the buffer end. If this assert fires, the framing
             // loop has a bounds bug exploitable as out-of-bounds read.
@@ -133,17 +133,17 @@ public class WireProtocolFramingFuzzTests
     /// drive the parser into a slice past the end.
     /// </summary>
     [Theory]
-    [InlineData(0xFFFF)] // max u16 — claims 65535 bytes
+    [InlineData(0xFFFF)] // claims 65535 bytes
     [InlineData(0x0100)] // 256 bytes
-    [InlineData(0x0005)] // just one byte beyond the truncated frame
+    [InlineData(0x0009)] // just one byte beyond the header-only frame
     public void OversizedLengthHeader_IsRejected(int claimedLen)
     {
-        var buf = new byte[4]; // header-only, no payload
-        BinaryPrimitives.WriteUInt16LittleEndian(buf, (ushort)claimedLen);
-        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), (ushort)MessageType.Subscribe);
+        var buf = new byte[8]; // header-only, no payload
+        BinaryPrimitives.WriteUInt32LittleEndian(buf, (uint)claimedLen);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(4), (ushort)MessageType.Subscribe);
 
         Assert.True(WireProtocol.TryReadFramingHeader(buf, out var len, out _));
-        Assert.Equal((ushort)claimedLen, len);
+        Assert.Equal((uint)claimedLen, len);
         // Caller is responsible for "len > available" check; verify it works:
         Assert.True(len > buf.Length || len == buf.Length, "test setup: claimed length should exceed real buffer");
     }
@@ -188,7 +188,7 @@ public class WireProtocolFramingFuzzTests
             if (!WireProtocol.TryReadFramingHeader(buf[offset..], out var len, out _)) break;
             if (len < WireProtocol.FramingHeaderSize) break;
             if (offset + len > buf.Length) break;
-            offset += len;
+            offset += (int)len;
         }
         return offset;
     }

--- a/tests/B3.Umdf.Server.Tests/GlobalUsings.WireV2.cs
+++ b/tests/B3.Umdf.Server.Tests/GlobalUsings.WireV2.cs
@@ -1,0 +1,1 @@
+global using B3.MarketData.Wire;

--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using B3.Umdf.Book;
 using B3.Umdf.Mbo.Sbe.V16;
+using MessageType = B3.MarketData.Wire.MessageType;
 using B3.Umdf.Server;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -148,8 +149,8 @@ public class GroupConflationHandlerAuctionPrintTests
             Thread.Sleep(10);
         }
         Assert.NotNull(frame);
-        Assert.Equal(37, frame!.Length);
-        return (TradeFlags)frame[36];
+        Assert.Equal(41, frame!.Length);
+        return (TradeFlags)frame[40];
     }
 
     private static void SetTradingStatus((SubscriptionManager Manager, GroupConflationHandler Group,

--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
@@ -90,12 +90,12 @@ public class GroupConflationHandlerMbpTests
 
             var lu = rec.LastFrame(MessageType.LevelUpdate);
             Assert.NotNull(lu);
-            // Layout: header(4) + secId(8) + side(1) + price(8) + totalQty(8) + count(4)
-            Assert.Equal(SecurityId, BinaryPrimitives.ReadUInt64LittleEndian(lu.AsSpan(4)));
-            Assert.Equal((byte)BookSideType.Bid, lu[12]);
-            Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(lu.AsSpan(13)));
-            Assert.Equal(10L, BinaryPrimitives.ReadInt64LittleEndian(lu.AsSpan(21))); // 7 + 3
-            Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(lu.AsSpan(29)));
+            // v2 layout: header(8) + secId(8) + price(8) + totalQty(8) + count u32 + side u8
+            Assert.Equal(SecurityId, BinaryPrimitives.ReadUInt64LittleEndian(lu.AsSpan(8)));
+            Assert.Equal((byte)BookSideType.Bid, lu[36]);
+            Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(lu.AsSpan(16)));
+            Assert.Equal(10L, BinaryPrimitives.ReadInt64LittleEndian(lu.AsSpan(24))); // 7 + 3
+            Assert.Equal(2u, BinaryPrimitives.ReadUInt32LittleEndian(lu.AsSpan(32)));
         }
         finally
         {
@@ -130,9 +130,9 @@ public class GroupConflationHandlerMbpTests
             Assert.Equal(0, rec.CountByType(MessageType.LevelUpdate));
 
             var ld = rec.LastFrame(MessageType.LevelDeleted)!;
-            Assert.Equal(SecurityId, BinaryPrimitives.ReadUInt64LittleEndian(ld.AsSpan(4)));
-            Assert.Equal((byte)BookSideType.Bid, ld[12]);
-            Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(ld.AsSpan(13)));
+            Assert.Equal(SecurityId, BinaryPrimitives.ReadUInt64LittleEndian(ld.AsSpan(8)));
+            Assert.Equal((byte)BookSideType.Bid, ld[24]);
+            Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(ld.AsSpan(16)));
         }
         finally
         {
@@ -336,10 +336,10 @@ internal sealed class RecordingWebSocket : WebSocket
         lock (_lock)
         {
             int o = 0;
-            while (o + 4 <= bytes.Length)
+            while (o + 8 <= bytes.Length)
             {
-                int frameLen = BinaryPrimitives.ReadUInt16LittleEndian(bytes.AsSpan(o));
-                if (frameLen < 4 || o + frameLen > bytes.Length) break;
+                int frameLen = (int)BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(o));
+                if (frameLen < 8 || o + frameLen > bytes.Length) break;
                 var frame = new byte[frameLen];
                 Buffer.BlockCopy(bytes, o, frame, 0, frameLen);
                 _frames.Add(frame);
@@ -358,7 +358,7 @@ internal sealed class RecordingWebSocket : WebSocket
             int n = 0;
             foreach (var f in _frames)
             {
-                if (f.Length >= 4 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(2)) == t)
+                if (f.Length >= 8 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(4)) == t)
                     n++;
             }
             return n;
@@ -372,7 +372,7 @@ internal sealed class RecordingWebSocket : WebSocket
             for (int i = _frames.Count - 1; i >= 0; i--)
             {
                 var f = _frames[i];
-                if (f.Length >= 4 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(2)) == t)
+                if (f.Length >= 8 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(4)) == t)
                     return f;
             }
             return null;
@@ -386,7 +386,7 @@ internal sealed class RecordingWebSocket : WebSocket
             var result = new List<byte[]>();
             foreach (var f in _frames)
             {
-                if (f.Length >= 4 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(2)) == t)
+                if (f.Length >= 8 && (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(f.AsSpan(4)) == t)
                     result.Add(f);
             }
             return result;

--- a/tests/B3.Umdf.Server.Tests/TradeHistoryFlagsTests.cs
+++ b/tests/B3.Umdf.Server.Tests/TradeHistoryFlagsTests.cs
@@ -62,10 +62,10 @@ public class TradeHistoryFlagsTests
 
         Assert.Equal(3, recorder.CountByType(MessageType.Trade));
         var frames = recorder.AllFrames(MessageType.Trade);
-        Assert.All(frames, f => Assert.Equal(37, f.Length));
-        Assert.Equal(0, frames[0][36]);
-        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[1][36]);
-        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[2][36]);
+        Assert.All(frames, f => Assert.Equal(41, f.Length));
+        Assert.Equal(0, frames[0][40]);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[1][40]);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, frames[2][40]);
     }
 
     private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)

--- a/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
@@ -252,14 +252,14 @@ public class WebSocketHostIntegrationTests
 
             Assert.Equal(WebSocketMessageType.Binary, result.MessageType);
 
-            // Frame 0: ServerHello (length-prefixed, type at offset 2).
-            ushort len = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer);
-            ushort type = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(2));
+            // Frame 0: ServerHello (u32 length @0, u16 type @4).
+            uint len = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+            ushort type = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(4));
             Assert.Equal((ushort)MessageType.ServerHello, type);
             Assert.True(filled >= len, $"frame should be at least {len} bytes (got {filled})");
 
             var (protocolVersion, capabilities, buildVersion) =
-                WireProtocol.ReadServerHello(buffer.AsSpan(WireProtocol.FramingHeaderSize, len - WireProtocol.FramingHeaderSize));
+                WireProtocol.ReadServerHello(buffer.AsSpan(WireProtocol.FramingHeaderSize, (int)len - WireProtocol.FramingHeaderSize));
 
             Assert.Equal(WireProtocol.ProtocolVersion, protocolVersion);
             Assert.False(string.IsNullOrEmpty(buildVersion), "ServerHello.buildVersion must be non-empty");

--- a/tests/B3.Umdf.Server.Tests/WireProtocolAuctionTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolAuctionTests.cs
@@ -11,8 +11,8 @@ namespace B3.Umdf.Server.Tests;
 /// </summary>
 public class WireProtocolAuctionTests
 {
-    private static (ushort length, MessageType type) ReadFraming(Span<byte> buf) =>
-        (BinaryPrimitives.ReadUInt16LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]));
+    private static (int length, MessageType type) ReadFraming(Span<byte> buf) =>
+        ((int)BinaryPrimitives.ReadUInt32LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]));
 
     [Fact]
     public void WriteAuction_MessageTypeIs0x00B2()
@@ -126,7 +126,7 @@ public class WireProtocolAuctionTests
     [Fact]
     public void DataFlags_Auction_IsInEverythingButNotAll()
     {
-        Assert.True(DataFlags.Everything.HasFlag(DataFlags.Auction));
+        Assert.True(DataFlags.AllKnown.HasFlag(DataFlags.Auction));
         Assert.False(DataFlags.All.HasFlag(DataFlags.Auction));
         Assert.Equal((byte)0x80, (byte)DataFlags.Auction);
     }
@@ -135,6 +135,6 @@ public class WireProtocolAuctionTests
     public void DataFlags_Everything_Is0xFF()
     {
         // After adding Auction (0x80), Everything should be all bits set.
-        Assert.Equal((byte)0xFF, (byte)DataFlags.Everything);
+        Assert.Equal((byte)0xFF, (byte)DataFlags.AllKnown);
     }
 }

--- a/tests/B3.Umdf.Server.Tests/WireProtocolMbpTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolMbpTests.cs
@@ -4,8 +4,8 @@ namespace B3.Umdf.Server.Tests;
 
 public class WireProtocolMbpTests
 {
-    private static (ushort length, MessageType type) ReadFraming(Span<byte> buf) =>
-        (BinaryPrimitives.ReadUInt16LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]));
+    private static (int length, MessageType type) ReadFraming(Span<byte> buf) =>
+        ((int)BinaryPrimitives.ReadUInt32LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]));
 
     [Fact]
     public void WriteLevelUpdate_RoundTrip()
@@ -18,11 +18,11 @@ public class WireProtocolMbpTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.LevelUpdate, type);
 
-        Assert.Equal(42UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(1, buf[12]);
-        Assert.Equal(1234567L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(13)));
-        Assert.Equal(9876L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(21)));
-        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(29)));
+        Assert.Equal(42UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(1, buf[36]);
+        Assert.Equal(1234567L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(16)));
+        Assert.Equal(9876L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(24)));
+        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(32)));
     }
 
     [Fact]
@@ -36,9 +36,9 @@ public class WireProtocolMbpTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.LevelDeleted, type);
 
-        Assert.Equal(99UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(0, buf[12]);
-        Assert.Equal(-5L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(13)));
+        Assert.Equal(99UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(0, buf[24]);
+        Assert.Equal(-5L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(16)));
     }
 
     [Fact]
@@ -57,14 +57,14 @@ public class WireProtocolMbpTests
         var (msgLen, type) = ReadFraming(buf);
         Assert.Equal(buf.Length, msgLen);
         Assert.Equal(MessageType.LevelSnapshot, type);
-        Assert.Equal(7UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        Assert.Equal((ushort)bidCount, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(12)));
-        Assert.Equal((ushort)askCount, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(14)));
+        Assert.Equal(7UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        Assert.Equal((ushort)bidCount, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(16)));
+        Assert.Equal((ushort)askCount, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(18)));
 
-        // First bid entry begins at offset 16.
-        Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(16)));
-        Assert.Equal(50L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(24)));
-        Assert.Equal(3u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(32)));
+        // First bid entry begins at offset 20.
+        Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(20)));
+        Assert.Equal(50L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(28)));
+        Assert.Equal(3u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(36)));
     }
 
     [Fact]
@@ -76,15 +76,15 @@ public class WireProtocolMbpTests
         var (msgLen, type) = ReadFraming(buf);
         Assert.Equal(buf.Length, msgLen);
         Assert.Equal(MessageType.LevelSnapshot, type);
-        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(12)));
-        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(14)));
+        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(16)));
+        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(18)));
     }
 
     [Fact]
     public void DataFlags_MbpBitMatchesProtocol()
     {
         Assert.Equal((DataFlags)0x08, DataFlags.Mbp);
-        Assert.True((DataFlags.Everything & DataFlags.Mbp) == DataFlags.Mbp);
+        Assert.True((DataFlags.AllKnown & DataFlags.Mbp) == DataFlags.Mbp);
         Assert.True((DataFlags.Book & DataFlags.Mbp) == 0);
     }
 }

--- a/tests/B3.Umdf.Server.Tests/WireProtocolNewsTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolNewsTests.cs
@@ -101,8 +101,8 @@ public class WireProtocolNewsTests
         WireProtocol.WriteNewsChunk(chunk, 1, WireProtocol.NewsField.Text, data, isFinal: false);
         WireProtocol.WriteNewsChunk(end, 1, WireProtocol.NewsField.Text, data, isFinal: true);
 
-        // Type byte sits inside the framing header — they must differ.
-        Assert.NotEqual(chunk[2], end[2]);
+        // Type field (u16) sits inside the framing header at offset 4 — they must differ.
+        Assert.NotEqual(chunk[4], end[4]);
     }
 
     [Fact]
@@ -126,9 +126,9 @@ public class WireProtocolNewsTests
     [Fact]
     public void DataFlags_Everything_IncludesNewsBit()
     {
-        Assert.True((DataFlags.Everything & DataFlags.News) == DataFlags.News);
-        Assert.True((DataFlags.Everything & DataFlags.Book) == DataFlags.Book);
-        Assert.True((DataFlags.Everything & DataFlags.Info) == DataFlags.Info);
+        Assert.True((DataFlags.AllKnown & DataFlags.News) == DataFlags.News);
+        Assert.True((DataFlags.AllKnown & DataFlags.Book) == DataFlags.Book);
+        Assert.True((DataFlags.AllKnown & DataFlags.Info) == DataFlags.Info);
     }
 
     [Fact]

--- a/tests/B3.Umdf.Server.Tests/WireProtocolPriceBandTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolPriceBandTests.cs
@@ -11,8 +11,8 @@ namespace B3.Umdf.Server.Tests;
 /// </summary>
 public class WireProtocolPriceBandTests
 {
-    private static (ushort length, MessageType type) ReadFraming(Span<byte> buf) =>
-        (BinaryPrimitives.ReadUInt16LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]));
+    private static (int length, MessageType type) ReadFraming(Span<byte> buf) =>
+        ((int)BinaryPrimitives.ReadUInt32LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]));
 
     [Fact]
     public void WritePriceBand_MessageTypeIs0x00B1()
@@ -114,7 +114,7 @@ public class WireProtocolPriceBandTests
     [Fact]
     public void DataFlags_PriceBand_IsInEverythingButNotAll()
     {
-        Assert.True(DataFlags.Everything.HasFlag(DataFlags.PriceBand));
+        Assert.True(DataFlags.AllKnown.HasFlag(DataFlags.PriceBand));
         Assert.False(DataFlags.All.HasFlag(DataFlags.PriceBand));
         Assert.Equal((byte)0x40, (byte)DataFlags.PriceBand);
     }

--- a/tests/B3.Umdf.Server.Tests/WireProtocolSecurityDefinitionTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolSecurityDefinitionTests.cs
@@ -12,8 +12,8 @@ namespace B3.Umdf.Server.Tests;
 /// </summary>
 public class WireProtocolSecurityDefinitionTests
 {
-    private static (ushort length, MessageType type) ReadFraming(Span<byte> buf) =>
-        (BinaryPrimitives.ReadUInt16LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]));
+    private static (int length, MessageType type) ReadFraming(Span<byte> buf) =>
+        ((int)BinaryPrimitives.ReadUInt32LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]));
 
     [Fact]
     public void WriteSecurityDefinition_MessageTypeIs0x00B0()
@@ -111,7 +111,7 @@ public class WireProtocolSecurityDefinitionTests
     [Fact]
     public void DataFlags_SecurityDefinition_IsInEverythingButNotInAll()
     {
-        Assert.True(DataFlags.Everything.HasFlag(DataFlags.SecurityDefinition));
+        Assert.True(DataFlags.AllKnown.HasFlag(DataFlags.SecurityDefinition));
         Assert.False(DataFlags.All.HasFlag(DataFlags.SecurityDefinition));
         Assert.Equal((byte)0x20, (byte)DataFlags.SecurityDefinition);
     }

--- a/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WireProtocolTests.cs
@@ -5,8 +5,8 @@ namespace B3.Umdf.Server.Tests;
 
 public class WireProtocolTests
 {
-    private static (ushort length, MessageType type) ReadFraming(Span<byte> buf) =>
-        (BinaryPrimitives.ReadUInt16LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[2..]));
+    private static (int length, MessageType type) ReadFraming(Span<byte> buf) =>
+        ((int)BinaryPrimitives.ReadUInt32LittleEndian(buf), (MessageType)BinaryPrimitives.ReadUInt16LittleEndian(buf[4..]));
 
     [Fact]
     public void WriteServerStatus_Ready_EncodesCorrectly()
@@ -14,11 +14,11 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteServerStatus(buf, ready: true);
 
-        Assert.Equal(5, len);
+        Assert.Equal(9, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(5, msgLen);
+        Assert.Equal(9, msgLen);
         Assert.Equal(MessageType.ServerStatus, type);
-        Assert.Equal(1, buf[4]);
+        Assert.Equal(1, buf[8]);
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public class WireProtocolTests
     {
         var buf = new byte[64];
         WireProtocol.WriteServerStatus(buf, ready: false);
-        Assert.Equal(0, buf[4]);
+        Assert.Equal(0, buf[8]);
     }
 
     [Fact]
@@ -39,11 +39,11 @@ public class WireProtocolTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.SubscribeOk, type);
 
-        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4));
+        ulong secId = BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8));
         Assert.Equal(12345UL, secId);
-        Assert.Equal((byte)DataFlags.All, buf[12]);
-        int symLen = buf[13];
-        Assert.Equal("PETR4", System.Text.Encoding.UTF8.GetString(buf, 14, symLen));
+        Assert.Equal((uint)DataFlags.All, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(16)));
+        int symLen = buf[20];
+        Assert.Equal("PETR4", System.Text.Encoding.UTF8.GetString(buf, 21, symLen));
     }
 
     [Fact]
@@ -55,9 +55,9 @@ public class WireProtocolTests
         var (msgLen, type) = ReadFraming(buf);
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.SubscribeError, type);
-        Assert.Equal((byte)SubscribeErrorCode.UnknownSymbol, buf[4]);
-        int symLen = buf[5];
-        Assert.Equal("UNKNOWN", System.Text.Encoding.UTF8.GetString(buf, 6, symLen));
+        Assert.Equal((byte)SubscribeErrorCode.UnknownSymbol, buf[8]);
+        int symLen = buf[9];
+        Assert.Equal("UNKNOWN", System.Text.Encoding.UTF8.GetString(buf, 10, symLen));
     }
 
     [Fact]
@@ -67,17 +67,17 @@ public class WireProtocolTests
         int len = WireProtocol.WriteOrderEvent(buf, MessageType.OrderAdded,
             securityId: 99, orderId: 42, side: 1, price: 10_000L, qty: 500L);
 
-        Assert.Equal(37, len);
+        Assert.Equal(41, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(37, msgLen);
+        Assert.Equal(41, msgLen);
         Assert.Equal(MessageType.OrderAdded, type);
 
-        int off = 4;
+        int off = 8;
         Assert.Equal(99UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(42UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
-        Assert.Equal(1, buf[off++]);
         Assert.Equal(10_000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
-        Assert.Equal(500L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off)));
+        Assert.Equal(500L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
+        Assert.Equal(1, buf[off]);
     }
 
     [Fact]
@@ -86,12 +86,12 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteOrderDeleted(buf, securityId: 7, orderId: 3, side: 2);
 
-        Assert.Equal(21, len);
+        Assert.Equal(25, len);
         var (_, type) = ReadFraming(buf);
         Assert.Equal(MessageType.OrderDeleted, type);
-        Assert.Equal(7UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(3UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(12)));
-        Assert.Equal(2, buf[20]);
+        Assert.Equal(7UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(3UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(16)));
+        Assert.Equal(2, buf[24]);
     }
 
     [Fact]
@@ -100,12 +100,12 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteTrade(buf, securityId: 1001, price: 55_000L, qty: 100L, tradeId: 9876L);
 
-        Assert.Equal(37, len);
+        Assert.Equal(41, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(37, msgLen);
+        Assert.Equal(41, msgLen);
         Assert.Equal(MessageType.Trade, type);
 
-        int off = 4;
+        int off = 8;
         Assert.Equal(1001UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(55_000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(100L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
@@ -120,8 +120,8 @@ public class WireProtocolTests
         int len = WireProtocol.WriteTrade(buf, securityId: 1001, price: 55_000L, qty: 100L, tradeId: 9876L,
             flags: (byte)TradeFlags.AuctionPrint);
 
-        Assert.Equal(37, len);
-        Assert.Equal((byte)TradeFlags.AuctionPrint, buf[36]);
+        Assert.Equal(41, len);
+        Assert.Equal((byte)TradeFlags.AuctionPrint, buf[40]);
     }
 
     [Fact]
@@ -130,11 +130,11 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteBookCleared(buf, securityId: 500, clearSide: 3);
 
-        Assert.Equal(13, len);
+        Assert.Equal(17, len);
         var (_, type) = ReadFraming(buf);
         Assert.Equal(MessageType.BookCleared, type);
-        Assert.Equal(500UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(3, buf[12]);
+        Assert.Equal(500UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(3, buf[16]);
     }
 
     [Fact]
@@ -143,16 +143,16 @@ public class WireProtocolTests
         var buf = new byte[64];
         int len = WireProtocol.WriteMarketTierUpdate(buf, securityId: 501, side: 0, totalQty: 12345, orderCount: 7);
 
-        Assert.Equal(25, len);
+        Assert.Equal(29, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(25, msgLen);
+        Assert.Equal(29, msgLen);
         Assert.Equal(MessageType.MarketTierUpdate, type);
 
-        int off = 4;
+        int off = 8;
         Assert.Equal(501UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
-        Assert.Equal(0, buf[off++]);
         Assert.Equal(12345L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
-        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(off)));
+        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(off))); off += 4;
+        Assert.Equal(0, buf[off]);
     }
 
     [Fact]
@@ -162,13 +162,13 @@ public class WireProtocolTests
         var info = new InstrumentInfo();
         int len = WireProtocol.WriteInfoSnapshot(buf, securityId: 42, info);
 
-        // framing(4) + secId(8) + mask(4) = 16 bytes minimum (no fields set)
-        Assert.Equal(16, len);
+        // framing(8) + secId(8) + mask(4) = 20 bytes minimum (no fields set)
+        Assert.Equal(20, len);
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(16, msgLen);
+        Assert.Equal(20, msgLen);
         Assert.Equal(MessageType.InfoSnapshot, type);
-        Assert.Equal(42UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(4)));
-        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12));
+        Assert.Equal(42UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(8)));
+        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(16));
         Assert.Equal(0u, mask);
     }
 
@@ -189,7 +189,7 @@ public class WireProtocolTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.InfoSnapshot, type);
 
-        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12));
+        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(16));
         Assert.NotEqual(0u, mask);
         Assert.True((mask & (1u << WireProtocol.FieldOpeningPrice)) != 0);
         Assert.True((mask & (1u << WireProtocol.FieldHighPrice)) != 0);
@@ -200,7 +200,7 @@ public class WireProtocolTests
         Assert.True((mask & (1u << WireProtocol.FieldClosingPrice)) == 0);
 
         // Verify values (in bit order: OpeningPrice first)
-        int off = 16; // after framing(4)+secId(8)+mask(4)
+        int off = 20; // after framing(8)+secId(8)+mask(4)
         Assert.Equal(10_000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(12_000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8; // High
         Assert.Equal(9_500L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off)));           // Low
@@ -224,7 +224,7 @@ public class WireProtocolTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.InfoSnapshot, type);
 
-        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12));
+        uint mask = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(16));
         Assert.True((mask & (1u << WireProtocol.FieldTheoreticalOpeningPrice)) != 0);
         Assert.True((mask & (1u << WireProtocol.FieldTheoreticalOpeningSize)) != 0);
         Assert.True((mask & (1u << WireProtocol.FieldAuctionImbalanceSize)) != 0);
@@ -232,7 +232,7 @@ public class WireProtocolTests
 
         // Values appear in bit order. The set bits here are 7,8,9,24 → that's
         // the order on the wire. (24 is set last, after the four lower bits.)
-        int off = 16;
+        int off = 20;
         Assert.Equal(12_3450L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8; // TheoreticalOpeningPrice
         Assert.Equal(7_500L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;   // TheoreticalOpeningSize
         Assert.Equal(250L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8;     // AuctionImbalanceSize
@@ -251,7 +251,7 @@ public class WireProtocolTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.CandleUpdate, type);
 
-        int off = 4;
+        int off = WireProtocol.FramingHeaderSize;
         Assert.Equal(333UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(1, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(off))); off += 2;
         Assert.Equal(1000L, BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(off))); off += 8; // Time
@@ -279,7 +279,7 @@ public class WireProtocolTests
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.CandleSnapshot, type);
 
-        int off = 4;
+        int off = WireProtocol.FramingHeaderSize;
         Assert.Equal(55UL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(off))); off += 8;
         Assert.Equal(1, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(off))); off += 2; // resolution
         Assert.Equal(WireProtocol.CandleFlagFirst | WireProtocol.CandleFlagLast, buf[off++]);
@@ -328,9 +328,9 @@ public class WireProtocolTests
     {
         var buf = new byte[64];
         WireProtocol.WriteServerStatus(buf, ready: true);
-        bool ok = WireProtocol.TryReadFramingHeader(buf, out ushort length, out MessageType type);
+        bool ok = WireProtocol.TryReadFramingHeader(buf, out uint length, out MessageType type);
         Assert.True(ok);
-        Assert.Equal(5, length);
+        Assert.Equal(9u, length);
         Assert.Equal(MessageType.ServerStatus, type);
     }
 
@@ -349,13 +349,13 @@ public class WireProtocolTests
         int len = WireProtocol.WriteRecoveryProgress(buf, totalSymbols: 18000, totalStaleSymbols: 0,
             staleByKind: ReadOnlySpan<int>.Empty);
 
-        Assert.Equal(13, len); // 4 framing + 4 + 4 + 1
+        Assert.Equal(17, len); // 8 framing + 4 + 4 + 1
         var (msgLen, type) = ReadFraming(buf);
-        Assert.Equal(13, msgLen);
+        Assert.Equal(17, msgLen);
         Assert.Equal(MessageType.RecoveryProgress, type);
-        Assert.Equal(18000u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(8)));
-        Assert.Equal(0, buf[12]); // kindCount
+        Assert.Equal(18000u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12)));
+        Assert.Equal(0, buf[16]); // kindCount
     }
 
     [Fact]
@@ -372,11 +372,11 @@ public class WireProtocolTests
         var (msgLen, type) = ReadFraming(buf);
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.RecoveryProgress, type);
-        Assert.Equal(18000u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(4)));
-        Assert.Equal(20u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(8)));
-        Assert.Equal(2, buf[12]); // kindCount = 2
+        Assert.Equal(18000u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(8)));
+        Assert.Equal(20u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(12)));
+        Assert.Equal(2, buf[16]); // kindCount = 2
 
-        int off = 13;
+        int off = 17;
         Assert.Equal(0, buf[off++]);
         Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(off))); off += 4;
         Assert.Equal(10, buf[off++]);
@@ -397,6 +397,6 @@ public class WireProtocolTests
         var (msgLen, type) = ReadFraming(buf);
         Assert.Equal(len, msgLen);
         Assert.Equal(MessageType.RecoveryProgress, type);
-        Assert.Equal(14, buf[12]);
+        Assert.Equal(14, buf[16]);
     }
 }

--- a/tests/golden/decode.test.mjs
+++ b/tests/golden/decode.test.mjs
@@ -1,0 +1,57 @@
+// Golden-vector decode test for the v2 wire protocol (frontend decoder).
+//
+// Decodes the committed, implementation-independent fixtures in
+// tests/golden/wire-v2-vectors.json with the production parseMessage() and
+// asserts the decoded fields. This is the JS half of the cross-language
+// forward-compatibility contract (the C# half lives in
+// tests/B3.MarketData.WebSocketClient.Tests/GoldenVectorTests.cs).
+//
+// Run:  node --test tests/golden/decode.test.mjs
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { parseMessage } from '../../frontend/js/protocol.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const golden = JSON.parse(readFileSync(join(here, 'wire-v2-vectors.json'), 'utf8'));
+
+function hexToArrayBuffer(hex) {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return bytes.buffer;
+}
+
+test('golden header constants match', () => {
+  assert.equal(golden.protocolVersion, 2);
+  assert.equal(golden.headerSize, 8);
+});
+
+for (const vec of golden.vectors) {
+  test(`decode ${vec.name}`, () => {
+    const buf = hexToArrayBuffer(vec.hex);
+    const view = new DataView(buf);
+    const totalLen = view.getUint32(0, true);
+    assert.equal(totalLen, buf.byteLength, 'framing length must equal buffer size');
+
+    const msg = parseMessage(buf, 0, totalLen);
+    assert.ok(msg, `parseMessage returned null for ${vec.name}`);
+    assert.equal(msg.type, vec.type);
+
+    for (const [key, want] of Object.entries(vec.expected)) {
+      if (key === 'fields') {
+        for (const [fk, fv] of Object.entries(want)) {
+          assert.equal(msg.fields[fk], fv, `${vec.name}.fields.${fk}`);
+        }
+      } else if (typeof msg[key] === 'bigint') {
+        assert.equal(String(msg[key]), String(want), `${vec.name}.${key}`);
+      } else {
+        assert.equal(msg[key], want, `${vec.name}.${key}`);
+      }
+    }
+  });
+}

--- a/tests/golden/generate.mjs
+++ b/tests/golden/generate.mjs
@@ -1,0 +1,146 @@
+// Standalone golden-vector generator for the v2 wire protocol.
+//
+// This encoder is intentionally INDEPENDENT of the production decoders
+// (frontend/js/protocol.js and the C# WireFormat/WireProtocol). It writes the
+// bytes by hand from the normative v2 layout so that both decoders can be
+// tested against a common, committed set of fixtures.
+//
+// Run:  node tests/golden/generate.mjs > tests/golden/wire-v2-vectors.json
+//
+// Header (8 bytes): [u32 length][u16 type][u16 headerFlags=0], little-endian.
+// Payload begins at offset 8. Hot fixed frames are largest-first (side/orderCount
+// moved to the end); cold/variable frames keep their historical field order.
+
+import { Buffer } from 'node:buffer';
+
+const MSG = {
+  SUBSCRIBE_OK: 0x0010,
+  ORDER_ADDED: 0x0030,
+  TRADE: 0x0033,
+  MARKET_TIER_UPDATE: 0x0036,
+  LEVEL_UPDATE: 0x0037,
+  LEVEL_DELETED: 0x0038,
+  SERVER_STATUS: 0x0050,
+  INFO_SNAPSHOT: 0x0021,
+  SERVER_HELLO: 0x00A0,
+};
+
+// A small growable writer that always prefixes the 8-byte v2 header on finish.
+class FrameWriter {
+  constructor(type) {
+    this.type = type;
+    this.bytes = [];
+  }
+  u8(x) { this.bytes.push(x & 0xff); }
+  u16(x) { this.u8(x); this.u8(x >>> 8); }
+  u32(x) { this.u16(x & 0xffff); this.u16((x >>> 16) & 0xffff); }
+  i64(x) {
+    let v = BigInt.asUintN(64, BigInt(x));
+    for (let i = 0; i < 8; i++) { this.u8(Number(v & 0xffn)); v >>= 8n; }
+  }
+  u64(x) { this.i64(x); }
+  str(s) {
+    const b = Buffer.from(s, 'utf8');
+    this.u8(b.length);
+    for (const c of b) this.u8(c);
+  }
+  finish(extraTrailing = 0) {
+    const payload = this.bytes;
+    const total = 8 + payload.length + extraTrailing;
+    const buf = Buffer.alloc(total);
+    buf.writeUInt32LE(total, 0);
+    buf.writeUInt16LE(this.type, 4);
+    buf.writeUInt16LE(0, 6); // headerFlags
+    Buffer.from(payload).copy(buf, 8);
+    // extraTrailing bytes remain zero — exercises the min-length skip rule.
+    return buf.toString('hex');
+  }
+}
+
+const vectors = [];
+function add(name, type, hex, expected) {
+  vectors.push({ name, type, hex, expected });
+}
+
+// SubscribeOk: [secId u64][flags u32][symLen u8][symbol]
+{
+  const w = new FrameWriter(MSG.SUBSCRIBE_OK);
+  w.u64(12345n); w.u32(0x1f); w.str('PETR4');
+  add('SubscribeOk', 'SubscribeOk', w.finish(),
+    { securityId: '12345', flags: 0x1f, symbol: 'PETR4' });
+}
+
+// OrderAdded (hot, reordered): [secId][orderId][price][qty][side u8]
+{
+  const w = new FrameWriter(MSG.ORDER_ADDED);
+  w.u64(99n); w.u64(42n); w.i64(10000); w.i64(500); w.u8(1);
+  add('OrderAdded', 'OrderAdded', w.finish(),
+    { securityId: '99', orderId: '42', price: 10000, qty: 500, side: 1 });
+}
+
+// Trade (hot): [secId][price][qty][tradeId][flags u8]
+{
+  const w = new FrameWriter(MSG.TRADE);
+  w.u64(1001n); w.i64(55000); w.i64(100); w.i64(9876); w.u8(0x01);
+  add('Trade', 'Trade', w.finish(),
+    { securityId: '1001', price: 55000, qty: 100, tradeId: 9876, flags: 0x01, auctionPrint: true });
+}
+
+// Trade with EXTRA trailing bytes — min-length rule: decoder ignores the tail.
+{
+  const w = new FrameWriter(MSG.TRADE);
+  w.u64(2002n); w.i64(60000); w.i64(200); w.i64(1234); w.u8(0x00);
+  add('TradeForwardCompatTrailing', 'Trade', w.finish(16),
+    { securityId: '2002', price: 60000, qty: 200, tradeId: 1234, flags: 0x00, auctionPrint: false });
+}
+
+// MarketTierUpdate (hot, reordered): [secId][totalQty][orderCount u32][side u8]
+{
+  const w = new FrameWriter(MSG.MARKET_TIER_UPDATE);
+  w.u64(501n); w.i64(12345); w.u32(7); w.u8(0);
+  add('MarketTierUpdate', 'MarketTierUpdate', w.finish(),
+    { securityId: '501', qty: 12345, count: 7, side: 0 });
+}
+
+// LevelUpdate (hot, reordered): [secId][price][totalQty][orderCount u32][side u8]
+{
+  const w = new FrameWriter(MSG.LEVEL_UPDATE);
+  w.u64(42n); w.i64(1234567); w.i64(9876); w.u32(2); w.u8(1);
+  add('LevelUpdate', 'LevelUpdate', w.finish(),
+    { securityId: '42', price: 1234567, qty: 9876, count: 2, side: 1 });
+}
+
+// LevelDeleted (hot, reordered): [secId][price][side u8]
+{
+  const w = new FrameWriter(MSG.LEVEL_DELETED);
+  w.u64(99n); w.i64(-5); w.u8(0);
+  add('LevelDeleted', 'LevelDeleted', w.finish(),
+    { securityId: '99', price: -5, side: 0 });
+}
+
+// ServerStatus: [ready u8]
+{
+  const w = new FrameWriter(MSG.SERVER_STATUS);
+  w.u8(1);
+  add('ServerStatus', 'ServerStatus', w.finish(), { ready: true });
+}
+
+// InfoSnapshot (cold, kept order): [secId][mask u32][i64 values in bit order]
+// Bits: OpeningPrice(0)=10000, HighPrice(2)=12000, LowPrice(3)=9500.
+{
+  const w = new FrameWriter(MSG.INFO_SNAPSHOT);
+  const mask = (1 << 0) | (1 << 2) | (1 << 3);
+  w.u64(77n); w.u32(mask); w.i64(10000); w.i64(12000); w.i64(9500);
+  add('InfoSnapshot', 'InfoSnapshot', w.finish(),
+    { securityId: '77', fields: { OpeningPrice: 10000, HighPrice: 12000, LowPrice: 9500 } });
+}
+
+// ServerHello (cold): [protocolVersion u32][capabilities u32][buildLen u8][build]
+{
+  const w = new FrameWriter(MSG.SERVER_HELLO);
+  w.u32(2); w.u32(0x03); w.str('test-build');
+  add('ServerHello', 'ServerHello', w.finish(),
+    { protocolVersion: 2, capabilities: 0x03, buildVersion: 'test-build' });
+}
+
+process.stdout.write(JSON.stringify({ protocolVersion: 2, headerSize: 8, vectors }, null, 2) + '\n');

--- a/tests/golden/wire-v2-vectors.json
+++ b/tests/golden/wire-v2-vectors.json
@@ -1,0 +1,118 @@
+{
+  "protocolVersion": 2,
+  "headerSize": 8,
+  "vectors": [
+    {
+      "name": "SubscribeOk",
+      "type": "SubscribeOk",
+      "hex": "1a0000001000000039300000000000001f000000055045545234",
+      "expected": {
+        "securityId": "12345",
+        "flags": 31,
+        "symbol": "PETR4"
+      }
+    },
+    {
+      "name": "OrderAdded",
+      "type": "OrderAdded",
+      "hex": "290000003000000063000000000000002a000000000000001027000000000000f40100000000000001",
+      "expected": {
+        "securityId": "99",
+        "orderId": "42",
+        "price": 10000,
+        "qty": 500,
+        "side": 1
+      }
+    },
+    {
+      "name": "Trade",
+      "type": "Trade",
+      "hex": "2900000033000000e903000000000000d8d60000000000006400000000000000942600000000000001",
+      "expected": {
+        "securityId": "1001",
+        "price": 55000,
+        "qty": 100,
+        "tradeId": 9876,
+        "flags": 1,
+        "auctionPrint": true
+      }
+    },
+    {
+      "name": "TradeForwardCompatTrailing",
+      "type": "Trade",
+      "hex": "3900000033000000d20700000000000060ea000000000000c800000000000000d2040000000000000000000000000000000000000000000000",
+      "expected": {
+        "securityId": "2002",
+        "price": 60000,
+        "qty": 200,
+        "tradeId": 1234,
+        "flags": 0,
+        "auctionPrint": false
+      }
+    },
+    {
+      "name": "MarketTierUpdate",
+      "type": "MarketTierUpdate",
+      "hex": "1d00000036000000f50100000000000039300000000000000700000000",
+      "expected": {
+        "securityId": "501",
+        "qty": 12345,
+        "count": 7,
+        "side": 0
+      }
+    },
+    {
+      "name": "LevelUpdate",
+      "type": "LevelUpdate",
+      "hex": "25000000370000002a0000000000000087d612000000000094260000000000000200000001",
+      "expected": {
+        "securityId": "42",
+        "price": 1234567,
+        "qty": 9876,
+        "count": 2,
+        "side": 1
+      }
+    },
+    {
+      "name": "LevelDeleted",
+      "type": "LevelDeleted",
+      "hex": "19000000380000006300000000000000fbffffffffffffff00",
+      "expected": {
+        "securityId": "99",
+        "price": -5,
+        "side": 0
+      }
+    },
+    {
+      "name": "ServerStatus",
+      "type": "ServerStatus",
+      "hex": "090000005000000001",
+      "expected": {
+        "ready": true
+      }
+    },
+    {
+      "name": "InfoSnapshot",
+      "type": "InfoSnapshot",
+      "hex": "2c000000210000004d000000000000000d0000001027000000000000e02e0000000000001c25000000000000",
+      "expected": {
+        "securityId": "77",
+        "fields": {
+          "OpeningPrice": 10000,
+          "HighPrice": 12000,
+          "LowPrice": 9500
+        }
+      }
+    },
+    {
+      "name": "ServerHello",
+      "type": "ServerHello",
+      "hex": "1b000000a000000002000000030000000a746573742d6275696c64",
+      "expected": {
+        "protocolVersion": 2,
+        "capabilities": 3,
+        "buildVersion": "test-build"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Migrates the WebSocket messaging protocol to **v2** — a single, deliberate pre-1.0 **breaking change** so that every *future* change can be additive. Downstream clients built against v0.x must upgrade.

## Framing
- **8-byte header** `[u32 length][u16 type][u16 headerFlags]` (was 4-byte `[u16 len][u16 type]`). `length` is `u32` and authoritative; max frame **16 MiB**.
- `headerFlags` reserved (`0`); receivers **reject** unknown header-flag bits.
- `DataFlags` widened to `u32`; `AllKnown` replaces the all-ones `Everything`.
- `SubscribeOk.flags` widened to `u32`; `ClientHello`/`ServerHello` version handshake; little-endian-only runtime guard.

## Layout
- New shared canonical wire lib **`B3.MarketData.Wire`** (single source of truth: constants, enums, framing helper, blittable fixed frames).
- Hot fixed frames laid out **largest-field-first** (`side`/`flags` at the end) → blittable structs; cold/variable frames keep field order.
- Universal **skip-unknown / min-length** rule (length-gated field appends).

## Fixes / hardening
- **Fix latent crash**: `WireFrame.Write` throws on an undersized dest buffer; grew all stale server write buffers to v2 sizes.
- **SDK receive buffer grows on demand** (64 KiB → up to 16 MiB) instead of throwing at 64 KiB, so large *coalesced* batches decode intact.
- SDK `SubscribeFlags` widened `byte` → `uint` to match the `u32` wire.

## Tests / docs
- Committed **cross-language golden vectors** (`tests/golden/`) with JS + C# decode tests; CI now runs `node --test tests/golden/`.
- Rewrote `docs/WEBSOCKET-PROTOCOL.md` / `docs/WEBSOCKET_API.md` for v2 with a normative **Forward-Compatibility Contract** and a **Consuming coalesced messages** section.

## Validation
- **745 tests green** across the solution + **11 JS golden tests**.

> [!WARNING]
> Breaking wire change. Bump `ProtocolVersion` to 2; v0.x SDK consumers must upgrade.