### PR TITLE
fix(recovery): repair false-healthy books

### DIFF
--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -1159,6 +1159,12 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     public long SnapshotsSkippedHealthyAhead => _snapshotApplier.SnapshotsSkippedHealthyAhead;
     /// <summary>Snapshots skipped because LastSequenceVersion is stale or missing after the channel epoch is established.</summary>
     public long SnapshotsRejectedStaleVersion => _snapshotApplier.SnapshotsRejectedStaleVersion;
+    /// <summary>Healthy snapshots whose authoritative side counts disagreed with the live book.</summary>
+    public long SnapshotsSemanticMismatch => _snapshotApplier.SnapshotsSemanticMismatch;
+    /// <summary>Healthy books atomically repaired after an authoritative side-count disagreement.</summary>
+    public long SnapshotsSemanticRepair => _snapshotApplier.SnapshotsSemanticRepair;
+    /// <summary>Snapshot assemblies rejected because received bid/offer counts contradicted Header_30.</summary>
+    public long SnapshotsRejectedSideCountMismatch => _snapshotApplier.SnapshotsRejectedSideCountMismatch;
     /// <summary>
     /// Pending snapshots overwritten by a new <c>Header_30</c> for the same
     /// instrument before completion (incomplete-then-replaced pattern). See
@@ -1198,6 +1204,14 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     // without forging raw SBE bytes.
     internal void OnSnapshotHeaderForTest(ulong securityId, uint lastRptSeq, uint ordersExpected, ushort? lastSequenceVersion)
         => _snapshotApplier.OnHeaderForTest(securityId, lastRptSeq, ordersExpected, lastSequenceVersion);
+    internal void OnSnapshotHeaderForTest(
+        ulong securityId,
+        uint lastRptSeq,
+        uint expectedBids,
+        uint expectedOffers,
+        ushort? lastSequenceVersion)
+        => _snapshotApplier.OnHeaderForTest(
+            securityId, lastRptSeq, expectedBids, expectedOffers, lastSequenceVersion);
     internal void StageSnapshotEntryForTest(ulong securityId, BookSideType side, ulong orderId, long price, long quantity)
         => _snapshotApplier.StageSnapshotEntryForTest(securityId, side, orderId, price, quantity);
     internal void StageSnapshotMarketOrderForTest(ulong securityId, BookSideType side, ulong orderId, long quantity, uint enteringFirm = 0)

--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -47,8 +47,14 @@ internal sealed class SnapshotApplier
         public uint LastRptSeq;        // 0 if no usable rptSeq baseline
         public uint OrdersExpected;    // TotNumBids + TotNumOffers from Header_30
         public uint OrdersReceived;    // accumulated across Orders_71 chunks
+        public uint BidsExpected;
+        public uint OffersExpected;
+        public uint BidsReceived;
+        public uint OffersReceived;
         public bool HasRptSeq;         // whether LastRptSeq is usable
         public bool Skipped;           // Header_30 saw the symbol Healthy + ahead of snap; chunks must be dropped silently
+        public bool ValidateSideCounts;
+        public bool SemanticRepair;
         public readonly List<OrderBookEntry> StagedBids = new();
         public readonly List<OrderBookEntry> StagedAsks = new();
         public readonly List<MarketOrder> StagedMarketBids = new();
@@ -80,6 +86,9 @@ internal sealed class SnapshotApplier
     private long _snapshotsOrphanChunk;
     private long _snapshotsReplacedHeader;
     private long _snapshotsAborted;
+    private long _snapshotsSemanticMismatch;
+    private long _snapshotsSemanticRepair;
+    private long _snapshotsRejectedSideCountMismatch;
 
     public long SnapshotsHealed => Volatile.Read(ref _snapshotsHealed);
     public long SnapshotsMissingRptSeq => Volatile.Read(ref _snapshotsMissingRptSeq);
@@ -165,6 +174,9 @@ internal sealed class SnapshotApplier
     /// pre-snapshot state until the next snapshot rotation.
     /// </summary>
     public long SnapshotsAborted => Volatile.Read(ref _snapshotsAborted);
