### PR TITLE
CI: publish multi-arch (linux/arm64) images for AKS ARM node pools

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -53,7 +56,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN dotnet tool install --tool-path /tools dotnet-trace \
  && dotnet tool install --tool-path /tools dotnet-gcdump \
  && dotnet tool install --tool-path /tools dotnet-stack
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -16,9 +18,9 @@ COPY Directory.Build.props global.json B3MarketDataPlatform.slnx ./
 COPY schemas/ schemas/
 COPY src/ src/
 
-RUN dotnet restore src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj
+RUN dotnet restore src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj -a $TARGETARCH
 RUN dotnet publish src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj \
-    -c Release -o /app --no-restore
+    -a $TARGETARCH -c Release -o /app --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 


### PR DESCRIPTION
Closes #66

## Changes
- `.github/workflows/docker.yml`: add `docker/setup-qemu-action@v3` and build `platforms: linux/amd64,linux/arm64`.
- `Dockerfile`: `build` stage pinned to `$BUILDPLATFORM` and cross-publishes natively with `dotnet restore/publish -a $TARGETARCH` — avoids emulating the .NET SDK. Kept .NET 10 (repo's actual version).

## Acceptance
- [x] Multi-arch build configured; `docker manifest inspect ghcr.io/pedrosakuma/b3-marketdata:latest` will list **linux/amd64 + linux/arm64** after the first main build.
- [x] PR builds still validate the Dockerfile (`push` gated on non-PR).

Unblocks pedrosakuma/B3Deploy#1 (M3) — ARM64 AKS node pools.