### PR TITLE
fix(recovery): advance epoch from newer snapshots (#76)

### DIFF
--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -188,7 +188,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
 
     public BookManager(IBookEventHandler? eventHandler = null, ILogger<BookManager>? logger = null,
         SymbolStateRegistry? stateRegistry = null,
-        StaleMboBuffer? staleBuffer = null)
+        StaleMboBuffer? staleBuffer = null,
+        ChannelEpochCoordinator? epochCoordinator = null)
     {
         _eventHandler = eventHandler;
         _logger = logger ?? NullLogger<BookManager>.Instance;
@@ -197,6 +198,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             "SymbolStateRegistry is required.");
         _staleBuffer = staleBuffer ?? throw new ArgumentNullException(nameof(staleBuffer),
             "StaleMboBuffer is required.");
+        _epochCoordinator = epochCoordinator ?? new ChannelEpochCoordinator(_logger);
         // Wire the registry's Mbo state-change callback so OnSymbolStaleStatusChanged
         // surfaces regardless of which kind exposed the global gap (MBO or stat).
         // Last-writer-wins on the registry: if multiple BookManagers shared a registry
@@ -213,12 +215,13 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             _eventHandler,
             _logger,
             ReplayDeferredMbo,
-            () => CurrentSequenceVersion);
+            _epochCoordinator);
     }
 
     private readonly SymbolStateRegistry _stateRegistry;
     private readonly StaleMboBuffer _staleBuffer;
     private readonly SnapshotApplier _snapshotApplier;
+    private readonly ChannelEpochCoordinator _epochCoordinator;
     private long _bufferedMboMessages;
     private long _replayedMboMessages;
     private long _mboStaleTransitions;
@@ -613,12 +616,10 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     /// </summary>
     public void OnSequenceVersionChanged(ushort newVersion)
     {
-        Volatile.Write(ref _currentSequenceVersion, newVersion);
+        _epochCoordinator.SynchronizeFromNotification(newVersion);
         ClearAllBooks();
         ResetPerSymbolEpoch($"SequenceVersionChanged → {newVersion}", SnapshotClearReason.SequenceVersionChanged);
     }
-
-    private int _currentSequenceVersion;
 
     /// <summary>
     /// Last SequenceVersion observed on the incremental stream and propagated
@@ -626,7 +627,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     /// <see cref="SnapshotApplier"/> to gate stale-version snapshots.
     /// 0 means "no version observed yet"; in that case no gating is applied.
     /// </summary>
-    internal ushort CurrentSequenceVersion => (ushort)Volatile.Read(ref _currentSequenceVersion);
+    internal ushort CurrentSequenceVersion => _epochCoordinator.CurrentVersion;
 
     // Feed thread is the sole writer for all book mutations — no locks needed.
     // Callbacks are inline (same thread) so no race condition exists.
@@ -1156,7 +1157,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     public long SnapshotsRejectedTooOld => _snapshotApplier.SnapshotsRejectedTooOld;
     /// <summary>Snapshots ignored at Header_30 because the symbol is already Healthy with a more recent baseline.</summary>
     public long SnapshotsSkippedHealthyAhead => _snapshotApplier.SnapshotsSkippedHealthyAhead;
-    /// <summary>Snapshots silently skipped because their LastSequenceVersion is older than the channel's current SequenceVersion (B3 spec §7.2).</summary>
+    /// <summary>Snapshots skipped because LastSequenceVersion is stale or missing after the channel epoch is established.</summary>
     public long SnapshotsRejectedStaleVersion => _snapshotApplier.SnapshotsRejectedStaleVersion;
     /// <summary>
     /// Pending snapshots overwritten by a new <c>Header_30</c> for the same

--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using B3.Umdf.Feed;
 using B3.Umdf.Mbo.Sbe.V16;
 using Microsoft.Extensions.Logging;
 
@@ -60,7 +61,7 @@ internal sealed class SnapshotApplier
     private readonly IBookEventHandler? _eventHandler;
     private readonly ILogger _logger;
     private readonly Func<ulong, uint, uint, int> _replayDeferredMbo;
-    private readonly Func<ushort> _currentSequenceVersion;
+    private readonly ChannelEpochCoordinator _epochCoordinator;
 
     private readonly Dictionary<ulong, PendingSnapshot> _pendingSnapshots = new();
 
@@ -108,10 +109,9 @@ internal sealed class SnapshotApplier
     /// </summary>
     public long SnapshotsAbortedByEpoch => Volatile.Read(ref _snapshotsAbortedByEpoch);
     /// <summary>
-    /// Snapshots silently skipped because their <c>LastSequenceVersion</c>
-    /// was older than the channel's current SequenceVersion (B3 spec §7.2).
-    /// Chunks for skipped snapshots are absorbed without polluting the
-    /// orphan counter.
+    /// Snapshots skipped because their <c>LastSequenceVersion</c> was older
+    /// than the channel epoch, or missing after an epoch was established.
+    /// Chunks are absorbed without polluting the orphan counter.
     /// </summary>
     public long SnapshotsRejectedStaleVersion => Volatile.Read(ref _snapshotsRejectedStaleVersion);
 
@@ -173,7 +173,7 @@ internal sealed class SnapshotApplier
         IBookEventHandler? eventHandler,
         ILogger logger,
         Func<ulong, uint, uint, int> replayDeferredMbo,