+    public long SnapshotsSemanticMismatch => Volatile.Read(ref _snapshotsSemanticMismatch);
+    public long SnapshotsSemanticRepair => Volatile.Read(ref _snapshotsSemanticRepair);
+    public long SnapshotsRejectedSideCountMismatch => Volatile.Read(ref _snapshotsRejectedSideCountMismatch);
 
     public SnapshotApplier(
         BookStore bookStore,
@@ -191,7 +203,9 @@ internal sealed class SnapshotApplier
     {
         ref readonly var msg = ref reader.Data;
         ulong secId = (ulong)msg.SecurityID;
-        uint expected = msg.TotNumBids + msg.TotNumOffers;
+        uint expectedBids = msg.TotNumBids;
+        uint expectedOffers = msg.TotNumOffers;
+        uint expected = expectedBids + expectedOffers;
 
         // Spec §7.2: "If a client encounters a snapshot whose
         // lastSequenceVersion is less than the sequence version coming from
@@ -206,6 +220,9 @@ internal sealed class SnapshotApplier
                 State = SnapshotAssemblyState.Skipped,
                 OrdersExpected = expected,
                 OrdersReceived = 0,
+                BidsExpected = expectedBids,
+                OffersExpected = expectedOffers,
+                ValidateSideCounts = true,
                 Skipped = true,
             });
             Interlocked.Increment(ref _snapshotsRejectedStaleVersion);
@@ -215,7 +232,7 @@ internal sealed class SnapshotApplier
         bool hasRpt = msg.LastRptSeq is { } v && v > 0;
         uint lastRpt = hasRpt ? msg.LastRptSeq!.Value : 0u;
 
-        BeginHeader(secId, lastRpt, hasRpt, expected);
+        BeginHeader(secId, lastRpt, hasRpt, expectedBids, expectedOffers, validateSideCounts: true);
     }
 
     /// <summary>
@@ -223,30 +240,71 @@ internal sealed class SnapshotApplier
     /// the wire-decode path and tests.
     /// </summary>
     public void BeginHeader(ulong secId, uint lastRptSeq, bool hasRptSeq, uint ordersExpected)
+        => BeginHeader(secId, lastRptSeq, hasRptSeq, ordersExpected, 0, validateSideCounts: false);
+
+    private void BeginHeader(
+        ulong secId,
+        uint lastRptSeq,
+        bool hasRptSeq,
+        uint expectedBids,
+        uint expectedOffers,
+        bool validateSideCounts)
     {
         var book = _bookStore.GetOrCreate(secId);
+        uint ordersExpected = expectedBids + expectedOffers;
+        bool semanticRepair = false;
 
-        // GUARD: never apply a snapshot to an already-Healthy symbol. The B3
-        // always-on snapshot stream rotates through every instrument
-        // periodically and does not target our consumer's specific state — its
-        // payload reflects state-as-of some snapshot moment T, which may be
-        // either behind or ahead of where we are. Applying would either
-        // clobber in-flight live messages or leave a hole between our last
-        // applied rptSeq and the snapshot baseline.
         var state = _stateRegistry.GetState(secId, SymbolGapKind.Mbo);
         if (state == SymbolState.Healthy)
         {
-            ReplacePendingSnapshot(secId, new PendingSnapshot
+            int liveBids = book.Bids.OrderCount + book.MarketOrderCount(BookSideType.Bid);
+            int liveOffers = book.Asks.OrderCount + book.MarketOrderCount(BookSideType.Ask);
+            bool countsMatch = !validateSideCounts
+                || ((uint)liveBids == expectedBids && (uint)liveOffers == expectedOffers);
+
+            // Preserve the cheap fast path when the authoritative header agrees
+            // with the live book. If it disagrees, a same/newer-rpt snapshot is
+            // allowed to stage an atomic semantic repair.
+            if (countsMatch || !hasRptSeq || lastRptSeq < book.LastRptSeq)
             {
-                State = SnapshotAssemblyState.Skipped,
-                LastRptSeq = lastRptSeq,
-                OrdersExpected = ordersExpected,
-                OrdersReceived = 0,
-                HasRptSeq = hasRptSeq,
-                Skipped = true,
-            });
-            Interlocked.Increment(ref _snapshotsSkippedHealthyAhead);
-            return;
+                ReplacePendingSnapshot(secId, new PendingSnapshot
+                {
+                    State = SnapshotAssemblyState.Skipped,
+                    LastRptSeq = lastRptSeq,
+                    OrdersExpected = ordersExpected,
+                    OrdersReceived = 0,
+                    BidsExpected = expectedBids,
+                    OffersExpected = expectedOffers,
+                    HasRptSeq = hasRptSeq,
+                    Skipped = true,
+                    ValidateSideCounts = validateSideCounts,
+                });
+                Interlocked.Increment(ref _snapshotsSkippedHealthyAhead);
+                return;
+            }
+
+            // Older snapshots can legitimately describe a different side
+            // composition. Count only actionable disagreements at the current
+            // or a newer rptSeq as semantic mismatches.
+            Interlocked.Increment(ref _snapshotsSemanticMismatch);
+
+            if (!_stateRegistry.BeginSnapshotReconciliation(secId, lastRptSeq))
+            {
+                ReplacePendingSnapshot(secId, new PendingSnapshot
+                {
+                    State = SnapshotAssemblyState.Skipped,
+                    LastRptSeq = lastRptSeq,
+                    OrdersExpected = ordersExpected,
+                    BidsExpected = expectedBids,
+                    OffersExpected = expectedOffers,
+                    HasRptSeq = hasRptSeq,
+                    Skipped = true,
+                    ValidateSideCounts = validateSideCounts,
+                });
+                Interlocked.Increment(ref _snapshotsSkippedHealthyAhead);
+                return;
+            }
+            semanticRepair = true;
         }
 
         // Begin a fresh snapshot for this instrument: stage in a parallel buffer.
