### PR TITLE
fix(recovery): harden semantic reconciliation after #78

### DIFF
--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -52,7 +52,7 @@ internal sealed class SnapshotApplier
         public uint BidsReceived;
         public uint OffersReceived;
         public bool HasRptSeq;         // whether LastRptSeq is usable
-        public bool Skipped;           // Header_30 saw the symbol Healthy + ahead of snap; chunks must be dropped silently
+        public bool Skipped;           // Snapshot is being absorbed without mutating the live book
         public bool ValidateSideCounts;
         public bool SemanticRepair;
         public readonly List<OrderBookEntry> StagedBids = new();
@@ -252,9 +252,27 @@ internal sealed class SnapshotApplier
     {
         var book = _bookStore.GetOrCreate(secId);
         uint ordersExpected = expectedBids + expectedOffers;
-        bool semanticRepair = false;
+        bool semanticRepair = _stateRegistry.TryGetSemanticReconciliationWatermark(
+            secId,
+            out uint semanticObservedRptSeq);
 
         var state = _stateRegistry.GetState(secId, SymbolGapKind.Mbo);
+        if (state != SymbolState.Healthy
+            && semanticRepair
+            && (!hasRptSeq || lastRptSeq > semanticObservedRptSeq))
+        {
+            AbsorbSnapshot(
+                secId,
+                lastRptSeq,
+                hasRptSeq,
+                expectedBids,
+                expectedOffers,
+                validateSideCounts);
+            if (!hasRptSeq)
+                Interlocked.Increment(ref _snapshotsMissingRptSeq);
+            return;
+        }
+
         if (state == SymbolState.Healthy)
         {
             int liveBids = book.Bids.OrderCount + book.MarketOrderCount(BookSideType.Bid);
@@ -262,46 +280,39 @@ internal sealed class SnapshotApplier
             bool countsMatch = !validateSideCounts
                 || ((uint)liveBids == expectedBids && (uint)liveOffers == expectedOffers);
 
-            // Preserve the cheap fast path when the authoritative header agrees
-            // with the live book. If it disagrees, a same/newer-rpt snapshot is
-            // allowed to stage an atomic semantic repair.
-            if (countsMatch || !hasRptSeq || lastRptSeq < book.LastRptSeq)
+            // Preserve the cheap fast path only when sequence health and the
+            // authoritative per-side counts agree.
+            if (countsMatch)
             {
-                ReplacePendingSnapshot(secId, new PendingSnapshot
-                {
-                    State = SnapshotAssemblyState.Skipped,
-                    LastRptSeq = lastRptSeq,
-                    OrdersExpected = ordersExpected,
-                    OrdersReceived = 0,
-                    BidsExpected = expectedBids,
-                    OffersExpected = expectedOffers,
-                    HasRptSeq = hasRptSeq,
-                    Skipped = true,
-                    ValidateSideCounts = validateSideCounts,
-                });
+                AbsorbSnapshot(
+                    secId,
+                    lastRptSeq,
+                    hasRptSeq,
+                    expectedBids,
+                    expectedOffers,
+                    validateSideCounts);
                 Interlocked.Increment(ref _snapshotsSkippedHealthyAhead);
                 return;
             }
 
-            // Older snapshots can legitimately describe a different side
-            // composition. Count only actionable disagreements at the current
-            // or a newer rptSeq as semantic mismatches.
+            // Sequence continuity does not prove semantic completeness. Count
+            // every authoritative disagreement, even when its watermark cannot
+            // safely repair the current book.
             Interlocked.Increment(ref _snapshotsSemanticMismatch);
 
-            if (!_stateRegistry.BeginSnapshotReconciliation(secId, lastRptSeq))
+            if (!hasRptSeq
+                || lastRptSeq < book.LastRptSeq
+                || !_stateRegistry.BeginSnapshotReconciliation(secId, lastRptSeq))
             {
-                ReplacePendingSnapshot(secId, new PendingSnapshot
-                {
-                    State = SnapshotAssemblyState.Skipped,
-                    LastRptSeq = lastRptSeq,
-                    OrdersExpected = ordersExpected,
-                    BidsExpected = expectedBids,
-                    OffersExpected = expectedOffers,
-                    HasRptSeq = hasRptSeq,
-                    Skipped = true,
-                    ValidateSideCounts = validateSideCounts,
-                });
-                Interlocked.Increment(ref _snapshotsSkippedHealthyAhead);
+                AbsorbSnapshot(
+                    secId,
+                    lastRptSeq,
+                    hasRptSeq,
+                    expectedBids,
+                    expectedOffers,
+                    validateSideCounts);
+                if (!hasRptSeq)
+                    Interlocked.Increment(ref _snapshotsMissingRptSeq);
                 return;
             }
             semanticRepair = true;
@@ -338,6 +349,30 @@ internal sealed class SnapshotApplier
         // Empty book snapshot (no Orders_71 chunks will follow): heal immediately.
         if (ordersExpected == 0)
             CompleteSnapshot(secId, book);
+    }
+
+    private void AbsorbSnapshot(
+        ulong securityId,
+        uint lastRptSeq,
+        bool hasRptSeq,
+        uint expectedBids,
+        uint expectedOffers,
+        bool validateSideCounts)
+    {
+        uint ordersExpected = expectedBids + expectedOffers;
+        ReplacePendingSnapshot(securityId, new PendingSnapshot
+        {
+            State = SnapshotAssemblyState.Skipped,
+            LastRptSeq = lastRptSeq,
+            OrdersExpected = ordersExpected,
+            BidsExpected = expectedBids,
+            OffersExpected = expectedOffers,
+            HasRptSeq = hasRptSeq,
+            Skipped = true,
+            ValidateSideCounts = validateSideCounts,
+        });
+        if (ordersExpected == 0)
+            _pendingSnapshots.Remove(securityId);
     }
 
     /// <summary>
@@ -452,6 +487,8 @@ internal sealed class SnapshotApplier
             {
                 Interlocked.Increment(ref _snapshotsAbandoned);
                 Interlocked.Increment(ref _snapshotsReplacedHeader);
+                if (existing.HasRptSeq)
+                    _stateRegistry.BumpMinHeal(secId, SymbolGapKind.Mbo, existing.LastRptSeq);
             }
             // Always release any protected floor that the predecessor pinned —
             // skipped replacements never call CompleteSnapshot, so without this
@@ -514,8 +551,7 @@ internal sealed class SnapshotApplier
 
         if (pending.ValidateSideCounts && !HasExactSideCounts(pending))
         {
-            _staleBuffer.ClearProtectedFloor(securityId);
-            Interlocked.Increment(ref _snapshotsRejectedSideCountMismatch);
+            RejectSideCountMismatch(securityId, pending);
             return;
         }
 
@@ -660,8 +696,18 @@ internal sealed class SnapshotApplier
 
     private void RejectSideCountMismatch(ulong securityId)
     {
-        if (!_pendingSnapshots.Remove(securityId, out _))
+        if (!_pendingSnapshots.Remove(securityId, out var pending))
             return;
+        RejectSideCountMismatch(securityId, pending);
+    }
+
+    private void RejectSideCountMismatch(ulong securityId, PendingSnapshot pending)
+    {
+        // Messages at-or-below LastRptSeq may have been evicted as covered by
+        // the protected snapshot floor. Once the assembly is rejected, preserve
+        // that coverage requirement in MinHeal before releasing the floor.
+        if (pending.HasRptSeq)
+            _stateRegistry.BumpMinHeal(securityId, SymbolGapKind.Mbo, pending.LastRptSeq);
         _staleBuffer.ClearProtectedFloor(securityId);
         Interlocked.Increment(ref _snapshotsRejectedSideCountMismatch);
         Interlocked.Increment(ref _snapshotsAborted);

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -203,6 +203,7 @@ public sealed class SymbolStateRegistry
         // message. This eliminates false-positive Stales caused by per-kind tracking
         // (where a stat advancing the global counter made the next MBO look like a gap).
         internal uint ObservedRptSeq;
+        internal bool MboSemanticReconciliation;
     }
 
     /// <summary>
@@ -297,7 +298,9 @@ public sealed class SymbolStateRegistry
     {
         const int mboIdx = (int)SymbolGapKind.Mbo;
         bool hasEstablishedBaseline = observed > 0 || entry.States[mboIdx] == SymbolState.Healthy;
-        bool globalGap = hasEstablishedBaseline && receivedRptSeq > observed + 1;
+        bool globalGap = hasEstablishedBaseline
+            && receivedRptSeq > observed
+            && receivedRptSeq - observed > 1;
         if (!globalGap) return default;
 
         uint gapSize = receivedRptSeq - observed - 1;
@@ -395,13 +398,14 @@ public sealed class SymbolStateRegistry
                 return false;
 
             uint priorHighWater = entry.LastRptSeq[mboIdx];
-            if (snapshotRptSeq < priorHighWater)
+            if (snapshotRptSeq < priorHighWater || snapshotRptSeq > entry.ObservedRptSeq)
                 return false;
 
             int prevMask = entry.StaleKindMask;
             entry.States[mboIdx] = SymbolState.Stale;
             entry.StaleSinceTicks[mboIdx] = _clock.NowTicks;
             entry.StaleKindMask |= 1 << mboIdx;
+            entry.MboSemanticReconciliation = true;
             if (priorHighWater > entry.MinHealRptSeq[mboIdx])
                 entry.MinHealRptSeq[mboIdx] = priorHighWater;
             if (prevMask == 0)
@@ -412,6 +416,23 @@ public sealed class SymbolStateRegistry
         if (transitioned)
             _onMboStaleStatusChanged?.Invoke(securityId, true);
         return transitioned;
+    }
+
+    internal bool TryGetSemanticReconciliationWatermark(
+        ulong securityId,
+        out uint observedRptSeq)
+    {
+        if (!_entries.TryGetValue(securityId, out var entry))
+        {
+            observedRptSeq = 0;
+            return false;
+        }
+
+        lock (entry.Sync)
+        {
+            observedRptSeq = entry.ObservedRptSeq;
+            return entry.MboSemanticReconciliation;
+        }
     }
 
     /// <summary>
@@ -559,6 +580,8 @@ public sealed class SymbolStateRegistry
             entry.LastRptSeq[idx] = snapshotRptSeq;
             entry.States[idx] = SymbolState.Healthy;
             entry.MinHealRptSeq[idx] = 0; // baseline restored — no constraint until next stale event
+            if (kind == SymbolGapKind.Mbo)
+                entry.MboSemanticReconciliation = false;
 
             // Bump observed to at least snapshotRptSeq. Snapshots are an authoritative
             // "instrument is at rptSeq=N" signal from the wire (lower bound — live may
@@ -651,6 +674,8 @@ public sealed class SymbolStateRegistry
             entry.LastRptSeq[idx] = anchor;
             entry.States[idx] = SymbolState.Healthy;
             entry.MinHealRptSeq[idx] = 0;
+            if (kind == SymbolGapKind.Mbo)
+                entry.MboSemanticReconciliation = false;
             if (anchor > entry.ObservedRptSeq) entry.ObservedRptSeq = anchor;
 
             bool transitioned = prev != SymbolState.Healthy;
@@ -699,6 +724,7 @@ public sealed class SymbolStateRegistry
                     entry.MinHealRptSeq[i] = 0;
                 }
                 entry.StaleKindMask = 0;