-        Func<ushort>? currentSequenceVersion = null)
+        ChannelEpochCoordinator epochCoordinator)
     {
         _bookStore = bookStore;
         _stateRegistry = stateRegistry;
@@ -181,7 +181,7 @@ internal sealed class SnapshotApplier
         _eventHandler = eventHandler;
         _logger = logger;
         _replayDeferredMbo = replayDeferredMbo;
-        _currentSequenceVersion = currentSequenceVersion ?? (static () => (ushort)0);
+        _epochCoordinator = epochCoordinator;
     }
 
     /// <summary>
@@ -199,9 +199,7 @@ internal sealed class SnapshotApplier
         // snapshot and wait for the updated version to avoid incurring
         // inconsistent state of the internal book." We absorb the chunks
         // silently (Skipped path) so the orphan counter is not polluted.
-        ushort currentVersion = _currentSequenceVersion();
-        if (currentVersion != 0
-            && !IsSnapshotVersionAcceptable(msg.LastSequenceVersion, currentVersion))
+        if (!ObserveSnapshotVersion(msg.LastSequenceVersion))
         {
             ReplacePendingSnapshot(secId, new PendingSnapshot
             {
@@ -392,19 +390,20 @@ internal sealed class SnapshotApplier
     }
 
     /// <summary>
-    /// Spec §7.2 guard, tightened: when the channel has observed a
-    /// SequenceVersion (currentVersion != 0), only snapshots that explicitly
-    /// match that version are processed. Snapshots without
-    /// <c>LastSequenceVersion</c> populated (sentinel null/0) and snapshots from
-    /// a different version are absorbed silently. The previous "snapVer &lt;
-    /// currentVersion" check let in-flight V1 snapshots (which often arrive
-    /// without the field after a rollover) leak through and poison the V2
-    /// baseline with huge V1 rptSeq values, silently dropping subsequent live
-    /// messages until rpt caught up.
+    /// Applies the Binary UMDF §7.2 version rule. Older snapshots are rejected;
+    /// a newer snapshot advances the shared channel epoch before its contents
+    /// are staged, allowing recovery even when the one-shot reset packet was
+    /// lost. Missing versions remain accepted only during initial bootstrap.
     /// </summary>
-    private static bool IsSnapshotVersionAcceptable(ushort? lastSequenceVersion, ushort currentVersion)
+    private bool ObserveSnapshotVersion(ushort? lastSequenceVersion)
     {
-        return lastSequenceVersion is { } v && v != 0 && v == currentVersion;
+        ushort currentVersion = _epochCoordinator.CurrentVersion;
+        if (lastSequenceVersion is not { } version || version == 0)
+            return currentVersion == 0;
+
+        return _epochCoordinator.Observe(version, ChannelEpochSource.Snapshot)
+            is not ChannelEpochObservation.Stale
+            and not ChannelEpochObservation.Invalid;
     }
 
     /// <summary>
@@ -422,6 +421,7 @@ internal sealed class SnapshotApplier
         {
             if (!pending.Skipped && pending.OrdersReceived < pending.OrdersExpected)
                 aborted++;
+            _staleBuffer.ClearProtectedFloor(secId);
         }
         if (aborted > 0)
             Interlocked.Add(ref _snapshotsAbortedByEpoch, aborted);
@@ -567,14 +567,12 @@ internal sealed class SnapshotApplier
 
     /// <summary>
     /// Test helper: mirrors the wire <see cref="OnHeader"/> path, including
-    /// the spec §7.2 stale-version gate. Set <paramref name="lastSequenceVersion"/>
-    /// to null/0 to bypass the version check.
+    /// the spec §7.2 version gate. Null/0 is accepted only before the channel
+    /// has established a non-zero epoch.
     /// </summary>
     internal void OnHeaderForTest(ulong secId, uint lastRptSeq, uint ordersExpected, ushort? lastSequenceVersion)
     {
-        ushort currentVersion = _currentSequenceVersion();
-        if (currentVersion != 0
-            && !IsSnapshotVersionAcceptable(lastSequenceVersion, currentVersion))
+        if (!ObserveSnapshotVersion(lastSequenceVersion))
         {
             ReplacePendingSnapshot(secId, new PendingSnapshot
             {

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -391,6 +391,7 @@ var marketDataManagers = new List<MarketDataManager>();
 var groupHandlers = new List<GroupConflationHandler>();
 var groupFeedHandlers = new Dictionary<int, IFeedEventHandler>();
 var groupMdHandlers = new Dictionary<int, IFeedEventHandler>();
+var epochCoordinators = new Dictionary<int, ChannelEpochCoordinator>();
 
 var bmLogger = loggerFactory.CreateLogger<BookManager>();
 var mdmLogger = loggerFactory.CreateLogger<MarketDataManager>();
@@ -407,6 +408,9 @@ foreach (var gid in groupIds)
 {
     IBookEventHandler bookHandler;
     IMarketDataEventHandler mdHandler = stats;
+    var epochCoordinator = new ChannelEpochCoordinator(
+        loggerFactory.CreateLogger<ChannelEpochCoordinator>());
+    epochCoordinators[gid] = epochCoordinator;
 
     var groupRegistry = new SymbolStateRegistry(registryLogger)
     {
@@ -439,7 +443,8 @@ foreach (var gid in groupIds)
         var gh = subscriptionManager.CreateGroupHandler();
         bookHandler = new CompositeBookEventHandler(stats, gh);
         var bm = new BookManager(bookHandler, bmLogger,
-            stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer);
+            stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer,
+            epochCoordinator: epochCoordinator);
         mdHandler = new CompositeMarketDataEventHandler(stats, gh, bm,
             new RecoveryEventLoggerHandler(recoveryEventLog, gid));
         gh.SetBookManager(bm);
@@ -451,7 +456,8 @@ foreach (var gid in groupIds)
     {
         bookHandler = stats;
         var bm = new BookManager(bookHandler, bmLogger,
-            stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer);
+            stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer,
+            epochCoordinator: epochCoordinator);
         mdHandler = new CompositeMarketDataEventHandler(stats, bm,
             new RecoveryEventLoggerHandler(recoveryEventLog, gid));
         bookManagers.Add(bm);
@@ -486,7 +492,8 @@ if (groupIds.Count > 1 || packetSource is null)
             marketDataHandlers: groupMdHandlers,
             logger: loggerFactory.CreateLogger<MultiFeedManager>(),
             feedChannelCapacity: feedChannelCapacity,
-            groupRingCapacity: groupRingCapacity)
+            groupRingCapacity: groupRingCapacity,
+            epochCoordinators: epochCoordinators)
         : new MultiFeedManager(
             packetSource,
             groupFeedHandlers,
@@ -494,7 +501,8 @@ if (groupIds.Count > 1 || packetSource is null)
             marketDataHandlers: groupMdHandlers,
             logger: loggerFactory.CreateLogger<MultiFeedManager>(),
             feedChannelCapacity: feedChannelCapacity,
-            groupRingCapacity: groupRingCapacity);
+            groupRingCapacity: groupRingCapacity,
+            epochCoordinators: epochCoordinators);
     if (subscriptionManager is not null)
         multiFeed.AnyGroupReady += () => subscriptionManager.SetReady();
     multiFeed.FlushWindowMs = serverFlushWindowMs;
@@ -503,7 +511,12 @@ else
 {
     // Source-driven single-group: replay path. FeedHandler avoids the per-group
     // dispatcher overhead since there's exactly one source feeding one group.
-    singleFeed = new FeedHandler(packetSource, groupFeedHandlers[groupIds[0]], feedLogger, marketDataHandler: groupMdHandlers[groupIds[0]]);
+    singleFeed = new FeedHandler(
+        packetSource,
+        groupFeedHandlers[groupIds[0]],
+        feedLogger,
+        marketDataHandler: groupMdHandlers[groupIds[0]],
+        epochCoordinator: epochCoordinators[groupIds[0]]);
 }
 
 if (subscriptionManager is not null)

--- a/src/B3.Umdf.Feed/ChannelEpochCoordinator.cs
+++ b/src/B3.Umdf.Feed/ChannelEpochCoordinator.cs
@@ -1,0 +1,131 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Feed;
+
+public enum ChannelEpochObservation : byte
+{
+    Invalid = 0,
+    Initialized = 1,
+    Current = 2,
+    Advanced = 3,
+    Stale = 4,
+}
+
+public enum ChannelEpochSource : byte
+{
+    Incremental = 0,
+    Snapshot = 1,
+}
+
+/// <summary>
+/// Channel-scoped source of truth for the active incremental SequenceVersion.
+/// Both incremental packets and snapshot LastSequenceVersion values may advance
+/// the epoch; every real advance resets downstream state exactly once.
+/// </summary>
+public sealed class ChannelEpochCoordinator
+{
+    private readonly object _sync = new();
+    private readonly ILogger _logger;
+    private IFeedEventHandler? _eventHandler;
+    private Action<ushort>? _channelStateReset;
+    private int _currentVersion;
+    private long _epochAdvances;
+    private long _handlerExceptionCount;
+
+    public ChannelEpochCoordinator(ILogger? logger = null)
+    {
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    public ushort CurrentVersion => (ushort)Volatile.Read(ref _currentVersion);
+    public long EpochAdvances => Volatile.Read(ref _epochAdvances);
+    public long HandlerExceptionCount => Volatile.Read(ref _handlerExceptionCount);
+
+    public void RegisterEventHandler(IFeedEventHandler eventHandler)
+    {
+        ArgumentNullException.ThrowIfNull(eventHandler);
+        lock (_sync)
+        {
+            if (_eventHandler is not null && !ReferenceEquals(_eventHandler, eventHandler))
+                throw new InvalidOperationException("An event handler is already registered for this channel epoch coordinator.");
+            _eventHandler = eventHandler;
+        }
+    }
+
+    public void RegisterChannelStateReset(Action<ushort> channelStateReset)
+    {
+        ArgumentNullException.ThrowIfNull(channelStateReset);
+        lock (_sync)
+        {
+            if (_channelStateReset is not null && _channelStateReset != channelStateReset)
+                throw new InvalidOperationException("A channel state reset callback is already registered.");
+            _channelStateReset = channelStateReset;
+        }
+    }
+
+    public ChannelEpochObservation Observe(ushort version, ChannelEpochSource source)
+    {
+        if (version == 0)
+            return ChannelEpochObservation.Invalid;
+
+        Action<ushort>? channelStateReset = null;
+        IFeedEventHandler? eventHandler = null;
+        ChannelEpochObservation result;
+
+        lock (_sync)
+        {
+            ushort current = (ushort)_currentVersion;
+            if (current == 0)
+            {
+                Volatile.Write(ref _currentVersion, version);
+                return ChannelEpochObservation.Initialized;
+            }
+
+            if (version < current)
+                return ChannelEpochObservation.Stale;
+            if (version == current)
+                return ChannelEpochObservation.Current;
+
+            Volatile.Write(ref _currentVersion, version);
+            Interlocked.Increment(ref _epochAdvances);
+            channelStateReset = _channelStateReset;
+            eventHandler = _eventHandler;
+            result = ChannelEpochObservation.Advanced;
+        }
+
+        channelStateReset?.Invoke(version);
+        if (eventHandler is not null)
+        {
+            try
+            {
+                eventHandler.OnSequenceVersionChanged(version);
+            }
+            catch (Exception ex)
+            {
+                Interlocked.Increment(ref _handlerExceptionCount);
+                _logger.LogWarning(ex,
+                    "Downstream handler threw while advancing channel epoch to SequenceVersion={SequenceVersion} from {Source}",
+                    version, source);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Keeps the coordinator synchronized when a downstream handler is invoked
+    /// directly (primarily tests and legacy integration surfaces).
+    /// </summary>
+    public void SynchronizeFromNotification(ushort version)
+    {
+        if (version == 0)
+            return;
+
+        lock (_sync)
+        {
+            if (version > _currentVersion)
+                Volatile.Write(ref _currentVersion, version);
+        }
+    }
+}

--- a/src/B3.Umdf.Feed/ChannelHandler.cs
+++ b/src/B3.Umdf.Feed/ChannelHandler.cs
@@ -54,48 +54,40 @@ public sealed class ChannelHandler : IDisposable
     private readonly IFeedEventHandler _eventHandler;
     private readonly int _maxReorderDistance;
     private readonly Dictionary<uint, UmdfPacket> _reorderBuffer;
-    private readonly ILogger _logger;
+    private readonly ChannelEpochCoordinator _epochCoordinator;
 
     private uint _expectedSeqNum = 1;
     private long _expectedSeqNumAdvancedAtTicks;
     private bool _stallClockStarted;
-
-    /// <summary>
-    /// Last observed SequenceVersion from the incremental stream PacketHeader.
-    /// 0 means "no packet observed yet" (pre-bootstrap). When a packet
-    /// arrives with a different non-zero version, the channel resets
-    /// (B3 spec §6.5.5.1 — weekly rollover or failover).
-    /// </summary>
-    private ushort _currentSequenceVersion;
+    private bool _awaitingFirstPacket;
+    private ushort _awaitingFirstPacketVersion;
 
     private long _packetsProcessed;
     private long _duplicatesSkipped;
     private long _gapsDetected;
     private long _reorderHits;
-    private long _sequenceVersionResets;
-    private long _sequenceResetHandlerExceptionCount;
     private int _maxObservedReorderDepth;
     private volatile uint _lastGapExpected;
     private volatile uint _lastGapReceived;
 
     public uint ExpectedSequenceNumber => _expectedSeqNum;
     /// <summary>Current SequenceVersion observed on this channel; 0 before first packet.</summary>
-    public ushort CurrentSequenceVersion => _currentSequenceVersion;
+    public ushort CurrentSequenceVersion => _epochCoordinator.CurrentVersion;
     public long PacketsProcessed => Volatile.Read(ref _packetsProcessed);
     public long DuplicatesSkipped => Volatile.Read(ref _duplicatesSkipped);
     public long GapsDetected => Volatile.Read(ref _gapsDetected);
     /// <summary>
-    /// Count of channel-wide resets triggered by a SequenceVersion change
-    /// in the PacketHeader (B3 spec §6.5.5.1).
+    /// Count of channel-wide epoch advances observed from either the
+    /// incremental packet header or snapshot LastSequenceVersion.
     /// </summary>
-    public long SequenceVersionResets => Volatile.Read(ref _sequenceVersionResets);
+    public long SequenceVersionResets => _epochCoordinator.EpochAdvances;
     /// <summary>
     /// Number of exceptions thrown by the downstream <see cref="IFeedEventHandler.OnSequenceVersionChanged"/>
     /// callback during a SequenceVersion change. Previously these were silently
     /// swallowed; now we surface a counter and log so a misbehaving handler can
     /// be diagnosed without destabilising the channel.
     /// </summary>
-    public long SequenceResetHandlerExceptionCount => Volatile.Read(ref _sequenceResetHandlerExceptionCount);
+    public long SequenceResetHandlerExceptionCount => _epochCoordinator.HandlerExceptionCount;
     /// <summary>
     /// Count of packets that arrived out-of-order and were later drained from the
     /// reorder buffer (i.e. saved a recovery cycle thanks to A/B arbitration).
@@ -122,13 +114,29 @@ public sealed class ChannelHandler : IDisposable
         : this(eventHandler, maxReorderDistance, NullLogger.Instance) { }
 
     public ChannelHandler(IFeedEventHandler eventHandler, int maxReorderDistance, ILogger logger)
+        : this(eventHandler, maxReorderDistance, logger, new ChannelEpochCoordinator(logger))
+    {
+        _epochCoordinator.RegisterEventHandler(eventHandler);
+    }
+
+    public ChannelHandler(
+        IFeedEventHandler eventHandler,
+        int maxReorderDistance,
+        ILogger logger,
+        ChannelEpochCoordinator epochCoordinator)
     {
         if (maxReorderDistance < 1)
             throw new ArgumentOutOfRangeException(nameof(maxReorderDistance), "Must be ≥ 1.");
         _eventHandler = eventHandler;
         _maxReorderDistance = maxReorderDistance;
         _reorderBuffer = new Dictionary<uint, UmdfPacket>(maxReorderDistance);
-        _logger = logger ?? NullLogger.Instance;
+        _epochCoordinator = epochCoordinator ?? throw new ArgumentNullException(nameof(epochCoordinator));
+        _epochCoordinator.RegisterChannelStateReset(OnEpochAdvanced);
+        if (_epochCoordinator.CurrentVersion != 0)
+        {
+            _awaitingFirstPacket = true;
+            _awaitingFirstPacketVersion = _epochCoordinator.CurrentVersion;
+        }
     }
 
     public GapResult HandlePacket(in UmdfPacket packet)
@@ -150,38 +158,29 @@ public sealed class ChannelHandler : IDisposable
             _stallClockStarted = true;
         }
 
-        // Spec §6.5.5.1: SequenceVersion increments on weekly rollover or
-        // failover; SequenceNumber resets to 1 in the new version. Detect
-        // the version change before any seq comparison so we don't treat
-        // post-rollover seq=1 as a "duplicate" of pre-rollover seq=N.
         ushort version = header.SequenceVersion;
-        if (_currentSequenceVersion == 0)
+        var epochObservation = _epochCoordinator.Observe(version, ChannelEpochSource.Incremental);
+        if (epochObservation == ChannelEpochObservation.Stale)
         {
-            _currentSequenceVersion = version;
+            _duplicatesSkipped++;
+            return GapResult.Duplicate;
         }
-        else if (version != _currentSequenceVersion)
+        if (epochObservation == ChannelEpochObservation.Invalid
+            && _epochCoordinator.CurrentVersion != 0)
         {
-            // Spec §6.5.5.1: SequenceVersion is monotonically increasing per
-            // session. A packet whose version is OLDER than the established
-            // current is a stale reorder-arrival from before the rollover —
-            // upstream (BookManager / SymbolStateRegistry) has already reset
-            // its V1 state. Replaying it would corrupt the V2 epoch. Drop
-            // silently as a duplicate (the other feed delivered the V2
-            // version first).
-            //
-            // ushort comparison would wrap if version actually rolls past
-            // 65535 (impossible in practice — weekly bumps for ~1259 years).
-            // We treat that hypothetical wrap conservatively: only accept
-            // strict-greater within a 16-bit window, which keeps the gate
-            // robust against any single misordered packet.
-            if (version < _currentSequenceVersion)
-            {
-                _duplicatesSkipped++;
-                return GapResult.Duplicate;
-            }
-            HandleSequenceVersionChange(version, seq, packet.ReceivedTimestampTicks);
-            // Fall through with the post-reset _expectedSeqNum so this
-            // packet (the first of the new version) is processed normally.
+            _duplicatesSkipped++;
+            return GapResult.Duplicate;
+        }
+
+        // A snapshot may establish the new epoch before its first incremental
+        // packet arrives. Rebase to that first packet so missing the one-shot
+        // reset packet cannot wedge the reorder buffer.
+        if (_awaitingFirstPacket && _awaitingFirstPacketVersion == version)
+        {
+            _expectedSeqNum = seq;
+            _expectedSeqNumAdvancedAtTicks = packet.ReceivedTimestampTicks;
+            _awaitingFirstPacket = false;
+            _awaitingFirstPacketVersion = 0;
         }
 
         // Cold-start: if the very first packet is far above the initial
@@ -304,31 +303,12 @@ public sealed class ChannelHandler : IDisposable
         DiscardReorderBuffer();
     }
 
-    /// <summary>
-    /// Reset to follow a new SequenceVersion. Discards any reorder-buffered
-    /// packets (they belonged to the previous version's seq space) and
-    /// re-baselines <see cref="_expectedSeqNum"/> to the first observed seq
-    /// of the new version. Notifies the event handler so per-symbol /
-    /// per-instrument state can be reset by upstream managers.
-    /// </summary>
-    private void HandleSequenceVersionChange(ushort newVersion, uint firstSeqOfNewVersion, long nowTicks)
+    private void OnEpochAdvanced(ushort newVersion)
     {
         DiscardReorderBuffer();
-        _currentSequenceVersion = newVersion;
-        _expectedSeqNum = firstSeqOfNewVersion;
-        _expectedSeqNumAdvancedAtTicks = nowTicks;
-        Interlocked.Increment(ref _sequenceVersionResets);
-        try { _eventHandler.OnSequenceVersionChanged(newVersion); }
-        catch (Exception ex)
-        {
-            // Event handler exceptions must not destabilize the channel; counters
-            // still reflect the reset. Track the failure so a misbehaving handler
-            // is observable instead of silently masked.
-            Interlocked.Increment(ref _sequenceResetHandlerExceptionCount);
-            _logger.LogWarning(ex,
-                "Downstream handler threw in OnSequenceVersionChanged(newVersion={NewVersion}); channel state advanced normally",
-                newVersion);
-        }
+        _expectedSeqNum = 1;
+        _awaitingFirstPacket = true;
+        _awaitingFirstPacketVersion = newVersion;
     }
 
     private void ProcessAndAdvance(in UmdfPacket packet, ReadOnlySpan<byte> span)

--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -76,26 +76,41 @@ public sealed class FeedHandler : IDisposable
     /// <summary>TickCount64 (milliseconds since process start) of the last packet processed. 0 if none yet.</summary>
     public long LastPacketTicks => Volatile.Read(ref _lastPacketTicks);
 
-    public FeedHandler(IPacketSource source, IFeedEventHandler eventHandler, ILogger<FeedHandler>? logger = null, IFeedEventHandler? marketDataHandler = null)
+    public FeedHandler(
+        IPacketSource source,
+        IFeedEventHandler eventHandler,
+        ILogger<FeedHandler>? logger = null,
+        IFeedEventHandler? marketDataHandler = null,
+        ChannelEpochCoordinator? epochCoordinator = null)
     {
         _source = source;
         _eventHandler = eventHandler;
         _marketDataHandler = marketDataHandler;
         _logger = logger ?? NullLogger<FeedHandler>.Instance;
-        _incrementalHandler = new ChannelHandler(eventHandler);
+        var coordinator = epochCoordinator ?? new ChannelEpochCoordinator(_logger);
+        coordinator.RegisterEventHandler(eventHandler);
+        _incrementalHandler = new ChannelHandler(
+            eventHandler, ChannelHandler.MaxReorderDistance, _logger, coordinator);
     }
 
     /// <summary>
     /// Creates a FeedHandler for external feeding (no owned source).
     /// Use FeedPacket() to push packets from an external loop.
     /// </summary>
-    public FeedHandler(IFeedEventHandler eventHandler, ILogger<FeedHandler>? logger = null, IFeedEventHandler? marketDataHandler = null)
+    public FeedHandler(
+        IFeedEventHandler eventHandler,
+        ILogger<FeedHandler>? logger = null,
+        IFeedEventHandler? marketDataHandler = null,
+        ChannelEpochCoordinator? epochCoordinator = null)
     {
         _source = null;
         _eventHandler = eventHandler;
         _marketDataHandler = marketDataHandler;
         _logger = logger ?? NullLogger<FeedHandler>.Instance;
-        _incrementalHandler = new ChannelHandler(eventHandler);
+        var coordinator = epochCoordinator ?? new ChannelEpochCoordinator(_logger);
+        coordinator.RegisterEventHandler(eventHandler);
+        _incrementalHandler = new ChannelHandler(
+            eventHandler, ChannelHandler.MaxReorderDistance, _logger, coordinator);
     }
 
     private long _perSymbolGapsAbsorbed;

--- a/src/B3.Umdf.Feed/MultiFeedManager.cs
+++ b/src/B3.Umdf.Feed/MultiFeedManager.cs
@@ -191,21 +191,21 @@ public sealed class MultiFeedManager : IDisposable, IAsyncDisposable
     /// not in <see cref="FeedState.Streaming"/>; pass <c>null</c> if not needed.
     /// </summary>
     /// <param name="feedChannelCapacity">No-op; see single-handler overload.</param>
-    public MultiFeedManager(IPacketSource source, IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger = null, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers = null, ILogger<MultiFeedManager>? logger = null, int feedChannelCapacity = 0, int groupRingCapacity = DefaultGroupRingCapacity)
-        : this(groupHandlers, feedLogger, marketDataHandlers, logger, source, groupRingCapacity)
+    public MultiFeedManager(IPacketSource source, IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger = null, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers = null, ILogger<MultiFeedManager>? logger = null, int feedChannelCapacity = 0, int groupRingCapacity = DefaultGroupRingCapacity, IReadOnlyDictionary<int, ChannelEpochCoordinator>? epochCoordinators = null)
+        : this(groupHandlers, feedLogger, marketDataHandlers, logger, source, groupRingCapacity, epochCoordinators)
     {
         _ = feedChannelCapacity;
     }
 
     /// <summary>Live-push constructor with per-group handlers (no internal dispatcher); see live-push overload above for the push-mode contract.</summary>
     /// <param name="feedChannelCapacity">No-op; see single-handler overload.</param>
-    public MultiFeedManager(IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger = null, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers = null, ILogger<MultiFeedManager>? logger = null, int feedChannelCapacity = 0, int groupRingCapacity = DefaultGroupRingCapacity)
-        : this(groupHandlers, feedLogger, marketDataHandlers, logger, source: null, groupRingCapacity)
+    public MultiFeedManager(IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger = null, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers = null, ILogger<MultiFeedManager>? logger = null, int feedChannelCapacity = 0, int groupRingCapacity = DefaultGroupRingCapacity, IReadOnlyDictionary<int, ChannelEpochCoordinator>? epochCoordinators = null)
+        : this(groupHandlers, feedLogger, marketDataHandlers, logger, source: null, groupRingCapacity, epochCoordinators)
     {
         _ = feedChannelCapacity;
     }
 
-    private MultiFeedManager(IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers, ILogger<MultiFeedManager>? logger, IPacketSource? source, int groupRingCapacity)
+    private MultiFeedManager(IReadOnlyDictionary<int, IFeedEventHandler> groupHandlers, ILogger<FeedHandler>? feedLogger, IReadOnlyDictionary<int, IFeedEventHandler>? marketDataHandlers, ILogger<MultiFeedManager>? logger, IPacketSource? source, int groupRingCapacity, IReadOnlyDictionary<int, ChannelEpochCoordinator>? epochCoordinators)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(groupRingCapacity, 2);
         _source = source;
@@ -216,7 +216,10 @@ public sealed class MultiFeedManager : IDisposable, IAsyncDisposable
         {
             IFeedEventHandler? mdHandler = null;
             marketDataHandlers?.TryGetValue(gid, out mdHandler);
-            _handlers[gid] = new FeedHandler(handler, feedLogger, marketDataHandler: mdHandler);
+            ChannelEpochCoordinator? epochCoordinator = null;
+            epochCoordinators?.TryGetValue(gid, out epochCoordinator);
+            _handlers[gid] = new FeedHandler(
+                handler, feedLogger, marketDataHandler: mdHandler, epochCoordinator: epochCoordinator);
             _rings[gid] = new MpscPacketRing(_ringCapacity);
             _dispatchExceptionCounts[gid] = 0L;
             _lastLoggedDropMilestone[gid] = 0L;

--- a/tests/B3.Umdf.Book.Tests/RecoveryGapScenariosTests.cs
+++ b/tests/B3.Umdf.Book.Tests/RecoveryGapScenariosTests.cs
@@ -12,10 +12,9 @@ namespace B3.Umdf.Book.Tests;
 ///         abandoned chunks and (b) clear the per-symbol StaleMboBuffer protected
 ///         floor, regardless of the replacement path (normal / Healthy-skip /
 ///         stale-version skip).
-///  - #19: when the channel has observed a SequenceVersion, snapshot Header_30
-///         with an absent or mismatched LastSequenceVersion MUST be rejected
-///         (otherwise an in-flight V1 snapshot can poison V2 baseline and
-///         silently drop subsequent live messages until rptSeq catches up).
+///  - #19/#76: after an epoch is established, absent/zero/older snapshot
+///         versions are rejected while a newer authoritative snapshot advances
+///         the shared epoch before it is applied.
 /// </summary>
 public class RecoveryGapScenariosTests
 {
@@ -167,18 +166,64 @@ public class RecoveryGapScenariosTests
     }
 
     [Fact]
-    public void Bug19_AfterVersionChange_FutureLastSequenceVersion_MustBeRejected()
+    public void Bug19_AfterVersionChange_ZeroLastSequenceVersion_MustBeRejected()
     {
         var (bm, reg, _) = CreatePerSymbol();
-        const ulong secId = 556;
+        const ulong secId = 559;
 
         bm.OnSequenceVersionChanged(newVersion: 2);
-        // A snapshot tagged with a FUTURE version (publisher bug or out-of-order
-        // version transition) cannot be trusted against our current epoch.
-        bm.OnSnapshotHeaderForTest(secId, lastRptSeq: 50, ordersExpected: 0, lastSequenceVersion: 3);
+        bm.OnSnapshotHeaderForTest(secId, lastRptSeq: 100, ordersExpected: 0, lastSequenceVersion: 0);
 
         Assert.Equal(SymbolState.Unknown, reg.GetState(secId, SymbolGapKind.Mbo));
         Assert.Equal(1L, bm.SnapshotsRejectedStaleVersion);
+    }
+
+    [Fact]
+    public void Issue76_FutureLastSequenceVersion_AdvancesEpochAndIsAccepted()
+    {
+        var reg = new SymbolStateRegistry(NullLogger.Instance);
+        var buf = new StaleMboBuffer(NullLogger.Instance);
+        var coordinator = new ChannelEpochCoordinator();
+        var bm = new BookManager(
+            stateRegistry: reg,
+            staleBuffer: buf,
+            epochCoordinator: coordinator);
+        coordinator.RegisterEventHandler(bm);
+        const ulong secId = 556;
+
+        bm.OnSequenceVersionChanged(newVersion: 2);
+        bm.OnSnapshotHeaderForTest(secId, lastRptSeq: 50, ordersExpected: 0, lastSequenceVersion: 3);
+
+        Assert.Equal((ushort)3, bm.CurrentSequenceVersion);
+        Assert.Equal(SymbolState.Healthy, reg.GetState(secId, SymbolGapKind.Mbo));
+        Assert.Equal(0L, bm.SnapshotsRejectedStaleVersion);
+        Assert.Equal(1L, bm.SnapshotsHealed);
+    }
+
+    [Fact]
+    public void Issue76_FutureSnapshot_AbortsPreviousEpochStagingBeforeApplying()
+    {
+        var reg = new SymbolStateRegistry(NullLogger.Instance);
+        var buf = new StaleMboBuffer(NullLogger.Instance);
+        var coordinator = new ChannelEpochCoordinator();
+        var bm = new BookManager(
+            stateRegistry: reg,
+            staleBuffer: buf,
+            epochCoordinator: coordinator);
+        coordinator.RegisterEventHandler(bm);
+        const ulong secId = 558;
+
+        bm.OnSequenceVersionChanged(newVersion: 2);
+        bm.OnSnapshotHeaderForTest(secId, lastRptSeq: 100, ordersExpected: 5, lastSequenceVersion: 2);
+        bm.RecordSnapshotChunkForTest(secId, ordersInChunk: 2);
+        Assert.Equal(101u, buf.ProtectedFloorOf(secId));
+
+        bm.OnSnapshotHeaderForTest(secId, lastRptSeq: 7, ordersExpected: 0, lastSequenceVersion: 3);
+
+        Assert.Equal((ushort)3, bm.CurrentSequenceVersion);
+        Assert.Equal(1L, bm.SnapshotsAbortedByEpoch);
+        Assert.Equal(0u, buf.ProtectedFloorOf(secId));
+        Assert.Equal(SymbolState.Healthy, reg.GetState(secId, SymbolGapKind.Mbo));
     }
 
     [Fact]

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceVersionRolloverTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceVersionRolloverTests.cs
@@ -145,6 +145,60 @@ public class ChannelHandlerSequenceVersionRolloverTests
         Assert.Equal(dupesBefore + 1, ch.DuplicatesSkipped);
     }
 
+    [Fact]
+    public void SnapshotDrivenVersionAdvance_DiscardsOldReorderAndRebasesFirstIncremental()
+    {
+        var tracker = new TrackingHandler();
+        var coordinator = new ChannelEpochCoordinator();
+        coordinator.RegisterEventHandler(tracker);
+        var ch = new ChannelHandler(
+            tracker,
+            ChannelHandler.MaxReorderDistance,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance,
+            coordinator);
+
+        ch.HandlePacket(Pkt(seqNum: 1, seqVer: 1));
+        ch.HandlePacket(Pkt(seqNum: 3, seqVer: 1));
+        Assert.Equal(1, ch.ReorderBufferDepth);
+
+        Assert.Equal(
+            ChannelEpochObservation.Advanced,
+            coordinator.Observe(version: 2, ChannelEpochSource.Snapshot));
+
+        Assert.Equal(0, ch.ReorderBufferDepth);
+        Assert.Equal(2, ch.CurrentSequenceVersion);
+        Assert.Equal(1, tracker.SequenceVersionChangedCount);
+
+        long duplicatesBefore = ch.DuplicatesSkipped;
+        Assert.Equal(GapResult.Duplicate, ch.HandlePacket(Pkt(seqNum: 4, seqVer: 1)));
+        Assert.Equal(duplicatesBefore + 1, ch.DuplicatesSkipped);
+
+        // The reset packet (typically seq=1) was missed. The first visible V2
+        // incremental establishes the sequence baseline without a second reset.
+        Assert.Equal(GapResult.InSequence, ch.HandlePacket(Pkt(seqNum: 5, seqVer: 2)));
+        Assert.Equal(6u, ch.ExpectedSequenceNumber);
+        Assert.Equal(1, tracker.SequenceVersionChangedCount);
+        Assert.Equal(1, ch.SequenceVersionResets);
+    }
+
+    [Fact]
+    public void EstablishedEpoch_ZeroVersionPacket_IsDroppedWithoutRebasing()
+    {
+        var tracker = new TrackingHandler();
+        var ch = new ChannelHandler(tracker);
+
+        ch.HandlePacket(Pkt(seqNum: 1, seqVer: 5));
+        ch.HandlePacket(Pkt(seqNum: 2, seqVer: 5));
+        uint expectedBefore = ch.ExpectedSequenceNumber;
+        long duplicatesBefore = ch.DuplicatesSkipped;
+
+        Assert.Equal(GapResult.Duplicate, ch.HandlePacket(Pkt(seqNum: 999_999, seqVer: 0)));
+
+        Assert.Equal(expectedBefore, ch.ExpectedSequenceNumber);
+        Assert.Equal(duplicatesBefore + 1, ch.DuplicatesSkipped);
+        Assert.Equal((ushort)5, ch.CurrentSequenceVersion);
+    }
+
     private sealed class TrackingHandler : IFeedEventHandler
     {
         public int PacketProcessedCount;


### PR DESCRIPTION
## Summary

Fixes #76.

Introduces a channel-scoped epoch coordinator shared by the incremental and snapshot paths, allowing an authoritative snapshot with a newer `LastSequenceVersion` to recover the consumer even when the one-shot UDP reset packet was missed.

## Changes

- make the shared coordinator the source of truth for the active incremental `SequenceVersion`;
- advance the epoch atomically when a newer snapshot version is observed;
- reset book/stat/registry state and discard old snapshot staging and incremental reorder buffers before applying the new snapshot;
- drop delayed incremental packets from older epochs;
- rebase the first incremental observed after snapshot-driven recovery without emitting a duplicate epoch reset;
- continue rejecting stale, null, and zero snapshot versions once an epoch is established;
- wire one coordinator per channel group through single- and multi-feed runtime composition;
- release stale-buffer protected floors when an epoch aborts pending snapshots.

## Coverage

Adds regressions for:

- future snapshot version advancing and healing the book;
- previous-epoch snapshot staging/floors being discarded;
- delayed old-version incrementals being dropped;
- first visible incremental rebasing after a missed reset;
- zero-version packets not corrupting the sequence baseline.