@@ -258,7 +316,11 @@ internal sealed class SnapshotApplier
             LastRptSeq = lastRptSeq,
             OrdersExpected = ordersExpected,
             OrdersReceived = 0,
+            BidsExpected = expectedBids,
+            OffersExpected = expectedOffers,
             HasRptSeq = hasRptSeq,
+            ValidateSideCounts = validateSideCounts,
+            SemanticRepair = semanticRepair,
         });
 
         // Floor pin: while this snapshot is in flight (Begin → Orders_71 chunks → End),
@@ -316,6 +378,10 @@ internal sealed class SnapshotApplier
             added++;
             long? rawPrice = entry.MDEntryPx.Mantissa;
             var side = entry.MDEntryType == MDEntryType.BID ? BookSideType.Bid : BookSideType.Ask;
+            if (side == BookSideType.Bid)
+                pending.BidsReceived++;
+            else
+                pending.OffersReceived++;
             long quantity = (long)entry.MDEntrySize;
             ulong orderId = (ulong)entry.SecondaryOrderID;
             uint enteringFirm = entry.EnteringFirm.Value ?? 0;
@@ -355,7 +421,13 @@ internal sealed class SnapshotApplier
 
         pending.OrdersReceived += added;
 
-        if (pending.OrdersReceived >= pending.OrdersExpected)
+        if (HasSideCountOverflow(pending))
+        {
+            RejectSideCountMismatch(securityId);
+            return;
+        }
+
+        if (IsSnapshotComplete(pending))
         {
             var book = _bookStore.GetOrCreate(securityId);
             CompleteSnapshot(securityId, book);
@@ -440,6 +512,13 @@ internal sealed class SnapshotApplier
             return;
         }
 
+        if (pending.ValidateSideCounts && !HasExactSideCounts(pending))
+        {
+            _staleBuffer.ClearProtectedFloor(securityId);
+            Interlocked.Increment(ref _snapshotsRejectedSideCountMismatch);
+            return;
+        }
+
         if (!pending.HasRptSeq)
             CompleteIlliquidSnapshot(securityId, book, pending);
         else
@@ -511,6 +590,8 @@ internal sealed class SnapshotApplier
         if (heal.TransitionedToHealthy)
             Interlocked.Increment(ref _snapshotsHealed);
         Interlocked.Increment(ref _snapshotsCompleted);
+        if (pending.SemanticRepair)
+            Interlocked.Increment(ref _snapshotsSemanticRepair);
         if (pending.OrdersExpected == 0)
             Interlocked.Increment(ref _snapshotsZeroOrder);
 