+                entry.MboSemanticReconciliation = false;
                 // Wire counter restarts on a catastrophic reset (SequenceReset_1 /
                 // ChannelReset_11) — clear the observed-rptSeq watermark so the next
                 // message at lower rptSeq doesn't trigger a spurious global gap.
@@ -772,6 +798,8 @@ public sealed class SymbolStateRegistry
             entry.StaleSinceTicks[idx] = 0;
             entry.MinHealRptSeq[idx] = 0;
             entry.StaleKindMask &= ~(1 << idx);
+            if (kind == SymbolGapKind.Mbo)
+                entry.MboSemanticReconciliation = false;
             if (prevMask != 0 && entry.StaleKindMask == 0)
                 Interlocked.Decrement(ref _staleSymbolCount);
             // EmptyBook resets the wire-level rptSeq counter for this instrument

--- a/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
+++ b/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
@@ -453,7 +453,7 @@ static class MetricsBinder
 
         Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_semantic_mismatch",
             () => PerGroupBook(bm => bm.SnapshotsSemanticMismatch),
-            unit: "{snapshots}", description: "Healthy books whose bid/offer counts disagreed with an authoritative compatible snapshot");
+            unit: "{snapshots}", description: "Sequence-healthy books whose bid/offer counts disagreed with an authoritative snapshot header");
 
         Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_semantic_repair",
             () => PerGroupBook(bm => bm.SnapshotsSemanticRepair),
