### PR TITLE
fix(sdk): make Wire bundling compatible with pack --no-build

### DIFF
--- a/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
+++ b/src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj
@@ -43,11 +43,9 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);_IncludeWireInPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
-  <Target Name="_IncludeWireInPackage" DependsOnTargets="ResolveReferences">
+  <Target Name="_IncludeWireInPackage">
     <ItemGroup>
-      <BuildOutputInPackage
-        Include="@(ReferenceCopyLocalPaths)"
-        Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' == 'ProjectReference' and '%(Extension)' == '.dll'" />
+      <BuildOutputInPackage Include="$(OutputPath)B3.MarketData.Wire.dll" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Follow-up to #62. The Wire-bundling target depended on `ResolveReferences`, which made the release workflow's `dotnet pack --no-build` try to rebuild `B3.MarketData.Wire` and fail with **NETSDK1085** (`NoBuild was set to true but the Build target was invoked`) — the v0.9.1 publish run failed there.

Reference the already-built `Wire.dll` from `$(OutputPath)` directly, so no rebuild is triggered during pack.

**Verified:** `dotnet build` then `dotnet pack --no-build` succeeds; `.nupkg` `lib/net10.0/` contains both DLLs, nuspec has no phantom `B3.MarketData.Wire` dependency.