@@ -563,6 +644,29 @@ internal sealed class SnapshotApplier
             book.MarketOrderCount(side));
     }
 
+    private static bool HasExactSideCounts(PendingSnapshot pending)
+        => pending.BidsReceived == pending.BidsExpected
+            && pending.OffersReceived == pending.OffersExpected;
+
+    private static bool HasSideCountOverflow(PendingSnapshot pending)
+        => pending.ValidateSideCounts
+            && (pending.BidsReceived > pending.BidsExpected
+                || pending.OffersReceived > pending.OffersExpected);
+
+    private static bool IsSnapshotComplete(PendingSnapshot pending)
+        => pending.ValidateSideCounts
+            ? HasExactSideCounts(pending)
+            : pending.OrdersReceived >= pending.OrdersExpected;
+
+    private void RejectSideCountMismatch(ulong securityId)
+    {
+        if (!_pendingSnapshots.Remove(securityId, out _))
+            return;
+        _staleBuffer.ClearProtectedFloor(securityId);
+        Interlocked.Increment(ref _snapshotsRejectedSideCountMismatch);
+        Interlocked.Increment(ref _snapshotsAborted);
+    }
+
     // ── Test helpers ─────────────────────────────────────────────────────────
 
     /// <summary>
@@ -585,6 +689,37 @@ internal sealed class SnapshotApplier
             return;
         }
         BeginHeader(secId, lastRptSeq, lastRptSeq > 0, ordersExpected);
+    }
+
+    internal void OnHeaderForTest(
+        ulong secId,
+        uint lastRptSeq,
+        uint expectedBids,
+        uint expectedOffers,
+        ushort? lastSequenceVersion)
+    {
+        if (!ObserveSnapshotVersion(lastSequenceVersion))
+        {
+            ReplacePendingSnapshot(secId, new PendingSnapshot
+            {
+                State = SnapshotAssemblyState.Skipped,
+                OrdersExpected = expectedBids + expectedOffers,
+                BidsExpected = expectedBids,
+                OffersExpected = expectedOffers,
+                ValidateSideCounts = true,
+                Skipped = true,
+            });
+            Interlocked.Increment(ref _snapshotsRejectedStaleVersion);
+            return;
+        }
+
+        BeginHeader(
+            secId,
+            lastRptSeq,
+            lastRptSeq > 0,
+            expectedBids,
+            expectedOffers,
+            validateSideCounts: true);
     }
 
     /// <summary>
@@ -635,11 +770,22 @@ internal sealed class SnapshotApplier
             Side = side,
         };
         if (side == BookSideType.Bid)
+        {
             pending.StagedBids.Add(entry);
+            if (pending.ValidateSideCounts) pending.BidsReceived++;
+        }
         else
+        {
             pending.StagedAsks.Add(entry);
+            if (pending.ValidateSideCounts) pending.OffersReceived++;
+        }
         pending.OrdersReceived++;
-        if (pending.OrdersReceived >= pending.OrdersExpected)
+        if (HasSideCountOverflow(pending))
+        {
+            RejectSideCountMismatch(securityId);
+            return;
+        }
+        if (IsSnapshotComplete(pending))
         {
             var book = _bookStore.GetOrCreate(securityId);
             CompleteSnapshot(securityId, book);
@@ -659,11 +805,22 @@ internal sealed class SnapshotApplier
             SecurityId = securityId,
         };
         if (side == BookSideType.Bid)
+        {
             pending.StagedMarketBids.Add(order);
+            if (pending.ValidateSideCounts) pending.BidsReceived++;
+        }
         else
+        {
             pending.StagedMarketAsks.Add(order);
+            if (pending.ValidateSideCounts) pending.OffersReceived++;
+        }
         pending.OrdersReceived++;
