### PR TITLE
fix(feed): stall escape valve for permanently-wedged incremental channel (#71)

### DIFF
--- a/src/B3.Umdf.Feed/ChannelHandler.cs
+++ b/src/B3.Umdf.Feed/ChannelHandler.cs
@@ -37,12 +37,28 @@ public sealed class ChannelHandler : IDisposable
     /// </summary>
     public const int MaxReorderDistance = 256;
 
+    /// <summary>
+    /// Wall-clock stall escape valve (issue #71): if <see cref="_expectedSeqNum"/>
+    /// has not advanced for this many milliseconds (measured via the
+    /// packet-supplied <see cref="UmdfPacket.ReceivedTimestampTicks"/>, same
+    /// clock source as <c>FeedHandler.InstrDefStuckTimeoutMs</c>) while a
+    /// future packet is pending, the channel force-declares a real gap
+    /// regardless of how small the SeqNum distance is. Bounds how long a
+    /// low-volume channel (few packets/sec) can be wedged waiting for a
+    /// backlog that will never grow past <see cref="MaxReorderDistance"/>.
+    /// Well above realistic A/B feed jitter (single-digit ms) so legitimate
+    /// short-lived reordering is unaffected.
+    /// </summary>
+    public const long ReorderStallTimeoutMs = 2_000;
+
     private readonly IFeedEventHandler _eventHandler;
     private readonly int _maxReorderDistance;
     private readonly Dictionary<uint, UmdfPacket> _reorderBuffer;
     private readonly ILogger _logger;
 
     private uint _expectedSeqNum = 1;
+    private long _expectedSeqNumAdvancedAtTicks;
+    private bool _stallClockStarted;
 
     /// <summary>
     /// Last observed SequenceVersion from the incremental stream PacketHeader.
@@ -123,6 +139,17 @@ public sealed class ChannelHandler : IDisposable
 
         uint seq = header.SequenceNumber;
 
+        // Start the stall-escape clock on the very first packet this
+        // instance ever sees (any channel type/path), so the timeout is
+        // measured relative to real elapsed time rather than an arbitrary
+        // zero baseline (which could otherwise be far in the past relative
+        // to Environment.TickCount64-based timestamps and fire spuriously).
+        if (!_stallClockStarted)
+        {
+            _expectedSeqNumAdvancedAtTicks = packet.ReceivedTimestampTicks;
+            _stallClockStarted = true;
+        }
+
         // Spec §6.5.5.1: SequenceVersion increments on weekly rollover or
         // failover; SequenceNumber resets to 1 in the new version. Detect
         // the version change before any seq comparison so we don't treat
@@ -152,7 +179,7 @@ public sealed class ChannelHandler : IDisposable
                 _duplicatesSkipped++;
                 return GapResult.Duplicate;
             }
-            HandleSequenceVersionChange(version, seq);
+            HandleSequenceVersionChange(version, seq, packet.ReceivedTimestampTicks);
             // Fall through with the post-reset _expectedSeqNum so this
             // packet (the first of the new version) is processed normally.
         }
@@ -168,6 +195,7 @@ public sealed class ChannelHandler : IDisposable
             && seq - _expectedSeqNum > _maxReorderDistance)
         {
             _expectedSeqNum = seq;
+            _expectedSeqNumAdvancedAtTicks = packet.ReceivedTimestampTicks;
         }
 
         // Already past expected — duplicate from the other feed (or already
@@ -188,9 +216,15 @@ public sealed class ChannelHandler : IDisposable
         }
 
         // Future packet. If within the reorder window, stash and wait for the
-        // hole to fill. Otherwise declare a real gap.
+        // hole to fill. Otherwise declare a real gap — either because the
+        // distance exceeds the window, or because (issue #71) the backlog
+        // has been stalled at the same _expectedSeqNum for longer than
+        // ReorderStallTimeoutMs: at low packet volume the distance alone may
+        // never grow past MaxReorderDistance even though the missing SeqNums
+        // are permanently gone (joined mid-stream, or lost on both A and B).
         uint distance = seq - _expectedSeqNum;
