### PR TITLE
fix: preserve trade fanout during MBO gap recovery

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -257,6 +257,7 @@ automatically.
 | `b3.umdf.book.active` | Gauge | `group` | Active order books |
 | `b3.umdf.persymbol.snapshots_healed` | Counter | `group` | Per-symbol snapshots accepted and applied |
 | `b3.umdf.persymbol.snapshots_rejected_too_old` | Counter | `group` | Snapshots rejected (snapshot.rptSeq < MinHeal). Sustained growth = recovery loop |
+| `b3.umdf.persymbol.snapshots_rejected_replay_gap` | Counter | `group` | Snapshots rejected because retained MBO plus proven non-MBO sequences leave a replay hole |
 | `b3.umdf.persymbol.snapshots_skipped_healthy_ahead` | Counter | `group` | Snapshots skipped because symbol is already ahead |
 | `b3.umdf.persymbol.snapshots_missing_rptseq` | Counter | `group` | Snapshots missing rptSeq metadata |
 | `b3.umdf.persymbol.channel_gaps_absorbed` | Counter | `group` | Channel-level gaps absorbed via per-symbol heal (no Recovery escalation) |

--- a/docs/RESILIENCE.md
+++ b/docs/RESILIENCE.md
@@ -110,7 +110,9 @@ stateDiagram-v2
     Stale --> Stale: snapshot.Begin<br/>SetProtectedFloor(snap+1)
     Stale --> Stale: hot-cap eviction (safe)<br/>oldest.rptSeq < ProtectedFloor<br/>MinHeal NOT bumped<br/>+stale_buffer_evicted_safe_below_floor
     Stale --> Stale: hot-cap eviction (unsafe)<br/>oldest.rptSeq ≥ ProtectedFloor<br/>MinHeal bumped (fail-safe)<br/>+stale_buffer_evicted_unsafe
+    Stale --> Stale: later global gap<br/>MinHeal := max(MinHeal, received - 1)
     Stale --> Stale: snapshot.Complete REJECT<br/>snap < MinHeal<br/>staging discarded; live book intact<br/>+snapshots_rejected_too_old
+    Stale --> Stale: snapshot.Complete REJECT<br/>post-snapshot replay has uncovered rptSeq<br/>staging discarded; live book intact<br/>+snapshots_rejected_replay_gap
 
     Stale --> Healthy: snapshot.Complete ACCEPT<br/>snap ≥ MinHeal<br/>ApplySnapshotStaging (atomic swap)<br/>replay buffer [snap+1, high-water]<br/>+snapshots_healed<br/>fires OnSymbolStaleStatusChanged(false)<br/>if StaleKindMask = 0
 
@@ -169,7 +171,12 @@ Snapshot arrives → BookManager.CompleteSnapshot
     ├── snapshotRptSeq < MinHeal → REJECT (lagging snapshot, stays Stale,
     │                              counts b3.umdf.persymbol.snapshots_rejected_too_old)
     │
-    └── snapshotRptSeq >= MinHeal → ACCEPT
+    ├── replay window contains an rptSeq that is neither retained MBO nor
+    │   proven delivered non-MBO semantics → REJECT (stays Stale, tightens
+    │   MinHeal to the first missing sequence, counts
+    │   b3.umdf.persymbol.snapshots_rejected_replay_gap)
+    │
+    └── snapshotRptSeq >= MinHeal and replay coverage is complete → ACCEPT
             │
             ▼
         ApplySnapshotStaging → live book swapped
@@ -235,6 +242,7 @@ b3.umdf.feed.channel_gaps_absorbed                  # gaps absorbed without leav
 b3.umdf.persymbol.stale_symbols                     # per-symbol Stale gauge by kind
 b3.umdf.persymbol.snapshots_healed
 b3.umdf.persymbol.snapshots_rejected_too_old        # ALERT if growing monotonically
+b3.umdf.persymbol.snapshots_rejected_replay_gap     # ALERT: retained replay has an uncovered sequence
 b3.umdf.persymbol.stale_buffer_hot_promotions       # symbols at hot cap (65 536)
 b3.umdf.persymbol.stale_buffer_evicted_safe_below_floor
 b3.umdf.persymbol.stale_buffer_evicted_unsafe       # ALERT if growing — pathological loss
@@ -326,12 +334,19 @@ Per-symbol stale buffers (`StaleMboBuffer`) cap at **8 192** messages
 (normal) / **65 536** (hot list — mini-index futures). When the cap is
 hit the buffer drops the **oldest** queued incremental, not the newest:
 keeping the freshest tail maximises the chance that an arriving snapshot
-covers the gap. Each eviction calls
-`SymbolStateRegistry.BumpMinHeal(secId, evictedRptSeq + 1)` so the
+covers the gap. Each unsafe eviction calls
+`SymbolStateRegistry.BumpMinHeal(secId, evictedRptSeq)` so the
 acceptance floor for the next snapshot stays monotonic with the buffer's
 earliest retained sequence — a snapshot older than the bumped floor is
 rejected immediately, with no risk of replaying stale data over a fresher
 book.
+
+While MBO is stale, every delivered non-MBO sequence is retained as compact
+coverage ranges. Before swapping a completed snapshot into the live book,
+the recovery path proves every `rptSeq` in the MBO replay window is either a
+retained MBO mutation or a delivered non-MBO semantic. This permits valid
+interleaving such as MBO 13, Trade 14, ExecSummary 15, MBO 16 while rejecting
+sparse replay that would bridge an unknown book mutation.
 
 ### 2.9 Forced-heal escape valve for hot symbols
 

--- a/docs/RESILIENCE.md
+++ b/docs/RESILIENCE.md
@@ -49,8 +49,10 @@ The consumer enforces this invariant in `SymbolStateRegistry`.
 For each `SecurityID` the registry tracks:
 
 - `ObservedRptSeq` — max `rptSeq` ever seen on **any** kind. Wire-truth.
-- `LastRptSeq[kind]` — last applied `rptSeq` per bucket (one shared `Mbo`
-  bucket; one bucket per stat template — SecurityStatus, PriceBand, etc.).
+- `LastRptSeq[kind]` — last applied `rptSeq` per recovery bucket (`Mbo`
+  plus one bucket per stat template — SecurityStatus, PriceBand, etc.).
+- `LastSemanticRptSeq[Trade]` — exactly-once watermark for irreplaceable
+  trade-family semantics that remain live while MBO awaits a snapshot.
 - `States[kind]` ∈ {Unknown, Healthy, Stale}.
 - `MinHealRptSeq[Mbo]` — lower bound for an acceptable snapshot.
 - `StaleKindMask` — bitmask of kinds currently Stale (drives the symbol-level
@@ -72,10 +74,11 @@ globalGap = ObservedRptSeq > 0 && receivedRptSeq > ObservedRptSeq + 1
 - **No global gap** → per-kind dispatch proceeds: duplicate is dropped,
   forward delivery is applied, and the kind is rebaselined to `received`.
 
-The shared `Mbo` bucket means seven templates (`Order_50`, `DeleteOrder_51`,
-`MassDelete_52`, `Trade_53`, `ForwardTrade_54`, `ExecSummary_55`,
-`TradeBust_57`) share one state — without this, a Trade between two MBOs
-would otherwise expose an artificial per-kind gap.
+The stateful `Mbo` bucket contains `Order_50`, `DeleteOrder_51`, and
+`MassDelete_52`. `Trade_53`, `ForwardTrade_54`, `ExecSummary_55`, and
+`TradeBust_57` use the explicit `Trade` semantic watermark: they still
+participate in the same global gap detection, but their irreplaceable
+downstream effects are delivered once even while MBO is Stale.
 
 ### 2.3 Why global-gap dispatch matters
 
@@ -257,20 +260,23 @@ snapshot rebuilds it.
 
 #### 2.7.2 Per-symbol scope of staleness
 
-The 14 `SymbolGapKind` values are tracked **independently** per
-`(securityId, kind)`. A gap on one kind does not stale the others:
+The 14 `SymbolGapKind` recovery states are tracked per `(securityId, kind)`.
+Their value state is independent, but every template advances the same global
+watermark, so any detected global gap conservatively stales `Mbo`:
 
 | Kind | What it carries (SBE templates) | Affected client surface |
 |---|---|---|
-| `Mbo` | `Order_50`, `DeleteOrder_51`, `MassDelete_52`, `Trade_53`, `ForwardTrade_54`, `ExecutionSummary_55`, `TradeBust_57` | Order book + Trades tape + Chart (candles derive from trades) |
+| `Mbo` | `Order_50`, `DeleteOrder_51`, `MassDelete_52` | Order book |
+| `Trade` semantic watermark | `Trade_53`, `ForwardTrade_54`, `ExecutionSummary_55`, `TradeBust_57` | Trades tape + Chart + execution/bust event fanout |
 | `SecurityStatus` | `tpl 3` | Auction/halt banner, trading-phase indicators |
 | `OpeningPrice` / `ClosingPrice` / `LastTradePrice` / `HighPrice` / `LowPrice` / `SettlementPrice` / `TheoreticalOpeningPrice` / `OpenInterest` / `AuctionImbalance` / `PriceBand` / `QuantityBand` / `ExecutionStatistics` | individual stat templates | Subscriptions-table columns (Info side) |
 
-Trades and the order book share the `Mbo` bucket because the wire mixes
-them under the same `rptSeq` stream — losing one byte of incremental
-traffic invalidates both consistently. Stat fields are independent
-streams: e.g. an `OpeningPrice` gap leaves the book and trades fully
-live; only that single field freezes until live-resync or snapshot.
+All templates share one per-security `ObservedRptSeq`. Any gap therefore
+conservatively invalidates MBO, regardless of which template exposes it.
+Trade, forward-trade, and execution-summary payloads are self-contained;
+trade bust is a best-effort correction against retained trade state. All four
+are irreplaceable semantic events, so they continue exactly-once fanout while
+only stateful MBO mutations wait for snapshot recovery.
 
 #### 2.7.3 Per-symbol behavior while a kind is Stale
 

--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -254,13 +254,16 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     /// <summary>
     /// Updates the book's global per-symbol
     /// <see cref="OrderBook.LastRptSeq"/>. Called from every MBO/Trade
-    /// handler instead of writing <c>LastRptSeq</c> directly.
+    /// handler instead of writing <c>LastRptSeq</c> directly. The published
+    /// watermark is monotonic so delayed semantic messages cannot regress a
+    /// snapshot or later global sequence baseline.
     /// The registry is the source of truth, so we skip the shadow tracker
     /// (which would double-count gaps).
     /// </summary>
     private void TrackMboRptSeq(OrderBook book, uint received)
     {
-        book.LastRptSeq = received;
+        if (received > book.LastRptSeq)
+            book.LastRptSeq = received;
     }
 
     /// <summary>

--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -1164,6 +1164,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     public long SnapshotChunksOrphaned => _snapshotApplier.SnapshotChunksOrphaned;
     /// <summary>Snapshots rejected because their LastRptSeq is older than the symbol's MinHealRptSeq.</summary>
     public long SnapshotsRejectedTooOld => _snapshotApplier.SnapshotsRejectedTooOld;
+    /// <summary>Snapshots rejected because retained MBO replay plus proven non-MBO coverage contained a hole.</summary>
+    public long SnapshotsRejectedReplayGap => _snapshotApplier.SnapshotsRejectedReplayGap;
     /// <summary>Snapshots ignored at Header_30 because the symbol is already Healthy with a more recent baseline.</summary>
     public long SnapshotsSkippedHealthyAhead => _snapshotApplier.SnapshotsSkippedHealthyAhead;
     /// <summary>Snapshots skipped because LastSequenceVersion is stale or missing after the channel epoch is established.</summary>

--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -113,7 +113,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     public long TradesFilteredNonReportable => Volatile.Read(ref _tradesFilteredNonReportable);
     /// <summary>Number of Trade_53 SBE messages observed by HandleTrade entry (pre-routing/filter).</summary>
     public long TradeSbeEntries => Volatile.Read(ref _tradeSbeEntries);
-    /// <summary>Trade_53 messages rejected by RouteMbo (gap/stale path).</summary>
+    /// <summary>Trade_53 messages rejected as duplicate or reordered semantics.</summary>
     public long TradeRouteRejected => Volatile.Read(ref _tradeRouteRejected);
     /// <summary>ExecutionSummary_55 SBE messages observed by HandleExecutionSummary entry (pre-routing).</summary>
     public long ExecutionSummaryEntries => Volatile.Read(ref _executionSummaryEntries);
@@ -252,7 +252,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     public SymbolGapTracker GapTracker { get; }
 
     /// <summary>
-    /// Records the per-symbol rptSeq gap (if any) and updates the book's
+    /// Updates the book's global per-symbol
     /// <see cref="OrderBook.LastRptSeq"/>. Called from every MBO/Trade
     /// handler instead of writing <c>LastRptSeq</c> directly.
     /// The registry is the source of truth, so we skip the shadow tracker
@@ -264,7 +264,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     }
 
     /// <summary>
