### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
 
@@ -28,7 +28,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,17 +22,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -52,7 +52,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/nuget-unlist.yml
+++ b/.github/workflows/nuget-unlist.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -24,12 +24,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -61,7 +61,7 @@ jobs:
         run: ls -la ./artifacts
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nupkgs
           path: ./artifacts/*.*nupkg

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload BDN artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bdn-artifacts
           path: |


### PR DESCRIPTION
Follow-up to #66 / #67.

The multi-arch build surfaced a deprecation annotation: several actions still declare Node.js 20 and are being force-run on Node 24 (Node 20 is removed from runners in Sep 2026).

## Change
Bump each action to the **minimum major that natively ships on Node 24** (conservative — avoids behavior changes from newer majors):

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-dotnet | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/upload-artifact | v4 | v5 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |

Covers all workflows: ci, docker, nuget, nuget-unlist, perf-smoke.

## Validation
- All workflow YAML re-parsed OK.
- CI on this PR exercises the bumped actions (checkout/setup-dotnet/setup-node + docker build).