@@ -510,7 +510,7 @@ static class MetricsBinder
 
         Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_skipped_healthy_ahead",
             () => PerGroupBook(bm => bm.SnapshotsSkippedHealthyAhead),
-            unit: "{snapshots}", description: "Snapshots ignored because symbol is already Healthy with a more recent book.LastRptSeq than the snapshot baseline (always-on snapshot stream noise)");
+            unit: "{snapshots}", description: "Snapshots ignored because the symbol is sequence-healthy and authoritative bid/offer counts agree");
 
         Meter.CreateObservableCounter("b3.umdf.persymbol.mbo_buffered",
             () => PerGroupBook(bm => bm.BufferedMboMessages),

--- a/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
@@ -143,7 +143,7 @@ public class Issue75RecoveryTests
     }
 
     [Fact]
-    public void HealthyBook_OlderSnapshotWithDifferentCounts_DoesNotReportSemanticMismatch()
+    public void HealthyBook_OlderSnapshotWithDifferentCounts_IsReportedAndLaterCompatibleSnapshotRepairs()
     {
         var (bookManager, _) = Create();
         const ulong securityId = 7506;
@@ -159,9 +159,263 @@ public class Issue75RecoveryTests
             expectedOffers: 1,
             lastSequenceVersion: null);
 
-        Assert.Equal(1L, bookManager.SnapshotsSkippedHealthyAhead);
-        Assert.Equal(0L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(0L, bookManager.SnapshotsSkippedHealthyAhead);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticMismatch);
         Assert.Equal(0L, bookManager.SnapshotsSemanticRepair);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 21, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 22, price: 101, quantity: 10);