-    /// Per-symbol routing decision for an incoming MBO/Trade message.
+    /// Per-symbol routing decision for an incoming stateful MBO mutation.
     /// Consults the registry: Apply lets the caller proceed; Buffer copies
     /// the body into <see cref="_staleBuffer"/> for later replay; Drop
     /// returns silently.
@@ -274,26 +274,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
     {
         if (rptSeqOpt is not { } rptSeq || rptSeq == 0) return true; // can't gap-track without rptSeq
         var result = _stateRegistry.Observe(securityId, SymbolGapKind.Mbo, rptSeq);
-        if (result.TransitionedToStale)
-        {
-            Interlocked.Increment(ref _mboStaleTransitions);
-            long gap = (long)result.GapSize;
-            Interlocked.Add(ref _mboStaleGapSizeSum, gap);
-            // Lock-free max update.
-            long currentMax;
-            do
-            {
-                currentMax = Volatile.Read(ref _mboStaleGapSizeMax);
-                if (gap <= currentMax) break;
-            } while (Interlocked.CompareExchange(ref _mboStaleGapSizeMax, gap, currentMax) != currentMax);
-            if (_logger.IsEnabled(LogLevel.Debug))
-                _logger.LogDebug(
-                    "PerSymbol Healthy→Stale secId={SecurityId} templateId={TemplateId} rptSeq={RptSeq} gap={Gap}",
-                    securityId, templateId, rptSeq, gap);
-            // Note: OnSymbolStaleStatusChanged is fired from the SymbolStateRegistry
-            // callback (wired in BookManager's constructor), so it surfaces regardless
-            // of which kind triggered the global gap (MBO or stat).
-        }
+        RecordMboStaleTransition(
+            securityId, templateId, rptSeq, result.TransitionedToStale, result.GapSize);
         switch (result.Action)
         {
             case SymbolStateRegistry.ObserveAction.Apply:
@@ -319,6 +301,49 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Routes trade-family semantics independently from MBO recovery. The shared
+    /// global watermark still detects loss and may force MBO stale, while the
+    /// irreplaceable semantic effect is delivered exactly once immediately.
+    /// </summary>
+    private bool RouteTradeSemantic(ulong securityId, ushort templateId, uint? rptSeqOpt)
+    {
+        if (rptSeqOpt is not { } rptSeq || rptSeq == 0) return true;
+
+        var result = _stateRegistry.ObserveSemantic(
+            securityId,
+            SymbolSemanticKind.Trade,
+            rptSeq);
+        RecordMboStaleTransition(
+            securityId, templateId, rptSeq, result.MboTransitionedToStale, result.GapSize);
+        return result.Action == SymbolStateRegistry.ObserveAction.Apply;
+    }
+
+    private void RecordMboStaleTransition(
+        ulong securityId,
+        ushort templateId,
+        uint rptSeq,
+        bool transitionedToStale,
+        uint gapSize)
+    {
+        if (!transitionedToStale) return;
+
+        Interlocked.Increment(ref _mboStaleTransitions);
+        long gap = gapSize;
+        Interlocked.Add(ref _mboStaleGapSizeSum, gap);
+        long currentMax;
+        do
+        {
+            currentMax = Volatile.Read(ref _mboStaleGapSizeMax);
+            if (gap <= currentMax) break;
+        } while (Interlocked.CompareExchange(ref _mboStaleGapSizeMax, gap, currentMax) != currentMax);
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+            _logger.LogDebug(
+                "PerSymbol Healthy→Stale secId={SecurityId} templateId={TemplateId} rptSeq={RptSeq} gap={Gap}",
+                securityId, templateId, rptSeq, gap);
     }
 
     /// <summary>
@@ -349,22 +374,6 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
                 case MassDeleteOrders_MBO_52Data.MESSAGE_ID:
                     if (MassDeleteOrders_MBO_52Data.TryParse(m.Span, m.BlockLength, out var mdReader))
                         HandleMassDelete(in mdReader);
-                    break;
-                case Trade_53Data.MESSAGE_ID:
-                    if (Trade_53Data.TryParse(m.Span, m.BlockLength, out var trReader))
-                        HandleTrade(in trReader);
-                    break;
-                case ForwardTrade_54Data.MESSAGE_ID:
-                    if (ForwardTrade_54Data.TryParse(m.Span, m.BlockLength, out var fwdReader))
-                        HandleForwardTrade(in fwdReader);
-                    break;
-                case ExecutionSummary_55Data.MESSAGE_ID:
-                    if (ExecutionSummary_55Data.TryParse(m.Span, m.BlockLength, out var exReader))
-                        HandleExecutionSummary(in exReader);
-                    break;
-                case TradeBust_57Data.MESSAGE_ID:
-                    if (TradeBust_57Data.TryParse(m.Span, m.BlockLength, out var tbReader))
-                        HandleTradeBust(in tbReader);
                     break;
             }
             Interlocked.Increment(ref _replayedMboMessages);
@@ -872,8 +881,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
 
-        if (!RouteMbo(securityId, Trade_53Data.MESSAGE_ID,
-                msg.RptSeq is { } trRs ? (uint)trRs : null, reader.Block, reader.BlockLength))
+        if (!RouteTradeSemantic(securityId, Trade_53Data.MESSAGE_ID,
+                msg.RptSeq is { } trRs ? (uint)trRs : null))
         {
             Interlocked.Increment(ref _tradeRouteRejected);
             return;
@@ -934,8 +943,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
 
-        if (!RouteMbo(securityId, ForwardTrade_54Data.MESSAGE_ID,
-                msg.RptSeq is { } fwdRs ? (uint)fwdRs : null, reader.Block, reader.BlockLength))
+        if (!RouteTradeSemantic(securityId, ForwardTrade_54Data.MESSAGE_ID,
+                msg.RptSeq is { } fwdRs ? (uint)fwdRs : null))
             return;
 
         long price = msg.MDEntryPx.Mantissa;
@@ -969,8 +978,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
 
-        if (!RouteMbo(securityId, ExecutionSummary_55Data.MESSAGE_ID,
-                msg.RptSeq is { } exRs ? (uint)exRs : null, reader.Block, reader.BlockLength))
+        if (!RouteTradeSemantic(securityId, ExecutionSummary_55Data.MESSAGE_ID,
+                msg.RptSeq is { } exRs ? (uint)exRs : null))
             return;
 
         long lastPx = msg.LastPx.Mantissa;
@@ -991,8 +1000,8 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
 
-        if (!RouteMbo(securityId, TradeBust_57Data.MESSAGE_ID,
-                msg.RptSeq is { } tbRs ? (uint)tbRs : null, reader.Block, reader.BlockLength))
+        if (!RouteTradeSemantic(securityId, TradeBust_57Data.MESSAGE_ID,
+                msg.RptSeq is { } tbRs ? (uint)tbRs : null))
             return;
 
         long price = msg.MDEntryPx.Mantissa;

--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -75,6 +75,7 @@ internal sealed class SnapshotApplier
     private long _snapshotsMissingRptSeq;
     private long _snapshotChunksOrphaned;
     private long _snapshotsRejectedTooOld;
+    private long _snapshotsRejectedReplayGap;
     private long _snapshotsSkippedHealthyAhead;
     private long _snapshotsRejectedStaleVersion;
     private long _snapshotMarketOrderAdds;
@@ -94,6 +95,7 @@ internal sealed class SnapshotApplier
     public long SnapshotsMissingRptSeq => Volatile.Read(ref _snapshotsMissingRptSeq);
     public long SnapshotChunksOrphaned => Volatile.Read(ref _snapshotChunksOrphaned);
     public long SnapshotsRejectedTooOld => Volatile.Read(ref _snapshotsRejectedTooOld);
+    public long SnapshotsRejectedReplayGap => Volatile.Read(ref _snapshotsRejectedReplayGap);
     public long SnapshotsSkippedHealthyAhead => Volatile.Read(ref _snapshotsSkippedHealthyAhead);
     public long SnapshotMarketOrderAdds => Volatile.Read(ref _snapshotMarketOrderAdds);
     /// <summary>
@@ -610,6 +612,33 @@ internal sealed class SnapshotApplier
     private void CompleteNormalSnapshot(ulong securityId, OrderBook book, PendingSnapshot pending)
     {
         uint snapshotRptSeq = pending.LastRptSeq;
+        uint replayFrom = snapshotRptSeq == uint.MaxValue
+            ? uint.MaxValue
+            : snapshotRptSeq + 1;
+        uint[] bufferedRptSeqs = _staleBuffer.SnapshotRptSeqs(
+            securityId,
+            replayFrom,
+            uint.MaxValue);
+        if (!_stateRegistry.ValidateMboReplayCoverage(
+                securityId,
+                snapshotRptSeq,
+                bufferedRptSeqs,
+                out uint missingRptSeq))
+        {
+            _stateRegistry.BumpMinHeal(
+                securityId,
+                SymbolGapKind.Mbo,
+                missingRptSeq);
+            _staleBuffer.ClearProtectedFloor(securityId);
+            Interlocked.Increment(ref _snapshotsRejectedReplayGap);
+            _logger.LogWarning(
+                "PerSymbol snapshot rejected: sparse MBO replay would bridge missing rptSeq. secId={SecurityId} snapshotRptSeq={SnapshotRptSeq} missingRptSeq={MissingRptSeq}",
+                securityId,
+                snapshotRptSeq,
+                missingRptSeq);
+            return;
+        }
+
         var heal = _stateRegistry.HealFromSnapshot(securityId, SymbolGapKind.Mbo, snapshotRptSeq);
 
         if (!heal.Accepted)

--- a/src/B3.Umdf.Book/StaleMboBuffer.cs
+++ b/src/B3.Umdf.Book/StaleMboBuffer.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace B3.Umdf.Book;
 
 /// <summary>
-/// Per-symbol payload buffer for MBO/Trade messages received while
+/// Per-symbol payload buffer for stateful MBO messages received while
 /// <see cref="SymbolStateRegistry"/> reports the symbol as
 /// <see cref="SymbolState.Stale"/> or <see cref="SymbolState.Unknown"/>.
 /// On heal, the caller drains the entries in the window returned by

--- a/src/B3.Umdf.Book/StaleMboBuffer.cs
+++ b/src/B3.Umdf.Book/StaleMboBuffer.cs
@@ -460,6 +460,38 @@ public sealed class StaleMboBuffer
         _queues.TryGetValue(securityId, out var q) ? q.Items.Count : 0;
 
     /// <summary>
+    /// Returns the sorted, de-duplicated buffered MBO rptSeq values in the
+    /// requested inclusive window. Used to prove snapshot replay continuity
+    /// before the live book is swapped.
+    /// </summary>
+    internal uint[] SnapshotRptSeqs(ulong securityId, uint from, uint to)
+    {
+        if (from > to || !_queues.TryGetValue(securityId, out var queue))
+            return Array.Empty<uint>();
+
+        var values = new List<uint>(queue.Items.Count);
+        foreach (var item in queue.Items)
+        {
+            if (item.RptSeq >= from && item.RptSeq <= to)
+                values.Add(item.RptSeq);
+        }
+
+        if (values.Count == 0)
+            return Array.Empty<uint>();
+
+        values.Sort();
+        int write = 1;
+        for (int read = 1; read < values.Count; read++)
+        {
+            if (values[read] != values[write - 1])
+                values[write++] = values[read];
+        }
+        if (write < values.Count)
+            values.RemoveRange(write, values.Count - write);
+        return values.ToArray();
+    }
+
+    /// <summary>
     /// Begin a transactional drain of the per-symbol buffer for
     /// <paramref name="securityId"/>. The returned <see cref="DrainTransaction"/>
     /// extracts the matching window (rptSeq ∈ [drainFrom, drainTo]) and the

--- a/src/B3.Umdf.Book/SymbolGapTracker.cs
+++ b/src/B3.Umdf.Book/SymbolGapTracker.cs
@@ -3,15 +3,12 @@ using Microsoft.Extensions.Logging;
 namespace B3.Umdf.Book;
 
 /// <summary>
-/// Per-symbol gap kind. Each value corresponds to an SBE message family that
-/// carries its own independent <c>rptSeq</c> counter per security in the B3
-/// UMDF v16 schema.
+/// Per-symbol recovery/telemetry kind. B3 uses one global <c>rptSeq</c> per
+/// security across templates; these values classify the affected semantics.
 /// </summary>
 public enum SymbolGapKind
 {
     Mbo = 0,                       // Order_MBO_50, DeleteOrder_MBO_51, MassDeleteOrders_MBO_52
-                                   // + Trade_53/ForwardTrade_54/ExecutionSummary_55/TradeBust_57
-                                   // (B3 shares one rptSeq stream between book + trade)
     OpeningPrice,                  // tpl 15
     TheoreticalOpeningPrice,       // tpl 16
     ClosingPrice,                  // tpl 17

--- a/src/B3.Umdf.Book/SymbolStatePolicy.cs
+++ b/src/B3.Umdf.Book/SymbolStatePolicy.cs
@@ -14,7 +14,7 @@ namespace B3.Umdf.Book;
 /// changes.</para>
 /// <para><b>Per-kind defaults.</b> Mbo uses <see cref="BootstrapPolicy.RequireSnapshot"/>
 /// + <see cref="LiveResyncPolicy.SnapshotOnly"/> (book is stateful — applying a
-/// delete or trade without a built book corrupts state silently). Every stat kind
+/// delete without a built book corrupts state silently). Every stat kind
 /// uses <see cref="BootstrapPolicy.AcceptFirst"/> + <see cref="LiveResyncPolicy.NextMessage"/>
 /// (each stat update fully replaces the field; partial loss is preferable to
 /// perpetual stale-ness).</para>

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -16,8 +16,8 @@ public enum BootstrapPolicy : byte
     /// Bootstrap requires snapshot: an Unknown→Healthy transition can only
     /// happen via <see cref="SymbolStateRegistry.HealFromSnapshot"/>. The
     /// first incremental for an Unknown symbol is buffered (caller must hold
-    /// it for replay). Used for MBO/Trade messages where applying a delete
-    /// or trade without a built book causes silent corruption.
+    /// it for replay). Used for stateful MBO mutations where applying a delete
+    /// without a built book causes silent corruption.
     /// </summary>
     RequireSnapshot,
 
@@ -54,6 +54,20 @@ public enum LiveResyncPolicy : byte
 }
 
 /// <summary>
+/// Trade-family semantics that share the per-security wire <c>rptSeq</c>
+/// but do not require MBO snapshot recovery before delivery.
+/// </summary>
+internal enum SymbolSemanticKind : byte
+{
+    /// <summary>
+    /// Trade, forward-trade, execution-summary, and trade-bust semantics.
+    /// The first three are self-contained; a bust is a best-effort correction
+    /// against retained trade state. None can be reconstructed by an MBO snapshot.
+    /// </summary>
+    Trade = 0,
+}
+
+/// <summary>
 /// Centralized per-(SecurityID, <see cref="SymbolGapKind"/>) state machine.
 /// Single source of truth for per-symbol recovery state across BookManager,
 /// MarketDataManager, fanout, and metrics — replaces the channel-level
@@ -82,6 +96,7 @@ public enum LiveResyncPolicy : byte
 public sealed class SymbolStateRegistry
 {
     private const int KindCount = (int)SymbolGapKind.SecurityStatus + 1;
+    private const int SemanticKindCount = (int)SymbolSemanticKind.Trade + 1;
 
     private readonly ConcurrentDictionary<ulong, SymbolEntry> _entries = new();
     private readonly ILogger _logger;
@@ -174,6 +189,7 @@ public sealed class SymbolStateRegistry
         internal readonly Lock Sync = new();
         internal readonly SymbolState[] States = new SymbolState[KindCount];
         internal readonly uint[] LastRptSeq = new uint[KindCount];
+        internal readonly uint[] LastSemanticRptSeq = new uint[SemanticKindCount];
         internal readonly long[] StaleSinceTicks = new long[KindCount];
 
         // Lower bound for snapshot rptSeq accepted by HealFromSnapshot. Set whenever
@@ -221,6 +237,15 @@ public sealed class SymbolStateRegistry
         public static readonly ObserveResult ApplyHealthy =
             new(SymbolState.Healthy, ObserveAction.Apply, false, false, 0);
     }
+
+    /// <summary>
+    /// Outcome of observing a self-contained semantic message. The message may
+    /// force MBO stale through the global watermark while still being applied.
+    /// </summary>
+    internal readonly record struct SemanticObserveResult(
+        ObserveAction Action,
+        bool MboTransitionedToStale,
+        uint GapSize);
 
     /// <summary>What the caller should do with the message that triggered <see cref="Observe"/>.</summary>
     public enum ObserveAction : byte
@@ -279,6 +304,54 @@ public sealed class SymbolStateRegistry
         if (fireMboStaleCallback) _onMboStaleStatusChanged?.Invoke(securityId, true);
 
         return result;
+    }
+
+    /// <summary>
+    /// Observes an incremental whose semantic effect is independent of MBO
+    /// snapshot recovery. Global gap detection still runs first and may force
+    /// the MBO bucket stale, but a forward semantic message is applied immediately.
+    /// Duplicate and reordered semantics are suppressed by both the dedicated
+    /// semantic watermark and the shared per-security observed watermark.
+    /// </summary>
+    internal SemanticObserveResult ObserveSemantic(
+        ulong securityId,
+        SymbolSemanticKind kind,
+        uint receivedRptSeq)
+    {
+        if (receivedRptSeq == 0)
+            return new SemanticObserveResult(ObserveAction.Drop, false, 0);
+
+        var entry = GetOrAddEntry(securityId);
+        int idx = (int)kind;
+        GapInfo gap;
+        bool drop;
+
+        lock (entry.Sync)
+        {
+            uint observed = entry.ObservedRptSeq;
+            uint lastSemantic = entry.LastSemanticRptSeq[idx];
+
+            gap = DetectAndApplyGlobalGap(
+                entry,
+                SymbolGapKind.Mbo,
+                receivedRptSeq,
+                observed);
+
+            drop = receivedRptSeq <= lastSemantic || receivedRptSeq <= observed;
+            if (!drop)
+            {
+                entry.LastSemanticRptSeq[idx] = receivedRptSeq;
+                entry.ObservedRptSeq = receivedRptSeq;
+            }
+        }
+
+        if (gap.MboForcedStale)
+            _onMboStaleStatusChanged?.Invoke(securityId, true);
+
+        return new SemanticObserveResult(
+            drop ? ObserveAction.Drop : ObserveAction.Apply,
+            gap.MboForcedStale,
+            gap.GlobalGap ? gap.Size : 0);
     }
 
     /// <summary>
@@ -723,6 +796,7 @@ public sealed class SymbolStateRegistry
                     entry.StaleSinceTicks[i] = 0;
                     entry.MinHealRptSeq[i] = 0;
                 }
+                Array.Clear(entry.LastSemanticRptSeq);
                 entry.StaleKindMask = 0;
                 entry.MboSemanticReconciliation = false;
                 // Wire counter restarts on a catastrophic reset (SequenceReset_1 /
@@ -806,6 +880,7 @@ public sealed class SymbolStateRegistry
             // (per spec). Clear ObservedRptSeq so the next incremental at rpt=1
             // doesn't trigger a spurious global gap against the pre-reset watermark.
             entry.ObservedRptSeq = 0;
+            Array.Clear(entry.LastSemanticRptSeq);
         }
     }
 

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -492,7 +492,12 @@ public sealed class SymbolStateRegistry
             if (minHeal > 0 && snapshotRptSeq < minHeal)
                 return true;
 
