### PR TITLE
feat(deploy): publish b3-marketdata as a Helm chart OCI artifact

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,84 @@
+name: Helm chart
+
+# Publishes charts/b3-marketdata as an OCI artifact to GHCR. Gated on a
+# Chart.yaml version bump: on push to main we diff Chart.yaml against the
+# previous commit and only package + push when `version` actually changed,
+# so merging unrelated chart-adjacent changes doesn't cut a spurious release.
+# Manual dispatch can force a (re)publish of the current version, e.g. to
+# backfill after a failed run.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'charts/b3-marketdata/**'
+      - '.github/workflows/helm-chart.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'charts/b3-marketdata/**'
+      - '.github/workflows/helm-chart.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  CHART_DIR: charts/b3-marketdata
+  CHART_NAME: b3-marketdata
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint & template chart
+        run: |
+          helm lint ${{ env.CHART_DIR }}
+          helm template test ${{ env.CHART_DIR }} > /dev/null
+
+      - name: Resolve chart version
+        id: chart
+        run: |
+          version=$(grep -m1 '^version:' ${{ env.CHART_DIR }}/Chart.yaml | awk '{print $2}')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Chart version: $version"
+
+      - name: Check for version bump
+        id: bump
+        if: github.event_name == 'push'
+        run: |
+          prev_version=$(git show HEAD^:${{ env.CHART_DIR }}/Chart.yaml 2>/dev/null | grep -m1 '^version:' | awk '{print $2}' || echo "")
+          echo "Previous version: ${prev_version:-<none>}"
+          if [ "$prev_version" != "${{ steps.chart.outputs.version }}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package chart
+        if: github.event_name == 'workflow_dispatch' || steps.bump.outputs.changed == 'true'
+        run: helm package ${{ env.CHART_DIR }} --destination ./dist
+
+      - name: Log in to GHCR
+        if: (github.event_name == 'workflow_dispatch' || steps.bump.outputs.changed == 'true') && github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        if: (github.event_name == 'workflow_dispatch' || steps.bump.outputs.changed == 'true') && github.event_name != 'pull_request'
+        run: |
+          helm push ./dist/${{ env.CHART_NAME }}-${{ steps.chart.outputs.version }}.tgz \
+            oci://${{ env.REGISTRY }}/pedrosakuma/charts

--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ consumers, the typed SDK is published on NuGet:
 (`dotnet add package B3.MarketData.WebSocketClient`) — see
 [docs/CLIENT-SDK.md](docs/CLIENT-SDK.md).
 
+### Helm chart (Kubernetes)
+
+The [`charts/b3-marketdata`](charts/b3-marketdata) Helm chart packages the
+Deployment, headless Service (UDP unicast ingest + WS fan-out), ConfigMap,
+and NetworkPolicy for the b3-sim deploy topology. It's published as an OCI
+artifact alongside the image:
+
+```bash
+helm install marketdata oci://ghcr.io/pedrosakuma/charts/b3-marketdata --version <chart-version>
+```
+
+See [charts/b3-marketdata/README.md](charts/b3-marketdata/README.md) for the
+values reference and topology notes.
+
 ## B3 schema
 
 This project uses the [B3 Market Data Messages v2.2.0](https://www.b3.com.br/en_us/solutions/platforms/puma-trading-system/for-developers-and-vendors/binary-umdf/)

--- a/charts/b3-marketdata/.helmignore
+++ b/charts/b3-marketdata/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/b3-marketdata/Chart.yaml
+++ b/charts/b3-marketdata/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: b3-marketdata
+description: |
+  UMDF unicast consumer + WebSocket fan-out for the b3-sim deploy topology.
+  Reads matching's unicast UDP (InstrumentDefinition/SnapshotRecovery/Incremental)
+  and fans the book out over WebSocket (8080) to trading-host and browsers.
+type: application
+
+# Chart version (SemVer). Bump this to publish a new chart release — CI only
+# pushes the OCI artifact when this value changes on main (see
+# .github/workflows/helm-chart.yml).
+version: 0.1.0
+
+# appVersion tracks the last b3-marketdata image validated against this chart
+# (see .github/workflows/docker.yml for image tags/digests).
+appVersion: "0.8.0"
+
+home: https://github.com/pedrosakuma/B3MarketDataPlatform
+sources:
+  - https://github.com/pedrosakuma/B3MarketDataPlatform
+keywords:
+  - b3
+  - market-data
+  - umdf
+  - websocket
+maintainers:
+  - name: pedrosakuma
+    url: https://github.com/pedrosakuma

--- a/charts/b3-marketdata/README.md
+++ b/charts/b3-marketdata/README.md
@@ -1,0 +1,50 @@
+# b3-marketdata
+
+Helm chart for the `b3-marketdata` UMDF consumer + WebSocket fan-out service
+(Layer-1 component chart, per the [deploy topology RFC](https://github.com/pedrosakuma/B3Deploy/issues/1)).
+
+`b3deploy` deploys this as `chart@version` + env-specific values; it is not
+meant to be a general-purpose UMDF chart — the network topology assumptions
+(unicast UDP from a `matching` workload, WS consumers such as `trading-host`)
+are specific to the b3-sim reference deployment.
+
+## Install
+
+```console
+helm install marketdata oci://ghcr.io/pedrosakuma/charts/b3-marketdata --version <chart-version>
+```
+
+## Key values
+
+| Key | Description | Default |
+| --- | --- | --- |
+| `image.repository` | Container image | `ghcr.io/pedrosakuma/b3-marketdata` |
+| `image.tag` | Image tag override | `.Chart.AppVersion` |
+| `image.digest` | Pin by digest (`sha256:...`), takes precedence over `tag` | `""` |
+| `wsPort` | WebSocket/health port | `8080` |
+| `udpPorts.*` | UMDF unicast UDP ingest ports | `30084/30085/30184/31084` |
+| `resources` | Pod resource requests/limits | `cpu: 75m`, `memory: 256Mi/512Mi` |
+| `colocation.enabled` | Pod affinity to co-locate with `matching` | `false` |
+| `networkPolicy.enabled` | Emit the marketdata-ingress NetworkPolicy | `true` |
+| `transportConfig` | Raw override for `transport.json`; leave empty to use the built-in EQT layout wired to `udpPorts` | `""` |
+
+See [`values.yaml`](./values.yaml) for the full surface.
+
+## Topology notes
+
+- **No LoadBalancer in the UDP path.** Azure VNets have no IP multicast, so
+  matching sends unicast UDP straight to the pod IP via a headless Service.
+- **`publishNotReadyAddresses: true` is load-bearing.** matching resolves the
+  Service DNS name at startup and aborts if it misses, so the A record must
+  exist before marketdata reports Ready.
+- **NetworkPolicy** admits only `matching` (the 4 UDP ports) and
+  `trading-host` (`:8080` WS). Adjust `networkPolicy.matchingPodSelector` /
+  `tradingHostPodSelector` if those workloads carry different labels in your
+  cluster.
+
+## Versioning contract
+
+Chart `version` is SemVer and released in lockstep with the `b3-marketdata`
+image; `appVersion` tracks the last image version validated against this
+chart. CI (`.github/workflows/helm-chart.yml`) only packages and pushes the
+chart when `Chart.yaml`'s `version` changes on `main`.

--- a/charts/b3-marketdata/templates/NOTES.txt
+++ b/charts/b3-marketdata/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Marketdata deployed as {{ include "b3-marketdata.fullname" . }} (namespace {{ .Release.Namespace }}).
+
+WebSocket fan-out:
+  ws://{{ include "b3-marketdata.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.wsPort }}/ws
+
+UMDF unicast UDP ingest (matching -> marketdata):
+  {{ include "b3-marketdata.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.udpPorts.incrementalA }}/udp   (IncrementalA)
+  {{ include "b3-marketdata.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.udpPorts.incrementalB }}/udp   (IncrementalB)
+  {{ include "b3-marketdata.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.udpPorts.snapshotRecovery }}/udp   (SnapshotRecovery)
+  {{ include "b3-marketdata.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.udpPorts.instrumentDefinition }}/udp   (InstrumentDefinition)
+
+The Service is headless with publishNotReadyAddresses: true — matching resolves
+this DNS name at startup and aborts if it misses, so the A record exists before
+marketdata reports Ready (by design, do not disable).

--- a/charts/b3-marketdata/templates/_helpers.tpl
+++ b/charts/b3-marketdata/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "b3-marketdata.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "b3-marketdata.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "b3-marketdata.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "b3-marketdata.labels" -}}
+helm.sh/chart: {{ include "b3-marketdata.chart" . }}
+{{ include "b3-marketdata.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: b3-sim
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "b3-marketdata.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "b3-marketdata.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Resolve the image reference, preferring digest over tag when both are set.
+*/}}
+{{- define "b3-marketdata.image" -}}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+{{- end }}