-        if (pending.OrdersReceived >= pending.OrdersExpected)
+        if (HasSideCountOverflow(pending))
+        {
+            RejectSideCountMismatch(securityId);
+            return;
+        }
+        if (IsSnapshotComplete(pending))
         {
             var book = _bookStore.GetOrCreate(securityId);
             CompleteSnapshot(securityId, book);

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -295,11 +295,12 @@ public sealed class SymbolStateRegistry
     /// </summary>
     private GapInfo DetectAndApplyGlobalGap(SymbolEntry entry, SymbolGapKind triggerKind, uint receivedRptSeq, uint observed)
     {
-        bool globalGap = observed > 0 && receivedRptSeq > observed + 1;
+        const int mboIdx = (int)SymbolGapKind.Mbo;
+        bool hasEstablishedBaseline = observed > 0 || entry.States[mboIdx] == SymbolState.Healthy;
+        bool globalGap = hasEstablishedBaseline && receivedRptSeq > observed + 1;
         if (!globalGap) return default;
 
         uint gapSize = receivedRptSeq - observed - 1;
-        const int mboIdx = (int)SymbolGapKind.Mbo;
         if (entry.States[mboIdx] != SymbolState.Healthy)
             return new GapInfo(true, gapSize, false);
 
@@ -378,6 +379,42 @@ public sealed class SymbolStateRegistry
     private readonly record struct GapInfo(bool GlobalGap, uint Size, bool MboForcedStale);
 
     /// <summary>
+    /// Temporarily moves a Healthy MBO symbol to Stale while an authoritative
+    /// semantic-repair snapshot is assembled. Incrementals arriving during the
+    /// staging window are then buffered and replayed after the atomic swap.
+    /// </summary>
+    public bool BeginSnapshotReconciliation(ulong securityId, uint snapshotRptSeq)
+    {
+        var entry = GetOrAddEntry(securityId);
+        const int mboIdx = (int)SymbolGapKind.Mbo;
+        bool transitioned = false;
+
+        lock (entry.Sync)
+        {
+            if (entry.States[mboIdx] != SymbolState.Healthy)
+                return false;
+
+            uint priorHighWater = entry.LastRptSeq[mboIdx];
+            if (snapshotRptSeq < priorHighWater)
+                return false;
+
+            int prevMask = entry.StaleKindMask;
+            entry.States[mboIdx] = SymbolState.Stale;
+            entry.StaleSinceTicks[mboIdx] = _clock.NowTicks;
+            entry.StaleKindMask |= 1 << mboIdx;
+            if (priorHighWater > entry.MinHealRptSeq[mboIdx])
+                entry.MinHealRptSeq[mboIdx] = priorHighWater;
+            if (prevMask == 0)
+                Interlocked.Increment(ref _staleSymbolCount);
+            transitioned = true;
+        }
+
+        if (transitioned)
+            _onMboStaleStatusChanged?.Invoke(securityId, true);
+        return transitioned;
+    }
+
+    /// <summary>
     /// Outcome of <see cref="HealFromSnapshot"/>.
     /// <see cref="Accepted"/> is false when the snapshot was rejected because its
     /// <see cref="SnapshotRptSeq"/> is older than the symbol's
@@ -425,8 +462,7 @@ public sealed class SymbolStateRegistry
             // or our last good rptSeq before going Stale (mid-session gap). Healing
             // anyway would leave a hole in the book — corrupt state that surfaces
             // as crossed BBOs and ghost orders. Symbol stays in its current state;
-            // caller leaves the snapshot bytes already applied to the book in place
-            // (book state == snapshot state) and continues buffering live
+            // caller discards the staged snapshot and continues buffering live
             // incrementals until a fresher snapshot arrives.
             //
             // Escape valve: if the symbol has been Stale longer than

--- a/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
+++ b/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
@@ -451,6 +451,18 @@ static class MetricsBinder
             () => PerGroupBook(bm => bm.SnapshotsRejectedStaleVersion),
             unit: "{snapshots}", description: "Snapshots rejected because they belong to an older SequenceVersion than the active epoch (post-rollover stragglers)");
 
+        Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_semantic_mismatch",
+            () => PerGroupBook(bm => bm.SnapshotsSemanticMismatch),
+            unit: "{snapshots}", description: "Healthy books whose bid/offer counts disagreed with an authoritative compatible snapshot");
+
+        Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_semantic_repair",
+            () => PerGroupBook(bm => bm.SnapshotsSemanticRepair),
+            unit: "{snapshots}", description: "Healthy books atomically repaired after an authoritative bid/offer count disagreement");
+
+        Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_rejected_side_count_mismatch",
+            () => PerGroupBook(bm => bm.SnapshotsRejectedSideCountMismatch),
+            unit: "{snapshots}", description: "Snapshot assemblies rejected because received bid/offer counts contradicted Header_30");
+
         Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_abandoned",
             () => PerGroupBook(bm => bm.SnapshotsAbandoned),
             unit: "{snapshots}", description: "Snapshots abandoned mid-flight (e.g. truncated before CompleteSnapshot, replaced by a newer snapshot for the same symbol)");