-            uint drainTo = entry.LastRptSeq[mboIdx];
+            // Coverage must extend through the global wire high-water, not only
+            // the last observed MBO message. On cold start, a non-MBO message at
+            // rptSeq=N proves that any unknown sequences before N could have
+            // contained MBO mutations; a snapshot below that window is safe only
+            // when buffered MBO or observed non-MBO messages cover every sequence.
+            uint drainTo = entry.ObservedRptSeq;
             if (snapshotRptSeq >= drainTo)
                 return true;
 

--- a/src/B3.Umdf.Book/SymbolStateRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolStateRegistry.cs
@@ -190,6 +190,7 @@ public sealed class SymbolStateRegistry
         internal readonly SymbolState[] States = new SymbolState[KindCount];
         internal readonly uint[] LastRptSeq = new uint[KindCount];
         internal readonly uint[] LastSemanticRptSeq = new uint[SemanticKindCount];
+        internal readonly List<SequenceRange> NonMboCoverage = new();
         internal readonly long[] StaleSinceTicks = new long[KindCount];
 
         // Lower bound for snapshot rptSeq accepted by HealFromSnapshot. Set whenever
@@ -221,6 +222,8 @@ public sealed class SymbolStateRegistry
         internal uint ObservedRptSeq;
         internal bool MboSemanticReconciliation;
     }
