### PR TITLE
fix(sdk): bundle B3.MarketData.Wire into NuGet package

### DIFF
--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -9,7 +9,7 @@
     <PackageId>B3.MarketData.WebSocketClient</PackageId>
     <Version Condition="'$(PackageVersion)' == ''">0.4.0</Version>
     <Authors>pedrosakuma</Authors>
-    <Description>Typed C# subscriber SDK for the B3MarketDataPlatform WebSocket distribution layer (v1: trades, info snapshots, server status). Built-in reconnect with transparent re-subscribe and bounded back-pressure.</Description>
+    <Description>Typed C# subscriber SDK for the B3MarketDataPlatform WebSocket distribution layer (v2 wire protocol: trades, info snapshots, server status). Built-in reconnect with transparent re-subscribe and bounded back-pressure.</Description>
     <PackageTags>b3;marketdata;websocket;sdk;trades;reference-price</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/pedrosakuma/B3MarketDataPlatform</PackageProjectUrl>
@@ -30,9 +30,26 @@
   <ItemGroup>
     <!-- Single canonical wire-protocol definition (neutral protocol assembly).
          Referenced (not the server) so the published SDK stays server-free while
-         both sides share one definition. -->
-    <ProjectReference Include="..\B3.MarketData.Wire\B3.MarketData.Wire.csproj" />
+         both sides share one definition. B3.MarketData.Wire is NOT published as a
+         standalone package, so we bundle its DLL into this package (see the
+         _IncludeWireInPackage target below) and suppress the phantom NuGet
+         dependency with PrivateAssets="all". -->
+    <ProjectReference Include="..\B3.MarketData.Wire\B3.MarketData.Wire.csproj" PrivateAssets="all" />
   </ItemGroup>
+
+  <!-- Bundle the B3.MarketData.Wire build output into lib/ so consumers restore a
+       single self-contained package instead of a missing B3.MarketData.Wire dependency. -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_IncludeWireInPackage</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="_IncludeWireInPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage
+        Include="@(ReferenceCopyLocalPaths)"
+        Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' and '%(Extension)' == '.dll'" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />


### PR DESCRIPTION
## Problem
Published `B3.MarketData.WebSocketClient` **v0.9.0** declares an unresolvable NuGet dependency on `B3.MarketData.Wire` — an internal project introduced by the WS protocol v2 migration that is **never published** to nuget.org. Downstream restore (e.g. `B3TradingPlatform`) fails.

## Fix
- `PrivateAssets="all"` on the `B3.MarketData.Wire` `<ProjectReference>` → suppresses the phantom `<dependency>` in the nuspec.
- `_IncludeWireInPackage` target (via `TargetsForTfmSpecificBuildOutput`) → bundles `B3.MarketData.Wire.dll` into `lib/net10.0/`.

The package is now self-contained.

## Verification (local)
- `.nupkg` `lib/net10.0/` contains **both** `B3.MarketData.WebSocketClient.dll` and `B3.MarketData.Wire.dll`.
- nuspec has **no** `B3.MarketData.Wire` dependency.
- A throwaway consumer project restores, builds, and **runs** against the package (`SubscribeFlags.AllKnown = 255`).

## Follow-up
- After merge: tag **v0.9.1** to republish.
- Consider **unlisting** the broken v0.9.0 on nuget.org.