--- a/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
@@ -1,0 +1,226 @@
+using System.Buffers.Binary;
+using B3.Umdf.Book;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+public class Issue75RecoveryTests
+{
+    private static (BookManager BookManager, SymbolStateRegistry Registry) Create()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var buffer = new StaleMboBuffer(NullLogger.Instance);
+        return (new BookManager(stateRegistry: registry, staleBuffer: buffer), registry);
+    }
+
+    [Fact]
+    public void EmptyBaseline_MissingRptSeqOne_DoesNotRemainHealthy_AndSnapshotRestoresBothSides()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7501;
+
+        bookManager.RecordSnapshotHeader(securityId, lastRptSeq: null);
+        bookManager.HealAfterSnapshotForTest(securityId);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        var observed = registry.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 2);
+        Assert.Equal(SymbolState.Stale, observed.NewState);
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Buffer, observed.Action);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 2,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 1, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 2, price: 101, quantity: 20);
+
+        var book = bookManager.Books[securityId];
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, book.Bids.OrderCount);
+        Assert.Equal(1, book.Asks.OrderCount);
+        Assert.Equal(2u, book.LastRptSeq);
+    }
+
+    [Fact]
+    public void HealthyOneSidedBook_CompatibleSnapshotRepairsSemanticMismatch()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7502;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 2, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 10, price: 100, quantity: 10);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(0, bookManager.Books[securityId].Asks.OrderCount);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 2,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 10, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 11, price: 101, quantity: 10);
+
+        var repaired = bookManager.Books[securityId];
+        Assert.Equal(1, repaired.Bids.OrderCount);
+        Assert.Equal(1, repaired.Asks.OrderCount);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticRepair);
+        Assert.Equal(0L, bookManager.SnapshotsSkippedHealthyAhead);
+    }
+
+    [Fact]
+    public void HealthySemanticRepair_BuffersAndReplaysIncrementalArrivingDuringStaging()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var buffer = new StaleMboBuffer(NullLogger.Instance);
+        var bookManager = new BookManager(stateRegistry: registry, staleBuffer: buffer);
+        const ulong securityId = 7505;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 2, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 40, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 2,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        var incremental = EncodeOrder(
+            securityId, orderId: 42, price: 99, quantity: 5, rptSeq: 3);
+        bookManager.OnPacket(
+            in EmptyPacket,
+            incremental,
+            Order_MBO_50Data.MESSAGE_ID);
+        Assert.Equal(1, buffer.DepthOf(securityId));
+        Assert.Equal(1, bookManager.Books[securityId].Bids.OrderCount);
+
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 40, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 41, price: 101, quantity: 10);
+
+        var repaired = bookManager.Books[securityId];
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(2, repaired.Bids.OrderCount);
+        Assert.Equal(1, repaired.Asks.OrderCount);
+        Assert.Equal(3u, repaired.LastRptSeq);
+        Assert.Equal(0, buffer.DepthOf(securityId));
+    }
+
+    [Fact]
+    public void HealthyBook_WithMatchingSideCounts_KeepsFastSkipPath()
+    {
+        var (bookManager, _) = Create();
+        const ulong securityId = 7503;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 20, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 0,
+            lastSequenceVersion: null);
+
+        Assert.Equal(1L, bookManager.SnapshotsSkippedHealthyAhead);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticRepair);
+    }
+
+    [Fact]
+    public void HealthyBook_OlderSnapshotWithDifferentCounts_DoesNotReportSemanticMismatch()
+    {
+        var (bookManager, _) = Create();
+        const ulong securityId = 7506;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 21, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 2,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+
+        Assert.Equal(1L, bookManager.SnapshotsSkippedHealthyAhead);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticRepair);
+    }
+
+    [Fact]
+    public void SnapshotWithCorrectTotalButWrongSideComposition_IsRejected()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7504;
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 5,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 30, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 31, price: 99, quantity: 10);
+
+        Assert.Equal(1L, bookManager.SnapshotsRejectedSideCountMismatch);
+        Assert.Equal(SymbolState.Unknown, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.False(bookManager.Books.TryGetValue(securityId, out var book)
+            && (book.Bids.OrderCount != 0 || book.Asks.OrderCount != 0));
+    }
+
+    private static readonly UmdfPacket EmptyPacket = new()
+    {
+        Data = ReadOnlyMemory<byte>.Empty,
+        Channel = ChannelType.IncrementalA,
+        ChannelGroup = 1,
+        ReceivedTimestampTicks = 0,
+    };
+
+    private static byte[] EncodeOrder(
+        ulong securityId,
+        ulong orderId,
+        long price,
+        long quantity,
+        uint rptSeq)
+    {
+        const int sbeHeaderSize = 8;
+        var buffer = new byte[sbeHeaderSize + Order_MBO_50Data.MESSAGE_SIZE];
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buffer.AsSpan(0), (ushort)Order_MBO_50Data.MESSAGE_SIZE);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buffer.AsSpan(2), Order_MBO_50Data.MESSAGE_ID);
+
+        var body = buffer.AsSpan(sbeHeaderSize);
+        var message = new Order_MBO_50Data
+        {
+            SecurityID = (SecurityID)securityId,
+            MDUpdateAction = MDUpdateAction.NEW,
+            MDEntryType = MDEntryType.BID,
+            MDEntrySize = (Quantity)quantity,
+            SecondaryOrderID = (OrderID)orderId,
+        };
+        message.SetRptSeq(rptSeq);
+        message.TryEncode(body, out _);
+        BinaryPrimitives.WriteInt64LittleEndian(body[12..20], price);
+        return buffer;
+    }
+}