+
+    internal readonly record struct SequenceRange(uint Start, uint End);
 
     /// <summary>
     /// Outcome of <see cref="Observe"/>: tells the caller whether to apply,
@@ -263,7 +266,8 @@ public sealed class SymbolStateRegistry
     /// stored last-seen value. Returns the action the caller should take.
     /// </summary>
     /// <param name="securityId">Security identifier.</param>
-    /// <param name="kind">Message family — distinguishes independent rptSeq streams per symbol.</param>
+    /// <param name="kind">Message family whose state/recovery policy is being updated.
+    /// Wire continuity is still tracked by the one global per-security watermark.</param>
     /// <param name="receivedRptSeq">The rptSeq carried by the incoming message. Caller
     /// must not pass 0 (sentinel for "absent" in SBE) — guard at the call site.</param>
     public ObserveResult Observe(ulong securityId, SymbolGapKind kind, uint receivedRptSeq)
@@ -296,6 +300,12 @@ public sealed class SymbolStateRegistry
             // absent: the global watermark above is the single source of truth.
             // The Healthy branch only handles duplicate suppression and forward apply.
             result = DispatchByState(entry, idx, kind, receivedRptSeq, lastSeen, prev, bootPolicy, gap);
+            if (kind != SymbolGapKind.Mbo
+                && result.Action != ObserveAction.Drop
+                && entry.States[(int)SymbolGapKind.Mbo] != SymbolState.Healthy)
+            {
+                AddNonMboCoverage(entry.NonMboCoverage, receivedRptSeq);
+            }
         }
 
         // Invoke the (Mbo) stale-status callback OUTSIDE the per-symbol lock to
@@ -310,8 +320,9 @@ public sealed class SymbolStateRegistry
     /// Observes an incremental whose semantic effect is independent of MBO
     /// snapshot recovery. Global gap detection still runs first and may force
     /// the MBO bucket stale, but a forward semantic message is applied immediately.
-    /// Duplicate and reordered semantics are suppressed by both the dedicated
-    /// semantic watermark and the shared per-security observed watermark.
+    /// Duplicate and reordered semantics are suppressed by the dedicated emitted
+    /// semantic watermark; snapshot advancement of the global watermark alone is
+    /// never proof that a semantic payload was delivered.
     /// </summary>
     internal SemanticObserveResult ObserveSemantic(
         ulong securityId,
@@ -337,11 +348,14 @@ public sealed class SymbolStateRegistry
                 receivedRptSeq,
                 observed);
 
-            drop = receivedRptSeq <= lastSemantic || receivedRptSeq <= observed;
+            drop = receivedRptSeq <= lastSemantic;
             if (!drop)
             {
                 entry.LastSemanticRptSeq[idx] = receivedRptSeq;
-                entry.ObservedRptSeq = receivedRptSeq;
+                if (receivedRptSeq > observed)
+                    entry.ObservedRptSeq = receivedRptSeq;
+                if (entry.States[(int)SymbolGapKind.Mbo] != SymbolState.Healthy)
+                    AddNonMboCoverage(entry.NonMboCoverage, receivedRptSeq);
             }
         }
 
@@ -378,15 +392,15 @@ public sealed class SymbolStateRegistry
 
         uint gapSize = receivedRptSeq - observed - 1;
         if (entry.States[mboIdx] != SymbolState.Healthy)
+        {
+            TightenMboMinHeal(entry, receivedRptSeq - 1);
             return new GapInfo(true, gapSize, false);
+        }
 
-        // Tighten MinHeal[Mbo] to (received - 1) on the Healthy→Stale transition.
-        // Subsequent gaps while already Stale do NOT bump MinHeal — the
-        // StaleMboBuffer eviction callback (BumpMinHeal) is responsible for
-        // advancing it when buffered entries are dropped.
-        uint mboMin = receivedRptSeq - 1;
-        if (mboMin > entry.MinHealRptSeq[mboIdx])
-            entry.MinHealRptSeq[mboIdx] = mboMin;
+        // Tighten MinHeal[Mbo] to (received - 1). The same rule applies to every
+        // later gap while Stale: skipped wire sequences are not replayable unless
+        // an accepted snapshot covers them.
+        TightenMboMinHeal(entry, receivedRptSeq - 1);
 
         int prevMask = entry.StaleKindMask;
         entry.States[mboIdx] = SymbolState.Stale;
@@ -426,7 +440,12 @@ public sealed class SymbolStateRegistry
                 // so a snapshot older than our first live observation is rejected
                 // (we cannot replay messages we never saw).
                 if (entry.MinHealRptSeq[idx] == 0 && receivedRptSeq > 0)
-                    entry.MinHealRptSeq[idx] = receivedRptSeq - 1;
+                {
+                    if (kind == SymbolGapKind.Mbo)
+                        TightenMboMinHeal(entry, receivedRptSeq - 1);
+                    else
+                        entry.MinHealRptSeq[idx] = receivedRptSeq - 1;
+                }
                 return new ObserveResult(SymbolState.Unknown, ObserveAction.Buffer, false, false, 0);
 
             case SymbolState.Healthy:
@@ -438,6 +457,8 @@ public sealed class SymbolStateRegistry
                     GapSize: gap.GlobalGap ? gap.Size : 0);
 
             case SymbolState.Stale:
+                if (receivedRptSeq <= lastSeen)
+                    return new ObserveResult(SymbolState.Stale, ObserveAction.Drop, false, false, 0);
                 if (receivedRptSeq > lastSeen)
                     entry.LastRptSeq[idx] = receivedRptSeq;
                 bool surfaceStaleTransition = gap.MboForcedStale && kind == SymbolGapKind.Mbo;
@@ -453,6 +474,167 @@ public sealed class SymbolStateRegistry
 
     /// <summary>Output of <see cref="DetectAndApplyGlobalGap"/>.</summary>
     private readonly record struct GapInfo(bool GlobalGap, uint Size, bool MboForcedStale);