--- a/charts/b3-marketdata/templates/configmap.yaml
+++ b/charts/b3-marketdata/templates/configmap.yaml
@@ -1,0 +1,34 @@
+{{/*
+marketdata-transport.json ConfigMap.
+
+Mounted read-only at /app/config/transport.json and selected via
+UMDF_MULTICAST_CONFIG (see templates/deployment.yaml). Default channel
+layout mirrors the validated B3Deploy envs/prod/config/marketdata-transport.json
+(unicast, bind 0.0.0.0 — no IGMP, no multicast group; Azure VNets have no IP
+multicast, see RFC #557).
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "b3-marketdata.fullname" . }}-config
+  labels:
+    {{- include "b3-marketdata.labels" . | nindent 4 }}
+data:
+  transport.json: |
+    {{- if .Values.transportConfig }}
+    {{- .Values.transportConfig | nindent 4 }}
+    {{- else }}
+    {
+      "channelGroups": [
+        {
+          "name": "EQT",
+          "channels": [
+            { "channelId":  84, "type": "IncrementalA",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": {{ .Values.udpPorts.incrementalA }} },
+            { "channelId":  84, "type": "IncrementalB",         "transport": "unicast", "multicastGroup": "0.0.0.0", "port": {{ .Values.udpPorts.incrementalB }} },
+            { "channelId": 184, "type": "InstrumentDefinition", "transport": "unicast", "multicastGroup": "0.0.0.0", "port": {{ .Values.udpPorts.instrumentDefinition }} },
+            { "channelId":  84, "type": "SnapshotRecovery",     "transport": "unicast", "multicastGroup": "0.0.0.0", "port": {{ .Values.udpPorts.snapshotRecovery }} }
+          ]
+        }
+      ]
+    }
+    {{- end }}

--- a/charts/b3-marketdata/templates/deployment.yaml
+++ b/charts/b3-marketdata/templates/deployment.yaml
@@ -1,0 +1,114 @@
+{{/*
+marketdata — UMDF unicast consumer + WebSocket fan-out (Layer-1, RFC #557).
+
+Stateless Deployment. Reads matching's unicast UDP (binds 0.0.0.0, no IGMP
+join — see the ConfigMap, transport=unicast) and fans the book out over WS
+{{ .Values.wsPort }} to trading-host (IReferencePrice) and any browser.
+
+The Service that fronts these pods is the headless Service in service.yaml —
+matching resolves that DNS name to the pod IP. This file only defines the
+workload; the labels here match that selector.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "b3-marketdata.fullname" . }}
+  labels:
+    {{- include "b3-marketdata.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "b3-marketdata.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "b3-marketdata.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: marketdata
+          image: {{ include "b3-marketdata.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: UMDF_WS_PORT
+              value: {{ .Values.wsPort | quote }}
+            - name: UMDF_MULTICAST_CONFIG
+              value: /app/config/transport.json
+          ports:
+            - name: ws
+              containerPort: {{ .Values.wsPort }}
+              protocol: TCP
+            - name: umdf-inc-a
+              containerPort: {{ .Values.udpPorts.incrementalA }}
+              protocol: UDP
+            - name: umdf-inc-b
+              containerPort: {{ .Values.udpPorts.incrementalB }}
+              protocol: UDP
+            - name: umdf-snap
+              containerPort: {{ .Values.udpPorts.snapshotRecovery }}
+              protocol: UDP
+            - name: umdf-instr
+              containerPort: {{ .Values.udpPorts.instrumentDefinition }}
+              protocol: UDP
+          {{- with .Values.readinessProbe }}
+          # Image is distroless (no curl/wget); probe the WS socket directly.
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: transport-config
+              mountPath: /app/config/transport.json
+              subPath: transport.json
+              readOnly: true
+      volumes:
+        - name: transport-config
+          configMap:
+            name: {{ include "b3-marketdata.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or .Values.colocation.enabled .Values.affinity }}
+      affinity:
+        {{- if .Values.affinity }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- else if .Values.colocation.enabled }}
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- toYaml .Values.colocation.matchingSelector | nindent 18 }}
+              topologyKey: {{ .Values.colocation.topologyKey }}
+        {{- end }}
+      {{- end }}

--- a/charts/b3-marketdata/templates/networkpolicy.yaml
+++ b/charts/b3-marketdata/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{/*
+marketdata ingress: admit only matching (UDP ingest) + trading-host (WS
+reference price). Structurally forbids any stray multicast consumer (only
+unicast UDP from matching is allowed). Mirrors B3Deploy
+envs/prod/network-policy.yaml (marketdata-ingress).
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "b3-marketdata.fullname" . }}-ingress
+  labels:
+    {{- include "b3-marketdata.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "b3-marketdata.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            {{- toYaml .Values.networkPolicy.matchingPodSelector | nindent 12 }}
+      ports:
+        - protocol: UDP
+          port: {{ .Values.udpPorts.incrementalA }}
+        - protocol: UDP
+          port: {{ .Values.udpPorts.incrementalB }}
+        - protocol: UDP
+          port: {{ .Values.udpPorts.snapshotRecovery }}
+        - protocol: UDP
+          port: {{ .Values.udpPorts.instrumentDefinition }}
+    - from:
+        - podSelector:
+            {{- toYaml .Values.networkPolicy.tradingHostPodSelector | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.wsPort }}
+{{- end }}

--- a/charts/b3-marketdata/templates/service.yaml
+++ b/charts/b3-marketdata/templates/service.yaml
@@ -1,0 +1,45 @@
+{{/*
+Headless Service for the UMDF unicast UDP pair + WS fan-out (RFC #557).
+
+matching's UnicastUdpPacketSink resolves this DNS name and emits unicast UDP
+straight to the pod IP — a headless Service (clusterIP: None) hands back the
+pod IP with NO load balancer in the UDP path, satisfying the RFC's
+unicast-UDP / no-multicast / no-LB constraint. The same name also serves the
+WebSocket fan-out (trading-host -> ws://<name>:{{ .Values.wsPort }}/ws).
+
+publishNotReadyAddresses: matching resolves this name at startup and aborts
+if DNS doesn't resolve (UnicastUdpPacketSink), so the A record must exist
+before marketdata reports Ready. This flag is load-bearing — do not remove.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "b3-marketdata.fullname" . }}
+  labels:
+    {{- include "b3-marketdata.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "b3-marketdata.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: umdf-inc-a
+      protocol: UDP
+      port: {{ .Values.udpPorts.incrementalA }}
+      targetPort: umdf-inc-a
+    - name: umdf-inc-b
+      protocol: UDP
+      port: {{ .Values.udpPorts.incrementalB }}
+      targetPort: umdf-inc-b
+    - name: umdf-snapshot
+      protocol: UDP
+      port: {{ .Values.udpPorts.snapshotRecovery }}
+      targetPort: umdf-snap
+    - name: umdf-instdef
+      protocol: UDP
+      port: {{ .Values.udpPorts.instrumentDefinition }}
+      targetPort: umdf-instr
+    - name: ws
+      protocol: TCP
+      port: {{ .Values.wsPort }}
+      targetPort: ws

--- a/charts/b3-marketdata/values.yaml
+++ b/charts/b3-marketdata/values.yaml
@@ -1,0 +1,96 @@
+# Default values for the b3-marketdata chart.
+# This is a YAML-formatted file. Declare variables to be passed into templates.
+
+# -- Number of marketdata replicas. The workload is stateless (no local state
+# survives a restart — the book rebuilds from the next SnapshotRecovery), so
+# this can be scaled, but note every replica independently joins the same
+# unicast UDP ports fanned out by matching.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/pedrosakuma/b3-marketdata
+  # -- Overrides the image tag; defaults to .Chart.AppVersion.
+  tag: ""
+  # -- Pins the image by digest (e.g. "sha256:..."). Takes precedence over
+  # `tag` when set — b3deploy pins `chart@version` next to `image@sha256:`.
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- WebSocket / health port (trading-host IReferencePrice + browser clients).
+wsPort: 8080
+
+# -- UMDF unicast UDP ingest ports (matching → marketdata). Keys mirror the
+# channel roles in config/marketdata-transport.json — the ConfigMap below is
+# rendered from these same values so the container ports, Service ports, and
+# transport config never drift apart.
+udpPorts:
+  incrementalA: 30084
+  incrementalB: 30085
+  snapshotRecovery: 30184
+  instrumentDefinition: 31084
+
+resources:
+  requests:
+    cpu: 75m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+readinessProbe:
+  tcpSocket:
+    port: ws
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 6
+
+livenessProbe:
+  tcpSocket:
+    port: ws
+  initialDelaySeconds: 15
+  periodSeconds: 15
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# -- Co-locate marketdata with matching (same node/subnet/AZ) to keep the
+# unicast UDP hop as cheap as possible. Disabled by default; enable and adjust
+# the selector/topologyKey to match the matching workload's labels.
+colocation:
+  enabled: false
+  topologyKey: kubernetes.io/hostname
+  matchingSelector:
+    app.kubernetes.io/name: matching
+
+# -- NetworkPolicy admitting only matching (UDP) and trading-host (WS:8080).
+# See RFC #557 / B3Deploy envs/prod/network-policy.yaml (marketdata-ingress).
+networkPolicy:
+  enabled: true
+  matchingPodSelector:
+    matchLabels:
+      app.kubernetes.io/name: matching
+  tradingHostPodSelector:
+    matchLabels:
+      app.kubernetes.io/name: trading-host
+
+# -- marketdata-transport.json (mounted at /app/config/transport.json,
+# selected via UMDF_MULTICAST_CONFIG). `transport: unicast` skips the IGMP
+# join and binds 0.0.0.0:<port> as a plain UDP socket — Azure VNets have no
+# IP multicast, so unicast straight to the pod IP is the only supported mode
+# in this chart (RFC #557).
+#
+# Leave empty (default) to render the built-in single-channel-group EQT
+# layout wired to `.Values.udpPorts` (see templates/configmap.yaml). Set this
+# to a raw JSON(C) string to override the channel layout entirely without a
+# chart bump.
+transportConfig: ""


### PR DESCRIPTION
Closes #69.

Adds `charts/b3-marketdata` (Layer-1, deploy topology RFC #557), templatizing the validated `B3Deploy@3b4c1d9` `envs/prod/marketdata.yaml` + `marketdata-service.yaml` + `config/marketdata-transport.json`:

- Deployment: WS 8080 + UDP 30084/30085/30184/31084 (UMDF unicast ingest), tcpSocket probes.
- Headless Service (`clusterIP: None`, `publishNotReadyAddresses: true`).
- ConfigMap for `marketdata-transport.json`, values-overridable.
- NetworkPolicy: matching→marketdata UDP, trading-host→marketdata:8080.
- `values.yaml`: image repo/tag/digest, resources, udpPorts, wsPort, colocation toggle.

New `.github/workflows/helm-chart.yml` packages + pushes to `oci://ghcr.io/pedrosakuma/charts/b3-marketdata`, gated on a `Chart.yaml` version bump on `main`; `workflow_dispatch` can force a republish.

Verified locally: `helm lint`, `helm template` (default + colocation/custom-port overrides), `helm package` all succeed.