-        if (distance > _maxReorderDistance)
+        bool stalled = packet.ReceivedTimestampTicks - _expectedSeqNumAdvancedAtTicks >= ReorderStallTimeoutMs;
+        if (distance > _maxReorderDistance || stalled)
         {
             _gapsDetected++;
             _lastGapExpected = _expectedSeqNum;
@@ -232,6 +266,7 @@ public sealed class ChannelHandler : IDisposable
         MessageDispatcher.Dispatch(in packet, span, _eventHandler);
         _eventHandler.OnPacketProcessed();
         _expectedSeqNum = seq + 1;
+        _expectedSeqNumAdvancedAtTicks = packet.ReceivedTimestampTicks;
 
         if (_reorderBuffer.Count > 0)
         {
@@ -254,6 +289,7 @@ public sealed class ChannelHandler : IDisposable
                     MessageDispatcher.Dispatch(in p, p.Data.Span, _eventHandler);
                     _eventHandler.OnPacketProcessed();
                     _expectedSeqNum = ph.SequenceNumber + 1;
+                    _expectedSeqNumAdvancedAtTicks = p.ReceivedTimestampTicks;
                 }
                 finally
                 {
@@ -275,11 +311,12 @@ public sealed class ChannelHandler : IDisposable
     /// of the new version. Notifies the event handler so per-symbol /
     /// per-instrument state can be reset by upstream managers.
     /// </summary>
-    private void HandleSequenceVersionChange(ushort newVersion, uint firstSeqOfNewVersion)
+    private void HandleSequenceVersionChange(ushort newVersion, uint firstSeqOfNewVersion, long nowTicks)
     {
         DiscardReorderBuffer();
         _currentSequenceVersion = newVersion;
         _expectedSeqNum = firstSeqOfNewVersion;
+        _expectedSeqNumAdvancedAtTicks = nowTicks;
         Interlocked.Increment(ref _sequenceVersionResets);
         try { _eventHandler.OnSequenceVersionChanged(newVersion); }
         catch (Exception ex)
@@ -298,6 +335,7 @@ public sealed class ChannelHandler : IDisposable
     {
         _packetsProcessed++;
         _expectedSeqNum++;
+        _expectedSeqNumAdvancedAtTicks = packet.ReceivedTimestampTicks;
         MessageDispatcher.Dispatch(in packet, span, _eventHandler);
         _eventHandler.OnPacketProcessed();
     }
@@ -311,6 +349,7 @@ public sealed class ChannelHandler : IDisposable
                 _reorderHits++;
                 _packetsProcessed++;
                 _expectedSeqNum++;
+                _expectedSeqNumAdvancedAtTicks = queued.ReceivedTimestampTicks;
                 MessageDispatcher.Dispatch(in queued, queued.Data.Span, _eventHandler);
                 _eventHandler.OnPacketProcessed();
             }

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerColdStartTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerColdStartTests.cs
@@ -1,0 +1,154 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+
+namespace B3.Umdf.Feed.Tests;
+
+/// <summary>
+/// Pins the wall-clock stall escape valve added for issue #71: a *small*
+/// SeqNum gap (well within <see cref="ChannelHandler.MaxReorderDistance"/>)
+/// that never fills — e.g. a marketdata pod cold-starting mid-session after
+/// only a couple of upstream trades, or a genuine double-loss on both A and B
+/// — must not wedge the channel forever waiting for a backlog that will never
+/// grow past the reorder window. Before this fix, low packet-volume channels
+/// (a few packets total) could sit in the reorder buffer indefinitely because
+/// the distance-based gap check alone never tripped.
+/// </summary>
+public class ChannelHandlerColdStartTests
+{
+    [Fact]
+    public void ColdStart_SmallGap_BuffersInitially_NoImmediateGap()
+    {
+        // A brief reorder window is still honored: the very first packet
+        // (small gap vs the seq=1 constructor default) is buffered, not
+        // immediately declared a gap, in case the "missing" earlier packets
+        // are just reordered and arrive moments later.
+        var tracker = new CountingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        var result = ch.HandlePacket(MakePacket(seqNum: 5, ticks: 0));
+
+        Assert.Equal(GapResult.InSequence, result);
+        Assert.Equal(0, tracker.PacketsProcessed);
+        Assert.Equal(1, ch.ReorderBufferDepth);
+    }
+
+    [Fact]
+    public void ColdStart_SmallGap_NeverFills_ForcesGapAfterStallTimeout()
+    {
+        var tracker = new CountingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        // Live channel already at seq=5 when this instance joins (small gap,
+        // well under MaxReorderDistance) — buffered, waiting for seq 1..4
+        // which will never arrive (already gone before we joined).
+        ch.HandlePacket(MakePacket(seqNum: 5, ticks: 0));
+        Assert.Equal(0, tracker.PacketsProcessed);
+
+        // More packets trickle in slowly (low-volume env), each still a
+        // "future" packet relative to the stuck baseline — none large enough
+        // to trip the distance-based gap on their own.
+        ch.HandlePacket(MakePacket(seqNum: 6, ticks: 500));
+        ch.HandlePacket(MakePacket(seqNum: 7, ticks: 1_000));
+        Assert.Equal(0, tracker.PacketsProcessed);
+
+        // Once real elapsed time exceeds ReorderStallTimeoutMs without
+        // _expectedSeqNum advancing, the next packet forces a Gap regardless
+        // of the (still small) distance.
+        var result = ch.HandlePacket(MakePacket(seqNum: 8, ticks: ChannelHandler.ReorderStallTimeoutMs + 1));
+        Assert.Equal(GapResult.Gap, result);
+        Assert.Equal(1, ch.GapsDetected);
+        Assert.Equal(0, tracker.PacketsProcessed); // Gap itself doesn't dispatch; caller does via AcceptGapAndAdvance
+
+        // Caller (FeedHandler) accepts the gap and drains the backlog —
+        // mirrors production behavior on GapResult.Gap. Per the existing
+        // AcceptGapAndAdvance contract (see
+        // AcceptGapAndAdvance_ReleasesBufferedPacketsBelowGap_WithoutDispatch),
+        // only the gap-triggering packet (8) is dispatched; anything buffered
+        // below the new baseline is released without dispatch and healed via
+        // the next per-symbol snapshot instead. The key regression this test
+        // guards against is that the channel un-wedges at all — before this
+        // fix it never got here, and packet 8 (and everything after it)
+        // would have been buffered forever.
+        var gapPacket = MakePacket(seqNum: 8, ticks: ChannelHandler.ReorderStallTimeoutMs + 1);
+        ch.AcceptGapAndAdvance(in gapPacket);
+
+        Assert.Equal(1, tracker.PacketsProcessed);
+        Assert.Equal(0, ch.ReorderBufferDepth);
+        Assert.Equal(9u, ch.ExpectedSequenceNumber);
+    }
+
+    [Fact]
+    public void ColdStart_ExactBaselineMatch_StillWorksNormally()
+    {
+        // First packet == the constructor default (seq=1): in-sequence, no
+        // stall/backlog involved.
+        var tracker = new CountingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        var result = ch.HandlePacket(MakePacket(seqNum: 1, ticks: 0));
+
+        Assert.Equal(GapResult.InSequence, result);
+        Assert.Equal(1, tracker.PacketsProcessed);
+        Assert.Equal(2u, ch.ExpectedSequenceNumber);
+    }
+
+    [Fact]
+    public void ColdStart_LargeGap_StillSeedsBaselineImmediately_PreExistingBehaviorPreserved()
+    {
+        var tracker = new CountingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        uint farFuture = 1u + (uint)ChannelHandler.MaxReorderDistance + 1u;
+        var result = ch.HandlePacket(MakePacket(seqNum: farFuture, ticks: 0));
+
+        Assert.Equal(GapResult.InSequence, result);
+        Assert.Equal(1, tracker.PacketsProcessed);
+        Assert.Equal(0, ch.GapsDetected);
+        Assert.Equal(farFuture + 1, ch.ExpectedSequenceNumber);
+    }
+
+    [Fact]
+    public void SmallReorder_FillsBeforeStallTimeout_DoesNotForceGap()
+    {
+        // Legitimate A/B reordering (missing packet arrives well within the
+        // stall window) must keep working exactly as before — the escape
+        // valve must not fire prematurely.
+        var tracker = new CountingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        ch.HandlePacket(MakePacket(seqNum: 1, ticks: 0));
+        ch.HandlePacket(MakePacket(seqNum: 3, ticks: 10)); // buffered, small gap
+        Assert.Equal(1, tracker.PacketsProcessed);
+
+        ch.HandlePacket(MakePacket(seqNum: 2, ticks: 20)); // fills the hole, well within timeout
+
+        Assert.Equal(3, tracker.PacketsProcessed);
+        Assert.Equal(0, ch.GapsDetected);
+        Assert.Equal(0, ch.ReorderBufferDepth);
+    }
+
+    private static UmdfPacket MakePacket(uint seqNum, long ticks, ushort seqVer = 1)
+    {
+        var buf = new byte[PacketHeader.MESSAGE_SIZE];
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(2), seqVer);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(4), seqNum);
+        return new UmdfPacket
+        {
+            Data = buf,
+            Channel = ChannelType.IncrementalA,
+            ChannelGroup = 0,
+            ReceivedTimestampTicks = ticks,
+        };
+    }
+
+    private sealed class CountingHandler : IFeedEventHandler
+    {
+        public int PacketsProcessed;
+        public void OnPacket(in UmdfPacket packet, ReadOnlySpan<byte> sbePayload, ushort templateId) { }
+        public void OnPacketProcessed() => PacketsProcessed++;
+        public void OnSequenceReset() { }
+        public void OnInstrumentDefinitionsComplete(int instrumentCount) { }
+        public void OnSequenceVersionChanged(ushort newVersion) { }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #71 — the incremental UMDF channel (`IncrementalA`/`IncrementalB`) could get permanently wedged with **zero** packets ever dispatched, despite confirmed upstream trades/orders.

## Root cause
`ChannelHandler` seeds `_expectedSeqNum = 1` at construction. A prior fix (e1bc6be) added a cold-start baseline reseed, but only when the observed gap exceeds `MaxReorderDistance` (256 packets).

In a low-volume environment (e.g. a freshly-deployed session with only a couple of trades so far), a marketdata pod joining/restarting mid-stream sees a **small** gap (e.g. live seq=5 vs the default expected=1). That gap is well under 256, so the reseed never triggers. Every subsequent packet is then treated as a "future" packet relative to the stuck baseline and gets buffered — never dispatched. The channel only self-heals once the backlog distance exceeds 256, which may never happen at low throughput, wedging the channel indefinitely. This matches the reported symptom exactly: `trades: sbe=0 recv=0 emit=0`, `orders: add=0 upd=0 del=0` on the incremental channel while the snapshot/instrument-definition channels work fine.

## Fix
Added a wall-clock stall escape valve to `ChannelHandler`: track how long `_expectedSeqNum` has gone without advancing (using the packet-supplied `ReceivedTimestampTicks`, the same clock source as `FeedHandler.InstrDefStuckTimeoutMs`). If a future packet arrives and the stall exceeds `ReorderStallTimeoutMs` (2s), force a real `Gap` regardless of SeqNum distance, handing off to the existing `AcceptGapAndAdvance` per-symbol-heal path. Legitimate short A/B reordering resolves well within 2s and is unaffected.

## Testing
- Added `ChannelHandlerColdStartTests` covering: small-gap cold start buffering, the new stall escape valve, the pre-existing large-gap immediate seed, exact-baseline-match, and legitimate small reorder (unaffected).
- `dotnet test tests/B3.Umdf.Feed.Tests` — 75/75 passed.
- `dotnet test tests/B3.Umdf.Book.Tests` — 237/237 passed.
- `dotnet test tests/B3.Umdf.ConsoleApp.Tests` — 42/42 passed.
- `dotnet test tests/B3.Umdf.Server.Tests` — 192/192 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>