+
+    internal bool ValidateMboReplayCoverage(
+        ulong securityId,
+        uint snapshotRptSeq,
+        ReadOnlySpan<uint> bufferedRptSeqs,
+        out uint missingRptSeq)
+    {
+        missingRptSeq = 0;
+        if (!_entries.TryGetValue(securityId, out var entry))
+            return true;
+
+        lock (entry.Sync)
+        {
+            const int mboIdx = (int)SymbolGapKind.Mbo;
+            uint minHeal = entry.MinHealRptSeq[mboIdx];
+            if (minHeal > 0 && snapshotRptSeq < minHeal)
+                return true;
+
+            uint drainTo = entry.LastRptSeq[mboIdx];
+            if (snapshotRptSeq >= drainTo)
+                return true;
+
+            uint expected = snapshotRptSeq + 1;
+            int bufferedIndex = 0;
+            int coverageIndex = 0;
+
+            while (true)
+            {
+                while (bufferedIndex < bufferedRptSeqs.Length
+                       && bufferedRptSeqs[bufferedIndex] < expected)
+                {
+                    bufferedIndex++;
+                }
+
+                while (coverageIndex < entry.NonMboCoverage.Count
+                       && entry.NonMboCoverage[coverageIndex].End < expected)
+                {
+                    coverageIndex++;
+                }
+
+                if (coverageIndex < entry.NonMboCoverage.Count)
+                {
+                    var coverage = entry.NonMboCoverage[coverageIndex];
+                    if (coverage.Start <= expected)
+                    {
+                        if (coverage.End >= drainTo)
+                            return true;
+                        expected = coverage.End + 1;
+                        coverageIndex++;
+                        continue;
+                    }
+                }
+
+                if (bufferedIndex < bufferedRptSeqs.Length
+                    && bufferedRptSeqs[bufferedIndex] == expected)
+                {
+                    if (expected == drainTo)
+                        return true;
+                    expected++;
+                    bufferedIndex++;
+                    continue;
+                }
+
+                missingRptSeq = expected;
+                return false;
+            }
+        }
+    }
+
+    private static void TightenMboMinHeal(SymbolEntry entry, uint newMin)
+    {
+        const int mboIdx = (int)SymbolGapKind.Mbo;
+        if (newMin <= entry.MinHealRptSeq[mboIdx])
+            return;
+
+        entry.MinHealRptSeq[mboIdx] = newMin;
+        RemoveNonMboCoverageThrough(entry.NonMboCoverage, newMin);
+    }
+
+    private static void AddNonMboCoverage(List<SequenceRange> ranges, uint rptSeq)
+    {
+        if (ranges.Count == 0)
+        {
+            ranges.Add(new SequenceRange(rptSeq, rptSeq));
+            return;
+        }
+
+        int lastIndex = ranges.Count - 1;
+        var last = ranges[lastIndex];
+        if (rptSeq > last.End)
+        {
+            if (last.End != uint.MaxValue && rptSeq == last.End + 1)
+                ranges[lastIndex] = last with { End = rptSeq };
+            else
+                ranges.Add(new SequenceRange(rptSeq, rptSeq));
+            return;
+        }
+
+        int lo = 0;
+        int hi = ranges.Count;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) / 2);
+            if (ranges[mid].Start <= rptSeq)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+
+        int nextIndex = lo;
+        int previousIndex = nextIndex - 1;
+        if (previousIndex >= 0 && rptSeq <= ranges[previousIndex].End)
+            return;
+
+        bool joinsPrevious = previousIndex >= 0
+            && ranges[previousIndex].End != uint.MaxValue
+            && rptSeq == ranges[previousIndex].End + 1;
+        bool joinsNext = nextIndex < ranges.Count
+            && rptSeq != uint.MaxValue
+            && rptSeq + 1 == ranges[nextIndex].Start;
+
+        if (joinsPrevious && joinsNext)
+        {
+            ranges[previousIndex] = new SequenceRange(
+                ranges[previousIndex].Start,
+                ranges[nextIndex].End);
+            ranges.RemoveAt(nextIndex);
+        }
+        else if (joinsPrevious)
+        {
+            ranges[previousIndex] = ranges[previousIndex] with { End = rptSeq };
+        }
+        else if (joinsNext)
+        {
+            ranges[nextIndex] = ranges[nextIndex] with { Start = rptSeq };
+        }
+        else
+        {
+            ranges.Insert(nextIndex, new SequenceRange(rptSeq, rptSeq));
+        }
+    }
+
+    private static void RemoveNonMboCoverageThrough(List<SequenceRange> ranges, uint rptSeq)
+    {
+        int removeCount = 0;
+        while (removeCount < ranges.Count && ranges[removeCount].End <= rptSeq)
+            removeCount++;
+        if (removeCount > 0)
+            ranges.RemoveRange(0, removeCount);
+
+        if (ranges.Count == 0 || ranges[0].Start > rptSeq)
+            return;
+
+        if (rptSeq == uint.MaxValue)
+        {
+            ranges.Clear();
+            return;
+        }
+
+        ranges[0] = ranges[0] with { Start = rptSeq + 1 };
+    }
 
     /// <summary>
     /// Temporarily moves a Healthy MBO symbol to Stale while an authoritative
@@ -479,8 +661,7 @@ public sealed class SymbolStateRegistry
             entry.StaleSinceTicks[mboIdx] = _clock.NowTicks;
             entry.StaleKindMask |= 1 << mboIdx;
             entry.MboSemanticReconciliation = true;
-            if (priorHighWater > entry.MinHealRptSeq[mboIdx])
-                entry.MinHealRptSeq[mboIdx] = priorHighWater;
+            TightenMboMinHeal(entry, priorHighWater);
             if (prevMask == 0)
                 Interlocked.Increment(ref _staleSymbolCount);
             transitioned = true;
@@ -654,7 +835,10 @@ public sealed class SymbolStateRegistry
             entry.States[idx] = SymbolState.Healthy;
             entry.MinHealRptSeq[idx] = 0; // baseline restored — no constraint until next stale event
             if (kind == SymbolGapKind.Mbo)
+            {
                 entry.MboSemanticReconciliation = false;
+                entry.NonMboCoverage.Clear();
+            }
 
             // Bump observed to at least snapshotRptSeq. Snapshots are an authoritative
             // "instrument is at rptSeq=N" signal from the wire (lower bound — live may
@@ -748,7 +932,10 @@ public sealed class SymbolStateRegistry
             entry.States[idx] = SymbolState.Healthy;
             entry.MinHealRptSeq[idx] = 0;
             if (kind == SymbolGapKind.Mbo)
+            {
                 entry.MboSemanticReconciliation = false;
+                entry.NonMboCoverage.Clear();
+            }
             if (anchor > entry.ObservedRptSeq) entry.ObservedRptSeq = anchor;
 
             bool transitioned = prev != SymbolState.Healthy;
@@ -797,6 +984,7 @@ public sealed class SymbolStateRegistry
                     entry.MinHealRptSeq[i] = 0;
                 }
                 Array.Clear(entry.LastSemanticRptSeq);
+                entry.NonMboCoverage.Clear();
                 entry.StaleKindMask = 0;
                 entry.MboSemanticReconciliation = false;
                 // Wire counter restarts on a catastrophic reset (SequenceReset_1 /
@@ -873,7 +1061,10 @@ public sealed class SymbolStateRegistry
             entry.MinHealRptSeq[idx] = 0;
             entry.StaleKindMask &= ~(1 << idx);
             if (kind == SymbolGapKind.Mbo)
+            {
                 entry.MboSemanticReconciliation = false;
+                entry.NonMboCoverage.Clear();
+            }
             if (prevMask != 0 && entry.StaleKindMask == 0)
                 Interlocked.Decrement(ref _staleSymbolCount);
             // EmptyBook resets the wire-level rptSeq counter for this instrument
@@ -919,7 +1110,10 @@ public sealed class SymbolStateRegistry
         {
             if (newMin > entry.MinHealRptSeq[idx])
             {
-                entry.MinHealRptSeq[idx] = newMin;
+                if (kind == SymbolGapKind.Mbo)
+                    TightenMboMinHeal(entry, newMin);
+                else
+                    entry.MinHealRptSeq[idx] = newMin;
                 return true;
             }
         }

--- a/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
+++ b/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
@@ -447,6 +447,10 @@ static class MetricsBinder
             () => PerGroupBook(bm => bm.SnapshotsRejectedTooOld),
             unit: "{snapshots}", description: "Snapshots rejected because LastRptSeq is older than the symbol's MinHealRptSeq (would leave a hole)");
 
+        Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_rejected_replay_gap",
+            () => PerGroupBook(bm => bm.SnapshotsRejectedReplayGap),
+            unit: "{snapshots}", description: "Snapshots rejected because retained MBO replay and proven non-MBO sequences did not cover the full post-snapshot window");
+
         Meter.CreateObservableCounter("b3.umdf.persymbol.snapshots_rejected_stale_version",
             () => PerGroupBook(bm => bm.SnapshotsRejectedStaleVersion),
             unit: "{snapshots}", description: "Snapshots rejected because they belong to an older SequenceVersion than the active epoch (post-rollover stragglers)");

--- a/src/B3.Umdf.ConsoleApp/StatsPrinter.cs
+++ b/src/B3.Umdf.ConsoleApp/StatsPrinter.cs
@@ -216,7 +216,7 @@ internal sealed class StatsPrinter
                     forced = $" forcedHeal[count:{authReset:N0} maxUnsafe:{maxUnsafe:N0} maxDiscardedTail:{maxDiscarded:N0}]";
                 }
                 perSymbolParts.Add(
-                    $"G{_groupIds[i]}=stale:{snap.TotalStaleSymbols}/{snap.TotalSymbols} buf:{stalePending:N0}msg/{bufBytes:N0}B healed:{bm.SnapshotsHealed:N0} skipHA:{bm.SnapshotsSkippedHealthyAhead:N0} rejTooOld:{bm.SnapshotsRejectedTooOld:N0} miss:{bm.SnapshotsMissingRptSeq:N0}{gate}{floor}{forced}");
+                    $"G{_groupIds[i]}=stale:{snap.TotalStaleSymbols}/{snap.TotalSymbols} buf:{stalePending:N0}msg/{bufBytes:N0}B healed:{bm.SnapshotsHealed:N0} skipHA:{bm.SnapshotsSkippedHealthyAhead:N0} rejTooOld:{bm.SnapshotsRejectedTooOld:N0} rejReplayGap:{bm.SnapshotsRejectedReplayGap:N0} miss:{bm.SnapshotsMissingRptSeq:N0}{gate}{floor}{forced}");
             }
         }
         if (_multiFeed is not null)

--- a/tests/B3.Umdf.Book.Tests/BookManagerSnapshotHealTests.cs
+++ b/tests/B3.Umdf.Book.Tests/BookManagerSnapshotHealTests.cs
@@ -24,12 +24,12 @@ public class BookManagerSnapshotHealTests
             reg.Observe(securityId: 42, SymbolGapKind.Mbo, r);
         // Cold-start MBO is Unknown (not yet Stale; that requires Healthy→gap).
 
-        bm.RecordSnapshotHeader(42, lastRptSeq: 12);
+        bm.RecordSnapshotHeader(42, lastRptSeq: 15);
         bm.HealAfterSnapshotForTest(42);
 
         Assert.Equal(1, bm.SnapshotsHealed);
         Assert.Equal(0, bm.SnapshotsMissingRptSeq);