+
+        Assert.Equal(2L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticRepair);
+        Assert.Equal(1, bookManager.Books[securityId].Asks.OrderCount);
+    }
+
+    [Fact]
+    public void HealthyBook_NoRptSemanticMismatch_IsNotClassifiedAsHealthySkip()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7507;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 23, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 0,
+            expectedBids: 0,
+            expectedOffers: 0,
+            lastSequenceVersion: null);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(0L, bookManager.SnapshotsSkippedHealthyAhead);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticRepair);
+        Assert.Equal(1L, bookManager.SnapshotsMissingRptSeq);
+        Assert.Equal(1, bookManager.Books[securityId].Bids.OrderCount);
+    }
+
+    [Fact]
+    public void HealthyBook_FutureSemanticSnapshot_DoesNotAdvancePastObservedWatermark()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7508;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 24, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 4,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(0L, bookManager.SnapshotsSkippedHealthyAhead);
+        Assert.Equal(1L, bookManager.SnapshotsSemanticMismatch);
+        Assert.Equal(0L, bookManager.SnapshotsSemanticRepair);
+
+        var next = registry.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 4);
+        Assert.Equal(SymbolStateRegistry.ObserveAction.Apply, next.Action);
+    }
+
+    [Fact]
+    public void SemanticRepair_FutureReplacementRemainsWatermarkGuarded()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7510;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 27, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 100,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 27, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 28, price: 101, quantity: 10);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(1L, bookManager.SnapshotsSemanticRepair);
+        Assert.Equal(3u, bookManager.Books[securityId].LastRptSeq);
+    }
+
+    [Fact]
+    public void RejectedSemanticRepair_FutureSnapshotRemainsWatermarkGuarded()
+    {
+        var (bookManager, registry) = Create();
+        const ulong securityId = 7511;
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 3, ordersExpected: 1);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 29, price: 100, quantity: 10);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 29, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 30, price: 99, quantity: 10);
+        Assert.Equal(1L, bookManager.SnapshotsRejectedSideCountMismatch);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 100,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 3,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 29, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Ask, orderId: 31, price: 101, quantity: 10);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+        Assert.Equal(1L, bookManager.SnapshotsSemanticRepair);
+        Assert.Equal(3u, bookManager.Books[securityId].LastRptSeq);
+    }
+
+    [Fact]
+    public void SideCountRejection_PreservesProtectedFloorCoverage()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var buffer = new StaleMboBuffer(NullLogger.Instance, perSymbolCap: 2, hotPerSymbolCap: 4);
+        var bookManager = new BookManager(stateRegistry: registry, staleBuffer: buffer);
+        const ulong securityId = 7509;
+
+        registry.HealFromSnapshot(securityId, SymbolGapKind.Mbo, snapshotRptSeq: 10);
+        registry.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 100);
+        foreach (uint rptSeq in new uint[] { 100, 101 })
+            Enqueue(rptSeq);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 105,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        foreach (uint rptSeq in new uint[] { 102, 103, 104, 105, 106, 107 })
+            Enqueue(rptSeq);
+
+        Assert.True(buffer.SafeEvictedBelowFloorCount > 0);
+
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 25, price: 100, quantity: 10);
+        bookManager.StageSnapshotEntryForTest(
+            securityId, BookSideType.Bid, orderId: 26, price: 99, quantity: 10);
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 104, ordersExpected: 0);
+        Assert.Equal(1L, bookManager.SnapshotsRejectedTooOld);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 105, ordersExpected: 0);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        void Enqueue(uint rptSeq)
+        {
+            buffer.Enqueue(
+                securityId,
+                templateId: Order_MBO_50Data.MESSAGE_ID,
+                rptSeq,
+                sendingTimeNs: 0,
+                body: new byte[] { (byte)rptSeq },
+                onEvictedOldest: evicted =>
+                    registry.BumpMinHeal(securityId, SymbolGapKind.Mbo, evicted));
+        }
+    }
+
+    [Fact]
+    public void ReplacedSnapshot_PreservesProtectedFloorCoverage()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var buffer = new StaleMboBuffer(NullLogger.Instance, perSymbolCap: 2, hotPerSymbolCap: 4);
+        var bookManager = new BookManager(stateRegistry: registry, staleBuffer: buffer);
+        const ulong securityId = 7512;
+
+        registry.HealFromSnapshot(securityId, SymbolGapKind.Mbo, snapshotRptSeq: 10);
+        registry.Observe(securityId, SymbolGapKind.Mbo, receivedRptSeq: 100);
+        foreach (uint rptSeq in new uint[] { 100, 101 })
+            Enqueue(rptSeq);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 105,
+            expectedBids: 1,
+            expectedOffers: 1,
+            lastSequenceVersion: null);
+        foreach (uint rptSeq in new uint[] { 102, 103, 104, 105, 106, 107 })
+            Enqueue(rptSeq);
+
+        Assert.True(buffer.SafeEvictedBelowFloorCount > 0);
+
+        bookManager.OnSnapshotHeaderForTest(
+            securityId,
+            lastRptSeq: 104,
+            expectedBids: 0,
+            expectedOffers: 0,
+            lastSequenceVersion: null);
+
+        Assert.Equal(1L, bookManager.SnapshotsAbandoned);
+        Assert.Equal(1L, bookManager.SnapshotsRejectedTooOld);
+        Assert.Equal(SymbolState.Stale, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        bookManager.BeginChunkedSnapshotForTest(securityId, lastRptSeq: 105, ordersExpected: 0);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(securityId, SymbolGapKind.Mbo));
+
+        void Enqueue(uint rptSeq)
+        {
+            buffer.Enqueue(
+                securityId,
+                templateId: Order_MBO_50Data.MESSAGE_ID,
+                rptSeq,
+                sendingTimeNs: 0,
+                body: new byte[] { (byte)rptSeq },
+                onEvictedOldest: evicted =>
+                    registry.BumpMinHeal(securityId, SymbolGapKind.Mbo, evicted));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #78. This branch is rebased onto `main` and contains only incremental semantic-recovery hardening found while comparing the two implementations.

## Net improvements over #78

1. **Semantic disagreement is not a Healthy skip.** Older, no-rpt, and future-watermark headers whose side counts disagree are recorded as semantic mismatches and absorbed without mutating the book; `snapshots_skipped_healthy_ahead` now means sequence health **and** count agreement.
2. **Observed-watermark guard survives reconciliation lifecycle.** Semantic repair cannot advance MBO/trade state beyond `ObservedRptSeq`, including after an in-flight repair is replaced or rejected. Compatible replacements retain semantic-repair accounting and buffered replay.
3. **Protected-floor coverage survives rejection/replacement.** Side-count rejection and incomplete-header replacement advance `MinHeal` to the abandoned snapshot watermark before releasing its protected floor, so safely evicted messages cannot become an unreplayable hole.
4. **Gap arithmetic is overflow-safe.** Global gap detection no longer relies on `observed + 1` wrapping behavior.

## Validation

- Targeted `Issue75RecoveryTests`: 12 passed
- Full suite, run serially: 768 passed, 0 failed
  - Book 253, Server 192, WebSocketClient 85, Feed 77, ConsoleApp 42, Fuzz 36, Transport 33, PcapReplay 28, SBE 16, PerfBaselineCompare 6
- Release solution build: succeeded, 0 warnings / 0 errors
- Changed-file `dotnet format --verify-no-changes`: passed