--- a/tests/B3.Umdf.Book.Tests/SymbolStateRegistryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SymbolStateRegistryTests.cs
@@ -5,6 +5,38 @@ namespace B3.Umdf.Book.Tests;
 
 public class SymbolStateRegistryTests
 {
+    [Fact]
+    public void EmptySnapshotBaseline_FirstVisibleRptSeqTwo_ForcesMboStale()
+    {
+        var r = NewRegistry();
+        const ulong securityId = 75;
+
+        r.HealFromSnapshot(securityId, SymbolGapKind.Mbo, snapshotRptSeq: 0);
+
+        var result = r.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 2);
+
+        Assert.Equal(SymbolState.Stale, result.NewState);
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Buffer, result.Action);
+        Assert.True(result.TransitionedToStale);
+        Assert.Equal(1u, result.GapSize);
+        Assert.Equal(SymbolState.Stale, r.GetState(securityId, SymbolGapKind.Mbo));
+    }
+
+    [Fact]
+    public void EmptySnapshotBaseline_FirstVisibleRptSeqOne_RemainsHealthy()
+    {
+        var r = NewRegistry();
+        const ulong securityId = 76;
+
+        r.HealFromSnapshot(securityId, SymbolGapKind.Mbo, snapshotRptSeq: 0);
+
+        var result = r.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 1);
+
+        Assert.Equal(SymbolState.Healthy, result.NewState);
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Apply, result.Action);
+        Assert.False(result.TransitionedToStale);
+    }
+
     private static SymbolStateRegistry NewRegistry() => new(NullLogger.Instance);
 
     // ---- BootstrapPolicy.AcceptFirst (stats) ----


### PR DESCRIPTION
## Summary
- detect a missing first incremental after a valid empty baseline
- reconcile Healthy books when authoritative snapshot side counts disagree, buffering and replaying interleaved incrementals
- validate bid and offer counts independently before atomically applying a snapshot
- expose semantic mismatch, repair, and side-count rejection metrics

## Tests
- `B3.Umdf.Book.Tests` (247)
- `B3.Umdf.ConsoleApp.Tests` (42)
- `B3.Umdf.Server.Tests` (192)

Fixes #75