-        Assert.Equal(12u, bm.Books[42].LastRptSeq); // book reflects snapshot baseline
+        Assert.Equal(15u, bm.Books[42].LastRptSeq); // book reflects snapshot baseline
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class BookManagerSnapshotHealTests
         for (uint r = 10; r <= 15; r++)
             reg.Observe(securityId: 100, SymbolGapKind.Mbo, r);
 
-        bm.BeginChunkedSnapshotForTest(100, lastRptSeq: 12, ordersExpected: 30);
+        bm.BeginChunkedSnapshotForTest(100, lastRptSeq: 15, ordersExpected: 30);
         bm.RecordSnapshotChunkForTest(100, ordersInChunk: 10);
         Assert.Equal(0, bm.SnapshotsHealed);
         Assert.Equal(0, bm.SnapshotsMissingRptSeq);
@@ -139,7 +139,7 @@ public class BookManagerSnapshotHealTests
         bm.RecordSnapshotChunkForTest(100, ordersInChunk: 10);
         Assert.Equal(1, bm.SnapshotsHealed);
         Assert.Equal(0, bm.SnapshotsMissingRptSeq);
-        Assert.Equal(12u, bm.Books[100].LastRptSeq);
+        Assert.Equal(15u, bm.Books[100].LastRptSeq);
     }
 
     [Fact]
@@ -390,23 +390,23 @@ public class BookManagerSnapshotHealTests
     }
 
     [Fact]
-    public void Snapshot_AcceptedAtBoundary_S_EqualsMinHeal()
+    public void Snapshot_CoveringHighWater_IsAccepted()
     {
-        // Cenário 3: snapshot exatamente em S = MinHeal deve ser aceito (>=, não >).
-        // Drain window = [S+1, highWater] = [MinHeal+1, highWater].
+        // A snapshot at the observed high-water needs no retained replay body.
         var (bm, reg, _) = CreatePerSymbol();
         for (uint r = 50; r <= 100; r++)
             reg.Observe(securityId: 900, SymbolGapKind.Mbo, r);
         reg.HealFromSnapshot(900, SymbolGapKind.Mbo, 100);
         reg.Observe(securityId: 900, SymbolGapKind.Mbo, 200); // gap → Stale; MinHeal=199, highWater=200
 
-        // Snapshot exatamente em 199 — boundary case.
-        bm.BeginChunkedSnapshotForTest(900, lastRptSeq: 199, ordersExpected: 0);
+        // No retained message body exists in this registry-only setup, so the
+        // snapshot must cover the observed high-water.
+        bm.BeginChunkedSnapshotForTest(900, lastRptSeq: 200, ordersExpected: 0);
 
         Assert.Equal(1, bm.SnapshotsHealed);
         Assert.Equal(0, bm.SnapshotsRejectedTooOld);
         Assert.Equal(SymbolState.Healthy, reg.GetState(900, SymbolGapKind.Mbo));
-        Assert.Equal(199u, bm.Books[900].LastRptSeq);
+        Assert.Equal(200u, bm.Books[900].LastRptSeq);
     }
 
     [Fact]
@@ -496,8 +496,8 @@ public class BookManagerSnapshotHealTests
         Assert.Equal(SymbolStateRegistry.ObserveAction.Buffer, obs.Action);
         Assert.Equal(SymbolState.Stale, reg.GetState(1300, SymbolGapKind.Mbo));
 
-        // Próximo snapshot fresco (rpt >= 159) cura corretamente.
-        bm.BeginChunkedSnapshotForTest(1300, lastRptSeq: 159, ordersExpected: 0);
+        // Snapshot covering the unretained registry-only observation heals.
+        bm.BeginChunkedSnapshotForTest(1300, lastRptSeq: 160, ordersExpected: 0);
         Assert.Equal(1, bm.SnapshotsHealed);
         Assert.Equal(SymbolState.Healthy, reg.GetState(1300, SymbolGapKind.Mbo));
     }

--- a/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
@@ -1,0 +1,282 @@
+using B3.Umdf.Book;
+using B3.Umdf.Feed;
+using B3.Umdf.Mbo.Sbe.V16;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+public class Issue80TradeGapRecoveryTests
+{
+    private const ulong SecurityId = 80;
+
+    [Fact]
+    public void GapExposedByTrade_StalesMboButEmitsTrade()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, bookManager.MboStaleTransitions);
+        Assert.Equal(2, bookManager.MboStaleGapSizeSum);
+        Assert.Equal(0, bookManager.TradeRouteRejected);
+        Assert.True(bookManager.TryGetTradeState(SecurityId, out var tradeState));
+        Assert.Equal(35_3400L, tradeState!.LastTradePrice);
+    }
+
+    [Fact]
+    public void TradeWhileMboStale_EmitsWhileMboMutationRemainsBuffered()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+        SendOrder(bookManager, rptSeq: 14, orderId: 100);
+        SendTrade(bookManager, rptSeq: 15, tradeId: 2);
+
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(2, recorder.TradeCount);
+        Assert.Equal(0, recorder.OrderAddCount);
+        Assert.Equal(1, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, bookManager.BufferedMboMessages);
+    }
+
+    [Fact]
+    public void CoveringSnapshot_PreservesAppliedTradeAndSuppressesDuplicate()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+        Assert.True(bookManager.TryGetTradeState(SecurityId, out var before));
+        Assert.Single(before!.Ring.AsSpan());
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 11, ordersExpected: 0);
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, bookManager.SnapshotsRejectedTooOld);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 13, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.True(bookManager.TryGetTradeState(SecurityId, out var after));
+        Assert.Single(after!.Ring.AsSpan());
+        Assert.Equal(35_3400L, after.LastTradePrice);
+
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Single(after.Ring.AsSpan());
+        Assert.Equal(1, bookManager.TradeRouteRejected);
+    }
+
+    [Fact]
+    public void DuplicateAndReorderedTrades_AreSuppressed()
+    {
+        var (bookManager, _, _, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendTrade(bookManager, rptSeq: 11, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 11, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 10, tradeId: 2);
+
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(2, bookManager.TradeRouteRejected);
+        Assert.True(bookManager.TryGetTradeState(SecurityId, out var tradeState));
+        Assert.Single(tradeState!.Ring.AsSpan());
+    }
+
+    [Fact]
+    public void TradeFamilies_ShareSemanticWatermarkAndGlobalContinuity()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendTrade(bookManager, rptSeq: 11, tradeId: 1);
+        SendForwardTrade(bookManager, rptSeq: 12, tradeId: 2);
+        SendExecutionSummary(bookManager, rptSeq: 13);
+        SendTradeBust(bookManager, rptSeq: 14, tradeId: 1);
+        SendOrder(bookManager, rptSeq: 15, orderId: 100);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.False(registry.IsAnyStale(SecurityId));
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(1, recorder.ForwardTradeCount);
+        Assert.Equal(1, recorder.ExecutionSummaryCount);
+        Assert.Equal(1, recorder.TradeBustCount);
+        Assert.Equal(1, recorder.OrderAddCount);
+        Assert.Equal(1, bookManager.TradeBustsApplied);
+        Assert.Equal(0, bookManager.MboStaleTransitions);
+    }
+
+    [Fact]
+    public void SemanticFamilies_EmitWhileMboAlreadyStale()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
+        SendForwardTrade(bookManager, rptSeq: 15, tradeId: 2);
+        SendExecutionSummary(bookManager, rptSeq: 16);
+        SendTradeBust(bookManager, rptSeq: 17, tradeId: 1);
+
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(1, recorder.ForwardTradeCount);
+        Assert.Equal(1, recorder.ExecutionSummaryCount);
+        Assert.Equal(1, recorder.TradeBustCount);
+        Assert.Equal(1, bookManager.TradeBustsApplied);
+    }
+
+    private static (BookManager Manager, SymbolStateRegistry Registry, StaleMboBuffer Buffer, Recorder Recorder) Create()
+    {
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var buffer = new StaleMboBuffer(NullLogger.Instance);
+        var recorder = new Recorder();
+        var manager = new BookManager(
+            eventHandler: recorder,
+            stateRegistry: registry,
+            staleBuffer: buffer);
+        return (manager, registry, buffer, recorder);
+    }
+
+    private static void Bootstrap(BookManager bookManager, uint rptSeq)
+        => bookManager.BeginChunkedSnapshotForTest(SecurityId, rptSeq, ordersExpected: 0);
+
+    private static void SendTrade(BookManager bookManager, uint rptSeq, uint tradeId)
+    {
+        var message = new Trade_53Data
+        {
+            SecurityID = SecurityId,
+            MDEntryPx = new Price { Mantissa = 35_3400 },
+            MDEntrySize = 100,
+            TradeID = tradeId,
+        };
+        message.SetRptSeq(rptSeq);
+        message.SetTrdSubType(null);
+        Dispatch(bookManager, message);
+    }
+
+    private static void SendForwardTrade(BookManager bookManager, uint rptSeq, uint tradeId)
+    {
+        var message = new ForwardTrade_54Data
+        {
+            SecurityID = SecurityId,
+            MDEntryPx = new Price { Mantissa = 35_3500 },
+            MDEntrySize = 50,
+            TradeID = tradeId,
+        };
+        message.SetRptSeq(rptSeq);
+        message.SetTrdSubType(null);
+        Dispatch(bookManager, message);
+    }
+
+    private static void SendExecutionSummary(BookManager bookManager, uint rptSeq)
+    {
+        var message = new ExecutionSummary_55Data
+        {
+            SecurityID = SecurityId,
+            LastPx = new Price { Mantissa = 35_3500 },
+            FillQty = 150,
+        };
+        message.SetRptSeq(rptSeq);
+        Dispatch(bookManager, message);
+    }
+
+    private static void SendTradeBust(BookManager bookManager, uint rptSeq, uint tradeId)
+    {
+        var message = new TradeBust_57Data
+        {
+            SecurityID = SecurityId,
+            MDEntryPx = new Price { Mantissa = 35_3400 },
+            MDEntrySize = 100,
+            TradeID = tradeId,
+        };
+        message.SetRptSeq(rptSeq);
+        Dispatch(bookManager, message);
+    }
+
+    private static void SendOrder(BookManager bookManager, uint rptSeq, ulong orderId)
+    {
+        var message = new Order_MBO_50Data
+        {
+            SecurityID = SecurityId,
+            MDUpdateAction = MDUpdateAction.NEW,
+            MDEntryType = MDEntryType.BID,
+            MDEntrySize = 10,
+            SecondaryOrderID = orderId,
+        };
+        message.SetRptSeq(rptSeq);
+        message.SetMDEntryPrevSize(null);
+        Dispatch(bookManager, message);
+    }
+
+    private static void Dispatch(BookManager bookManager, Trade_53Data message)
+    {
+        var payload = new byte[MessageHeader.MESSAGE_SIZE + Math.Max(Trade_53Data.MESSAGE_SIZE, Trade_53Data.BLOCK_LENGTH)];
+        Trade_53Data.WriteHeader(payload);
+        message.Encode(payload.AsSpan(MessageHeader.MESSAGE_SIZE));
+        bookManager.OnPacket(default, payload, Trade_53Data.MESSAGE_ID);
+    }
+
+    private static void Dispatch(BookManager bookManager, ForwardTrade_54Data message)
+    {
+        var payload = new byte[MessageHeader.MESSAGE_SIZE + Math.Max(ForwardTrade_54Data.MESSAGE_SIZE, ForwardTrade_54Data.BLOCK_LENGTH)];
+        ForwardTrade_54Data.WriteHeader(payload);
+        message.Encode(payload.AsSpan(MessageHeader.MESSAGE_SIZE));
+        bookManager.OnPacket(default, payload, ForwardTrade_54Data.MESSAGE_ID);
+    }
+
+    private static void Dispatch(BookManager bookManager, ExecutionSummary_55Data message)
+    {
+        var payload = new byte[MessageHeader.MESSAGE_SIZE + Math.Max(ExecutionSummary_55Data.MESSAGE_SIZE, ExecutionSummary_55Data.BLOCK_LENGTH)];
+        ExecutionSummary_55Data.WriteHeader(payload);
+        message.Encode(payload.AsSpan(MessageHeader.MESSAGE_SIZE));
+        bookManager.OnPacket(default, payload, ExecutionSummary_55Data.MESSAGE_ID);
+    }
+
+    private static void Dispatch(BookManager bookManager, TradeBust_57Data message)
+    {
+        var payload = new byte[MessageHeader.MESSAGE_SIZE + Math.Max(TradeBust_57Data.MESSAGE_SIZE, TradeBust_57Data.BLOCK_LENGTH)];
+        TradeBust_57Data.WriteHeader(payload);
+        message.Encode(payload.AsSpan(MessageHeader.MESSAGE_SIZE));
+        bookManager.OnPacket(default, payload, TradeBust_57Data.MESSAGE_ID);
+    }
+
+    private static void Dispatch(BookManager bookManager, Order_MBO_50Data message)
+    {
+        var payload = new byte[MessageHeader.MESSAGE_SIZE + Math.Max(Order_MBO_50Data.MESSAGE_SIZE, Order_MBO_50Data.BLOCK_LENGTH)];
+        Order_MBO_50Data.WriteHeader(payload);
+        message.Encode(payload.AsSpan(MessageHeader.MESSAGE_SIZE));
+        bookManager.OnPacket(default, payload, Order_MBO_50Data.MESSAGE_ID);
+    }
+
+    private sealed class Recorder : IBookEventHandler
+    {
+        public int TradeCount;
+        public int ForwardTradeCount;
+        public int ExecutionSummaryCount;
+        public int TradeBustCount;
+        public int OrderAddCount;
+
+        public void OnOrderAdded(OrderBook book, in OrderBookEntry entry) => OrderAddCount++;
+        public void OnOrderUpdated(OrderBook book, in OrderBookEntry entry) { }
+        public void OnOrderDeleted(OrderBook book, ulong orderId, BookSideType side) { }
+        public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+            => TradeCount++;
+        public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+            => ForwardTradeCount++;
+        public void OnExecutionSummary(ulong securityId, long lastPx, long fillQty)
+            => ExecutionSummaryCount++;
+        public void OnTradeBust(ulong securityId, long price, long quantity, long tradeId)
+            => TradeBustCount++;
+        public void OnBookCleared(ulong securityId, BookClearSide side) { }
+    }
+}

--- a/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
@@ -83,16 +83,39 @@ public class Issue80TradeGapRecoveryTests
         SendOrder(bookManager, rptSeq: 13, orderId: 100);
         bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 14, ordersExpected: 0);
         Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(14u, bookManager.Books[SecurityId].LastRptSeq);
 
-        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
-        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
-        SendTrade(bookManager, rptSeq: 13, tradeId: 2);
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 13, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 12, tradeId: 2);
 
         Assert.Equal(1, recorder.TradeCount);
         Assert.Equal(2, bookManager.TradeRouteRejected);
+        Assert.Equal(14u, bookManager.Books[SecurityId].LastRptSeq);
         Assert.True(bookManager.TryGetTradeState(SecurityId, out var tradeState));
         Assert.Single(tradeState!.Ring.AsSpan());
         Assert.Equal(35_3400L, tradeState.LastTradePrice);
+    }
+
+    [Fact]
+    public void ColdStartNonMboHighWater_RejectsSnapshotWithUncoveredMboWindow()
+    {
+        var (bookManager, registry, _, recorder) = Create();
+
+        SendTrade(bookManager, rptSeq: 100, tradeId: 1);
+        Assert.Equal(SymbolState.Unknown, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, recorder.TradeCount);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 50, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Unknown, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, bookManager.SnapshotsRejectedReplayGap);
+        Assert.Equal(0u, bookManager.Books[SecurityId].LastRptSeq);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 99, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(99u, bookManager.Books[SecurityId].LastRptSeq);
     }
 
     [Fact]

--- a/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
@@ -75,6 +75,27 @@ public class Issue80TradeGapRecoveryTests
     }
 
     [Fact]
+    public void SnapshotWatermark_DoesNotSuppressNeverEmittedDelayedTrade()
+    {
+        var (bookManager, registry, _, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 14, ordersExpected: 0);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+
+        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
+        SendTrade(bookManager, rptSeq: 13, tradeId: 2);
+
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(2, bookManager.TradeRouteRejected);
+        Assert.True(bookManager.TryGetTradeState(SecurityId, out var tradeState));
+        Assert.Single(tradeState!.Ring.AsSpan());
+        Assert.Equal(35_3400L, tradeState.LastTradePrice);
+    }
+
+    [Fact]
     public void DuplicateAndReorderedTrades_AreSuppressed()
     {
         var (bookManager, _, _, recorder) = Create();
@@ -135,10 +156,105 @@ public class Issue80TradeGapRecoveryTests
         Assert.Equal(1, bookManager.TradeBustsApplied);
     }
 
+    [Fact]
+    public void AdditionalGapWhileStale_TightensMinHealAndPreventsSparseReplay()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        SendOrder(bookManager, rptSeq: 16, orderId: 101);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 14, ordersExpected: 0);
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, bookManager.SnapshotsRejectedTooOld);
+        Assert.Equal(2, buffer.DepthOf(SecurityId));
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 15, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+        Assert.Equal(1, recorder.OrderAddCount);
+        Assert.True(bookManager.Books[SecurityId].Bids.TryGetOrder(101, out _));
+        Assert.False(bookManager.Books[SecurityId].Bids.TryGetOrder(100, out _));
+    }
+
+    [Fact]
+    public void SemanticOnlySequences_ProveSparseMboReplayCoverage()
+    {
+        var (bookManager, registry, buffer, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        SendTrade(bookManager, rptSeq: 14, tradeId: 1);
+        SendExecutionSummary(bookManager, rptSeq: 15);
+        SendOrder(bookManager, rptSeq: 16, orderId: 101);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 12, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+        Assert.Equal(2, recorder.OrderAddCount);
+        Assert.Equal(1, recorder.TradeCount);
+        Assert.Equal(1, recorder.ExecutionSummaryCount);
+        Assert.Equal(0, bookManager.SnapshotsRejectedReplayGap);
+        Assert.True(bookManager.Books[SecurityId].Bids.TryGetOrder(100, out _));
+        Assert.True(bookManager.Books[SecurityId].Bids.TryGetOrder(101, out _));
+    }
+
+    [Fact]
+    public void MissingBufferedMbo_IsRejectedUntilSnapshotCoversIt()
+    {
+        var buffer = new StaleMboBuffer(
+            NullLogger.Instance,
+            perSymbolCap: 8,
+            globalByteCap: 1,
+            hotPerSymbolCap: 16);
+        var (bookManager, registry, _, recorder) = Create(buffer);
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        Assert.Equal(1, buffer.DroppedGlobalCapCount);
+        Assert.Equal(0, buffer.DepthOf(SecurityId));
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 12, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, bookManager.SnapshotsRejectedReplayGap);
+        Assert.Equal(0, recorder.OrderAddCount);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 13, ordersExpected: 0);
+
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(0, recorder.OrderAddCount);
+    }
+
+    [Fact]
+    public void SemanticGapWhileStale_TightensFloorButStillEmitsSemantic()
+    {
+        var (bookManager, registry, _, recorder) = Create();
+        Bootstrap(bookManager, rptSeq: 10);
+
+        SendOrder(bookManager, rptSeq: 13, orderId: 100);
+        SendTrade(bookManager, rptSeq: 16, tradeId: 1);
+
+        Assert.Equal(1, recorder.TradeCount);
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 14, ordersExpected: 0);
+        Assert.Equal(SymbolState.Stale, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, bookManager.SnapshotsRejectedTooOld);
+
+        bookManager.BeginChunkedSnapshotForTest(SecurityId, lastRptSeq: 15, ordersExpected: 0);
+        Assert.Equal(SymbolState.Healthy, registry.GetState(SecurityId, SymbolGapKind.Mbo));
+        Assert.Equal(1, recorder.TradeCount);
+    }
+
     private static (BookManager Manager, SymbolStateRegistry Registry, StaleMboBuffer Buffer, Recorder Recorder) Create()
+        => Create(new StaleMboBuffer(NullLogger.Instance));
+
+    private static (BookManager Manager, SymbolStateRegistry Registry, StaleMboBuffer Buffer, Recorder Recorder) Create(
+        StaleMboBuffer buffer)
     {
         var registry = new SymbolStateRegistry(NullLogger.Instance);
-        var buffer = new StaleMboBuffer(NullLogger.Instance);
         var recorder = new Recorder();
         var manager = new BookManager(
             eventHandler: recorder,

--- a/tests/B3.Umdf.Book.Tests/PerSymbolEndToEndTests.cs
+++ b/tests/B3.Umdf.Book.Tests/PerSymbolEndToEndTests.cs
@@ -275,8 +275,12 @@ public class PerSymbolEndToEndTests
         var book = bm.GetOrCreateBook(sec);
         var entry = new B3.Umdf.Book.OrderBookEntry
         {
-            OrderId = 7777, Price = 14721000, Quantity = 5, EnteringFirm = 0,
-            SecurityId = sec, Side = B3.Umdf.Book.BookSideType.Bid,
+            OrderId = 7777,
+            Price = 14721000,
+            Quantity = 5,
+            EnteringFirm = 0,
+            SecurityId = sec,
+            Side = B3.Umdf.Book.BookSideType.Bid,
         };
         book.GetSide(B3.Umdf.Book.BookSideType.Bid).Add(in entry);
         Assert.Equal(1, book.Bids.OrderCount);
@@ -342,9 +346,8 @@ public class PerSymbolEndToEndTests
 
         long skippedBefore = bm.SnapshotsSkippedHealthyAhead;
 
-        // Snapshot at 109 (= MinHealRptSeq): should NOT be skipped (symbol is Stale),
-        // and should be accepted by the heal path.
-        bm.BeginSnapshotHeader(sec, lastRptSeq: 109, hasRptSeq: true, ordersExpected: 0);
+        // Snapshot covers the registry-only observation and must not be skipped.
+        bm.BeginSnapshotHeader(sec, lastRptSeq: 110, hasRptSeq: true, ordersExpected: 0);
 
         Assert.Equal(skippedBefore, bm.SnapshotsSkippedHealthyAhead); // not skipped
         Assert.Equal(SymbolState.Healthy, reg.GetState(sec, SymbolGapKind.Mbo));
@@ -426,8 +429,8 @@ public class PerSymbolEndToEndTests
         Assert.Equal(3, snap.TotalSymbols);
 
         // Heal 500: snap drops to 1.
-        reg.Observe(500, SymbolGapKind.Mbo, 200); // first observation already buffered above
-        bm.RecordSnapshotHeader(500, lastRptSeq: 199);
+        reg.Observe(500, SymbolGapKind.Mbo, 200); // duplicate observation
+        bm.RecordSnapshotHeader(500, lastRptSeq: 200);
         bm.HealAfterSnapshotForTest(500);
         Assert.Equal(1, reg.GetAggregateSnapshot().TotalStaleSymbols);
     }

--- a/tests/B3.Umdf.Book.Tests/SnapshotApplierCompletionStatesTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SnapshotApplierCompletionStatesTests.cs
@@ -97,14 +97,14 @@ public class SnapshotApplierCompletionStatesTests
         Assert.Equal(0, bm.Books[4004].Bids.OrderCount); // staging only — book untouched.
 
         // Replacement header: old staging discarded.
-        bm.BeginChunkedSnapshotForTest(4004, lastRptSeq: 9, ordersExpected: 2);
+        bm.BeginChunkedSnapshotForTest(4004, lastRptSeq: 10, ordersExpected: 2);
         bm.StageSnapshotEntryForTest(4004, BookSideType.Bid, orderId: 92, price: 101, quantity: 2);
         bm.StageSnapshotEntryForTest(4004, BookSideType.Ask, orderId: 93, price: 105, quantity: 3);
 
         Assert.Equal(1, bm.SnapshotsReplacedHeader);
         Assert.Equal(1, bm.SnapshotsAbandoned); // legacy parallel counter still ticks.
         Assert.Equal(1, bm.SnapshotsCompleted);
-        Assert.Equal(9u, bm.Books[4004].LastRptSeq);
+        Assert.Equal(10u, bm.Books[4004].LastRptSeq);
         Assert.Equal(1, bm.Books[4004].Bids.OrderCount);
         Assert.Equal(1, bm.Books[4004].Asks.OrderCount);
         // Discarded predecessor's order 91 must not appear.
@@ -122,14 +122,14 @@ public class SnapshotApplierCompletionStatesTests
             reg.Observe(securityId: 5005, SymbolGapKind.Mbo, r);
 
         // First, heal the book to a known baseline.
-        bm.BeginChunkedSnapshotForTest(5005, lastRptSeq: 10, ordersExpected: 1);
+        bm.BeginChunkedSnapshotForTest(5005, lastRptSeq: 20, ordersExpected: 1);
         bm.StageSnapshotEntryForTest(5005, BookSideType.Bid, orderId: 1, price: 99, quantity: 7);
         Assert.Equal(1, bm.SnapshotsCompleted);
-        Assert.Equal(10u, bm.Books[5005].LastRptSeq);
+        Assert.Equal(20u, bm.Books[5005].LastRptSeq);
         Assert.Equal(1, bm.Books[5005].Bids.OrderCount);
 
         // Begin a second assembly and stage a partial chunk.
-        bm.BeginChunkedSnapshotForTest(5005, lastRptSeq: 18, ordersExpected: 5);
+        bm.BeginChunkedSnapshotForTest(5005, lastRptSeq: 20, ordersExpected: 5);
         bm.StageSnapshotEntryForTest(5005, BookSideType.Bid, orderId: 2, price: 100, quantity: 3);
         bm.StageSnapshotEntryForTest(5005, BookSideType.Ask, orderId: 3, price: 110, quantity: 4);
 
@@ -139,7 +139,7 @@ public class SnapshotApplierCompletionStatesTests
         Assert.True(aborted);
         Assert.Equal(1, bm.SnapshotsAborted);
         // Live book MUST be untouched: still the post-first-snapshot baseline.
-        Assert.Equal(10u, bm.Books[5005].LastRptSeq);
+        Assert.Equal(20u, bm.Books[5005].LastRptSeq);
         Assert.Equal(1, bm.Books[5005].Bids.OrderCount);
         Assert.Equal(0, bm.Books[5005].Asks.OrderCount);
         Assert.True(bm.Books[5005].Bids.TryGetOrder(1, out _));

--- a/tests/B3.Umdf.Book.Tests/SymbolStateRegistryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SymbolStateRegistryTests.cs
@@ -111,11 +111,11 @@ public class SymbolStateRegistryTests
         r.Observe(1, SymbolGapKind.Mbo, 110);  // gap → Stale
         r.Observe(1, SymbolGapKind.Mbo, 115);  // buffered, advances high-water
 
-        var heal = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 112);
+        var heal = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 114);
 
         Assert.True(heal.TransitionedToHealthy);
-        Assert.Equal(112u, heal.SnapshotRptSeq);
-        Assert.Equal(113u, heal.DrainFrom);
+        Assert.Equal(114u, heal.SnapshotRptSeq);
+        Assert.Equal(115u, heal.DrainFrom);
         Assert.Equal(115u, heal.DrainTo);
         Assert.False(r.IsAnyStale(1));
     }
@@ -154,10 +154,10 @@ public class SymbolStateRegistryTests
         Assert.Equal(2, r.LaggingSnapshotCount);
 
         // A snapshot fresh enough to bridge the gap is accepted normally.
-        var fresh = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 150);
+        var fresh = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 199);
         Assert.True(fresh.Accepted);
         Assert.True(fresh.TransitionedToHealthy);
-        Assert.Equal(151u, fresh.DrainFrom);
+        Assert.Equal(200u, fresh.DrainFrom);
         Assert.Equal(200u, fresh.DrainTo);
     }
 
@@ -207,15 +207,14 @@ public class SymbolStateRegistryTests
         var r = NewRegistry();
         r.HealFromSnapshot(1, SymbolGapKind.Mbo, 100);
         r.Observe(1, SymbolGapKind.Mbo, 105);  // gap → Stale, MinHealRptSeq=104
-        r.Observe(1, SymbolGapKind.Mbo, 108);
+        r.Observe(1, SymbolGapKind.Mbo, 108); // later gap tightens MinHealRptSeq=107
 
-        // Snapshot at exactly MinHealRptSeq (104): drain [105, 108] aligns with first
-        // buffered entry. Accepted.
-        var heal = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 104);
+        // Snapshot at the tightened MinHealRptSeq (107) is accepted.
+        var heal = r.HealFromSnapshot(1, SymbolGapKind.Mbo, snapshotRptSeq: 107);
 
         Assert.True(heal.Accepted);
         Assert.True(heal.TransitionedToHealthy);
-        Assert.Equal(105u, heal.DrainFrom);
+        Assert.Equal(108u, heal.DrainFrom);
         Assert.Equal(108u, heal.DrainTo);
     }
 


### PR DESCRIPTION
## Summary
- keep one global per-security `ObservedRptSeq`, so any cross-template gap still conservatively forces MBO stale
- route Trade_53, ForwardTrade_54, ExecutionSummary_55, and TradeBust_57 through a dedicated exactly-once trade-semantic watermark while MBO recovery waits for a snapshot
- suppress trade semantics by the emitted semantic watermark rather than snapshot/global observation, preserving never-emitted delayed trades
- tighten `MinHeal` on later stale gaps and prove every replay sequence is retained MBO or delivered non-MBO before swapping a snapshot
- validate replay coverage through the global observation watermark, preventing cold-start non-MBO traffic from authorizing a snapshot with an unknown MBO window
- keep `OrderBook.LastRptSeq` monotonic so delayed trade-family semantics cannot regress the watermark published by `SnapshotEmitter`
- expose replay-gap snapshot rejections through metrics and operator stats

## Semantics
- Trade_53 and ForwardTrade_54 remain reportability-filtered trade/tape/candle inputs
- ExecutionSummary_55 is a self-contained execution callback
- TradeBust_57 remains an irreplaceable best-effort correction against retained trade state
- Order_50/DeleteOrder_51/MassDelete_52 remain buffered while MBO is stale
- snapshot healing now requires complete global sequence coverage through `ObservedRptSeq`; non-MBO observations prove only their own sequence positions
- the published book snapshot watermark never moves backward when a never-emitted delayed semantic message is accepted

## Tests
- focused issue #80 tests: 12 passed in Debug and Release
- full book tests: 265 passed in Debug and Release
- full solution: 780 passed in Debug and Release
- changed-file `dotnet format --verify-no-changes` passed

Closes #80