### PR TITLE
fix(transport): recover from oversized snapshot datagrams

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -116,6 +116,7 @@ Optional channel fields:
 - `sourceAddress` — enables source-specific multicast (SSM), receiving only from the given sender IP.
 - `localAddress` — selects the local NIC/IP used for the multicast membership join (ASM or SSM).
 - `receiveBufferBytes` — per-socket UDP receive buffer size. When omitted, the consumer picks per-channel-type defaults: **16 MiB** for `IncrementalA`/`IncrementalB`, **8 MiB** for `SnapshotRecovery`, **2 MiB** for `InstrumentDefinition`. All values are still capped by `net.core.rmem_max`.
+- `maxDatagramBytes` — maximum size of one atomic UDP payload, distinct from the kernel queue sized by `receiveBufferBytes`. The default is the full IPv4 UDP payload maximum (**65,507 bytes**) for `SnapshotRecovery`, and **9,216 bytes** for other channel types. Datagrams above an explicitly lower cap are dropped whole and counted; they are never passed downstream partially. The consumer does not reassemble application-level fragments because the UMDF sender protocol defines each received UDP datagram as an atomic packet.
 
 Example — unicast (Docker Compose bridge):
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -241,6 +241,12 @@ automatically.
 | `b3.umdf.feed.last_packet_age` | Gauge | `group` | Milliseconds since last packet (stale feed) |
 | `b3.umdf.feed.queue_depth` | Gauge | `group` | Pending packets in feed queue |
 
+### Transport
+
+| Metric | Type | Tags | Description |
+|--------|------|------|-------------|
+| `b3.umdf.transport.datagrams.truncated` | Counter | `group`, `channel` | UDP datagrams dropped whole after exceeding `maxDatagramBytes`; any increase indicates sender/config mismatch |
+
 ### Book
 
 | Metric | Type | Tags | Description |

--- a/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
+++ b/src/B3.Umdf.ConsoleApp/MetricsBinder.cs
@@ -221,6 +221,10 @@ static class MetricsBinder
                 () => PerSource(s => s.BatchedDatagrams),
                 unit: "{datagrams}", description: "Datagrams received via recvmmsg batched receive (avg batch = datagrams / syscalls)");
 
+            Meter.CreateObservableCounter("b3.umdf.transport.datagrams.truncated",
+                () => PerSource(s => s.TruncatedDatagramCount),
+                unit: "{datagrams}", description: "UDP datagrams dropped because they exceeded the configured per-datagram receive cap");
+
             Meter.CreateObservableCounter("b3.umdf.transport.membership.joins",
                 () => PerSource(s => s.MembershipJoins),
                 unit: "{events}", description: "IGMP joins on multicast sources (initial + recovery rejoins)");

--- a/src/B3.Umdf.Transport/ChannelConfig.cs
+++ b/src/B3.Umdf.Transport/ChannelConfig.cs
@@ -12,4 +12,5 @@ public sealed record ChannelConfig(
     int ReceiveBufferBytes = 16 * 1024 * 1024,
     int ChannelGroup = 0,
     int ReceiveSocketCount = 1,
-    TransportKind Transport = TransportKind.Multicast);
+    TransportKind Transport = TransportKind.Multicast,
+    int MaxDatagramBytes = 0);

--- a/src/B3.Umdf.Transport/MulticastFeedConfig.cs
+++ b/src/B3.Umdf.Transport/MulticastFeedConfig.cs
@@ -44,7 +44,8 @@ public sealed class MulticastFeedConfig
                     ReceiveBufferBytes: ch.ReceiveBufferBytes ?? DefaultReceiveBufferBytesFor(ch.Type),
                     ChannelGroup: g,
                     ReceiveSocketCount: Math.Max(1, ch.ReceiveSocketCount ?? 1),
-                    Transport: ParseTransport(ch.Transport)));
+                    Transport: ParseTransport(ch.Transport),
+                    MaxDatagramBytes: ch.MaxDatagramBytes ?? DefaultMaxDatagramBytesFor(ch.Type)));
             }
         }
         return configs;
@@ -69,7 +70,7 @@ public sealed class MulticastFeedConfig
     /// <summary>
     /// Builds flat list of publish routes from all groups for PCAP replay to multicast.
     /// Reuses the same JSON topology as live consume mode, but ignores receive-only fields
-    /// such as sourceAddress and receiveBufferBytes.
+    /// such as sourceAddress, receiveBufferBytes, and maxDatagramBytes.
     /// </summary>
     public List<MulticastPublishChannelConfig> ToPublishChannelConfigs()
     {
@@ -112,6 +113,17 @@ public sealed class MulticastFeedConfig
         ChannelType.InstrumentDefinition  =>  2 * 1024 * 1024,  //  2 MiB — low-rate, periodic, idempotent
         _                                 =>  4 * 1024 * 1024,
     };
+
+    /// <summary>
+    /// Per-datagram application buffer sizing. Snapshot recovery accepts the full
+    /// IPv4 UDP payload range because a snapshot is one atomic UDP datagram and
+    /// cannot be reconstructed after kernel truncation. Other UMDF channels retain
+    /// the jumbo-frame-sized cap to avoid inflating hot-path packet leases.
+    /// </summary>
+    public static int DefaultMaxDatagramBytesFor(ChannelType type) =>
+        type == ChannelType.SnapshotRecovery
+            ? MulticastPacketSource.MaximumUdpPayloadBytes
+            : MulticastPacketSource.JumboDatagramBytes;
 }
 
 public sealed class ChannelGroupConfig
@@ -145,6 +157,13 @@ public sealed class ChannelEntryConfig
 
     [JsonPropertyName("receiveBufferBytes")]
     public int? ReceiveBufferBytes { get; set; }
+
+    /// <summary>
+    /// Maximum bytes accepted in one UDP datagram. This is distinct from
+    /// <see cref="ReceiveBufferBytes"/>, which sizes the kernel's queued-data buffer.
+    /// </summary>
+    [JsonPropertyName("maxDatagramBytes")]
+    public int? MaxDatagramBytes { get; set; }
 
     /// <summary>
     /// Number of UDP sockets to bind for this channel using SO_REUSEPORT (Linux).

--- a/src/B3.Umdf.Transport/MulticastPacketSource.cs
+++ b/src/B3.Umdf.Transport/MulticastPacketSource.cs
@@ -19,6 +19,7 @@ public sealed class MulticastPacketSource : IPacketSource
     private readonly int _channelGroup;
     private readonly TransportKind _transport;
     private readonly int _maxDatagramBytes;
+    private readonly int _receiveCapacityBytes;
     private readonly bool _copyBatchPayloads;
     private readonly ILogger _logger;
 
@@ -56,9 +57,8 @@ public sealed class MulticastPacketSource : IPacketSource
     /// <summary>Count of successful multicast membership leaves.</summary>
     public long MembershipLeaves => Volatile.Read(ref _membershipLeaves);
     /// <summary>
-    /// Number of datagrams the kernel reported as truncated to the per-datagram buffer
-    /// (MSG_TRUNC in the recvmmsg path). These are dropped — never delivered downstream —
-    /// because a partial UDP datagram cannot be parsed safely.
+    /// Number of datagrams dropped because they exceeded <see cref="MaxDatagramBytes"/>
+    /// or the kernel reported MSG_TRUNC. They are never delivered partially downstream.
     /// </summary>
     public long TruncatedDatagramCount => Volatile.Read(ref _truncatedDatagramCount);
 
@@ -119,6 +119,11 @@ public sealed class MulticastPacketSource : IPacketSource
         _channelGroup = config.ChannelGroup;
         _transport = config.Transport;
         _maxDatagramBytes = maxDatagramBytes;
+        // A one-byte lookahead distinguishes a valid datagram exactly at the configured
+        // cap from an oversized datagram without relying on MSG_TRUNC propagation.
+        _receiveCapacityBytes = maxDatagramBytes < MaximumUdpPayloadBytes
+            ? maxDatagramBytes + 1
+            : MaximumUdpPayloadBytes;
         // Large receive slots remain scratch buffers. Copying only the bytes actually
         // received prevents every in-flight snapshot from retaining a 64 KiB pinned
         // array while preserving the existing zero-copy path for hot UMDF channels.
@@ -338,15 +343,15 @@ public sealed class MulticastPacketSource : IPacketSource
     {
         while (true)
         {
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(_maxDatagramBytes);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_receiveCapacityBytes);
             try
             {
                 var result = await _socket.ReceiveMessageFromAsync(
-                    buffer.AsMemory(0, _maxDatagramBytes),
+                    buffer.AsMemory(0, _receiveCapacityBytes),
                     SocketFlags.None,
                     new IPEndPoint(IPAddress.Any, 0),
                     ct);
-                if (IsKernelTruncated((int)result.SocketFlags, result.ReceivedBytes, _maxDatagramBytes))
+                if (IsOversizedOrTruncated((int)result.SocketFlags, result.ReceivedBytes, _maxDatagramBytes))
                 {
                     long tn = Interlocked.Increment(ref _truncatedDatagramCount);
                     LogTruncatedRateLimited(tn, result.ReceivedBytes);
@@ -374,14 +379,14 @@ public sealed class MulticastPacketSource : IPacketSource
     {
         while (true)
         {
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(_maxDatagramBytes);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_receiveCapacityBytes);
             try
             {
                 SocketFlags flags = SocketFlags.None;
                 EndPoint remote = new IPEndPoint(IPAddress.Any, 0);
                 int received = _socket.ReceiveMessageFrom(
-                    buffer, 0, _maxDatagramBytes, ref flags, ref remote, out _);
-                if (IsKernelTruncated((int)flags, received, _maxDatagramBytes))
+                    buffer, 0, _receiveCapacityBytes, ref flags, ref remote, out _);
+                if (IsOversizedOrTruncated((int)flags, received, _maxDatagramBytes))
                 {
                     long tn = Interlocked.Increment(ref _truncatedDatagramCount);
                     LogTruncatedRateLimited(tn, received);
@@ -457,12 +462,11 @@ public sealed class MulticastPacketSource : IPacketSource
             int received = (int)mmsghdrs[i].msg_len;
             int msgFlags = mmsghdrs[i].msg_hdr.msg_flags;
 
-            if (IsKernelTruncated(msgFlags, received, _maxDatagramBytes))
+            if (IsOversizedOrTruncated(msgFlags, received, _maxDatagramBytes))
             {
-                // Datagram exceeded our per-datagram buffer — kernel truncated it.
-                // Dropping is the only safe option: a partial UMDF SBE message would
-                // mis-parse downstream. Reuse the buffer in-place (no rent/return)
-                // since no lease is created and the iovec is still bound to it.
+                // Datagram exceeded the configured cap or the kernel truncated it.
+                // Drop the whole datagram: partial UMDF data would mis-parse downstream.
+                // Reuse the buffer in-place since no lease is created.
                 long tn = Interlocked.Increment(ref _truncatedDatagramCount);
                 LogTruncatedRateLimited(tn, received);
                 continue;
@@ -511,34 +515,25 @@ public sealed class MulticastPacketSource : IPacketSource
     }
 
     /// <summary>
-    /// True if the kernel signalled that the datagram was truncated to the per-datagram buffer.
-    /// Prefers the direct MSG_TRUNC flag (<see cref="LinuxNative.MSG_TRUNC"/>) when set in
-    /// <paramref name="msgFlags"/>; otherwise falls back to a heuristic on older kernels /
-    /// libc combinations that don't propagate per-message flags through recvmmsg: the
-    /// returned length being exactly a configured sub-maximum cap is suspect.
-    /// Exposed as internal so the truncation policy can be unit-tested with synthetic flags.
+    /// True when a datagram exceeded the configured policy cap or the kernel explicitly
+    /// reported truncation. Receive buffers use one byte of lookahead below the protocol
+    /// maximum, so a length exactly equal to <paramref name="maxDatagramBytes"/> is valid.
     /// </summary>
-    internal static bool IsKernelTruncated(int msgFlags, int receivedLen, int bufferCap)
-    {
-        if ((msgFlags & LinuxNative.MSG_TRUNC) != 0) return true;
-        // At the IPv4 UDP protocol maximum, equality is a valid complete datagram;
-        // no larger payload can exist. For smaller configured caps, equality remains
-        // a conservative fallback for platforms that fail to surface MSG_TRUNC.
-        return bufferCap < MaximumUdpPayloadBytes && receivedLen >= bufferCap;
-    }
+    internal static bool IsOversizedOrTruncated(int msgFlags, int receivedLen, int maxDatagramBytes) =>
+        (msgFlags & LinuxNative.MSG_TRUNC) != 0 || receivedLen > maxDatagramBytes;
 
     private void LogTruncatedRateLimited(long counter, int receivedLen)
     {
         if (counter == 1 || (counter & 63) == 0)
             _logger.LogWarning(
-                "Dropped truncated UDP datagram on {ChannelType} (group {ChannelGroup}): kernel truncated to {ReceivedLen} bytes (maxDatagramBytes={Cap}); upstream sender exceeds the configured per-datagram cap (TruncatedDatagramCount={Count}).",
+                "Dropped oversized or truncated UDP datagram on {ChannelType} (group {ChannelGroup}): received {ReceivedLen} bytes (maxDatagramBytes={Cap}); upstream sender exceeds the configured per-datagram cap (TruncatedDatagramCount={Count}).",
                 _channelType, _channelGroup, receivedLen, _maxDatagramBytes, counter);
     }
 
     private void EnsureBatchStateInitialized()
     {
         if (_batchBufferPool is not null) return;
-        _batchBufferPool = new PinnedBufferPool(_maxDatagramBytes);
+        _batchBufferPool = new PinnedBufferPool(_receiveCapacityBytes);
         _batchIovecs = new LinuxNative.Iovec[MaxBatchSize];
         _batchMmsghdrs = new LinuxNative.Mmsghdr[MaxBatchSize];
         _batchPendingBuffers = new byte[MaxBatchSize][];
@@ -565,7 +560,7 @@ public sealed class MulticastPacketSource : IPacketSource
                     _batchIovecs[i].iov_base = (IntPtr)p;
                 }
             }
-            _batchIovecs[i].iov_len = (nuint)_maxDatagramBytes;
+            _batchIovecs[i].iov_len = (nuint)_receiveCapacityBytes;
         }
     }
 

--- a/src/B3.Umdf.Transport/MulticastPacketSource.cs
+++ b/src/B3.Umdf.Transport/MulticastPacketSource.cs
@@ -10,15 +10,16 @@ namespace B3.Umdf.Transport;
 public sealed class MulticastPacketSource : IPacketSource
 {
     private const int SourceMembershipRequestSize = 12;
-    // UMDF over UDP datagrams are bounded by Ethernet MTU (~1500 bytes); 9 KiB jumbo is the realistic upper bound.
-    // Using 64 KiB per rent multiplied by hundreds of thousands of in-flight pooled buffers caused OOM on bursts.
-    private const int MaxDatagramSize = 9 * 1024;
+    public const int JumboDatagramBytes = 9 * 1024;
+    public const int MaximumUdpPayloadBytes = 65_507;
     public const int MaxBatchSize = 64;
 
     private readonly Socket _socket;
     private readonly ChannelType _channelType;
     private readonly int _channelGroup;
     private readonly TransportKind _transport;
+    private readonly int _maxDatagramBytes;
+    private readonly bool _copyBatchPayloads;
     private readonly ILogger _logger;
 
     // Membership info retained so we can leave and rejoin the multicast group on demand
@@ -55,16 +56,16 @@ public sealed class MulticastPacketSource : IPacketSource
     /// <summary>Count of successful multicast membership leaves.</summary>
     public long MembershipLeaves => Volatile.Read(ref _membershipLeaves);
     /// <summary>
-    /// Number of datagrams the kernel reported as truncated to the receive buffer
+    /// Number of datagrams the kernel reported as truncated to the per-datagram buffer
     /// (MSG_TRUNC in the recvmmsg path). These are dropped — never delivered downstream —
-    /// so the count is the operator's only visibility into "datagram bigger than
-    /// <see cref="MaxDatagramSize"/>" events.
+    /// because a partial UDP datagram cannot be parsed safely.
     /// </summary>
     public long TruncatedDatagramCount => Volatile.Read(ref _truncatedDatagramCount);
 
     public ChannelType ChannelType => _channelType;
     public int ChannelGroup => _channelGroup;
     public TransportKind Transport => _transport;
+    public int MaxDatagramBytes => _maxDatagramBytes;
     public bool IsJoined { get { lock (_membershipLock) return _isJoined; } }
 
     // Test-only: exposes whether the recvmmsg batch state (POH buffer pool +
@@ -88,6 +89,11 @@ public sealed class MulticastPacketSource : IPacketSource
     public MulticastPacketSource(ChannelConfig config, ILogger<MulticastPacketSource>? logger = null)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(config.ReceiveBufferBytes, 1);
+        int maxDatagramBytes = config.MaxDatagramBytes == 0
+            ? MulticastFeedConfig.DefaultMaxDatagramBytesFor(config.Type)
+            : config.MaxDatagramBytes;
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxDatagramBytes, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maxDatagramBytes, MaximumUdpPayloadBytes);
         ValidateIPv4(config.MulticastGroup, nameof(config.MulticastGroup));
         if (config.SourceAddress is not null)
             ValidateIPv4(config.SourceAddress, nameof(config.SourceAddress));
@@ -112,6 +118,11 @@ public sealed class MulticastPacketSource : IPacketSource
         _channelType = config.Type;
         _channelGroup = config.ChannelGroup;
         _transport = config.Transport;
+        _maxDatagramBytes = maxDatagramBytes;
+        // Large receive slots remain scratch buffers. Copying only the bytes actually
+        // received prevents every in-flight snapshot from retaining a 64 KiB pinned
+        // array while preserving the existing zero-copy path for hot UMDF channels.
+        _copyBatchPayloads = maxDatagramBytes > JumboDatagramBytes;
         _multicastGroup = config.MulticastGroup;
         _port = config.Port;
         _localAddress = config.LocalAddress;
@@ -182,8 +193,8 @@ public sealed class MulticastPacketSource : IPacketSource
             // directly. _isJoined is set true so callers treat the source as "ready to receive";
             // Leave/Rejoin become no-ops (see those methods).
             _logger.LogInformation(
-                "Listening unicast UDP on {Bind}:{Port} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes})",
-                bindAddress, config.Port, _channelType, _channelGroup, actualReceiveBufferBytes);
+                "Listening unicast UDP on {Bind}:{Port} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes}, maxDatagram={MaxDatagramBytes})",
+                bindAddress, config.Port, _channelType, _channelGroup, actualReceiveBufferBytes, _maxDatagramBytes);
         }
         else if (config.SourceAddress is not null)
         {
@@ -194,8 +205,8 @@ public sealed class MulticastPacketSource : IPacketSource
                 BuildSourceMembershipRequest(config.MulticastGroup, localAddress, config.SourceAddress));
 
             _logger.LogInformation(
-                "Joined SSM group {Group}:{Port} source {SourceAddress} via {LocalAddress} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes})",
-                config.MulticastGroup, config.Port, config.SourceAddress, localAddress, _channelType, _channelGroup, actualReceiveBufferBytes);
+                "Joined SSM group {Group}:{Port} source {SourceAddress} via {LocalAddress} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes}, maxDatagram={MaxDatagramBytes})",
+                config.MulticastGroup, config.Port, config.SourceAddress, localAddress, _channelType, _channelGroup, actualReceiveBufferBytes, _maxDatagramBytes);
         }
         else if (config.LocalAddress is not null)
         {
@@ -204,8 +215,8 @@ public sealed class MulticastPacketSource : IPacketSource
                 SocketOptionName.AddMembership,
                 new MulticastOption(config.MulticastGroup, config.LocalAddress));
             _logger.LogInformation(
-                "Joined multicast group {Group}:{Port} via {LocalAddress} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes})",
-                config.MulticastGroup, config.Port, config.LocalAddress, _channelType, _channelGroup, actualReceiveBufferBytes);
+                "Joined multicast group {Group}:{Port} via {LocalAddress} ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes}, maxDatagram={MaxDatagramBytes})",
+                config.MulticastGroup, config.Port, config.LocalAddress, _channelType, _channelGroup, actualReceiveBufferBytes, _maxDatagramBytes);
         }
         else
         {
@@ -214,8 +225,8 @@ public sealed class MulticastPacketSource : IPacketSource
                 SocketOptionName.AddMembership,
                 new MulticastOption(config.MulticastGroup));
             _logger.LogInformation(
-                "Joined multicast group {Group}:{Port} on any local interface ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes})",
-                config.MulticastGroup, config.Port, _channelType, _channelGroup, actualReceiveBufferBytes);
+                "Joined multicast group {Group}:{Port} on any local interface ({ChannelType}, group {ChannelGroup}, recvBuffer={ReceiveBufferBytes}, maxDatagram={MaxDatagramBytes})",
+                config.MulticastGroup, config.Port, _channelType, _channelGroup, actualReceiveBufferBytes, _maxDatagramBytes);
         }
         _isJoined = true;
         Interlocked.Increment(ref _membershipJoins);
@@ -325,22 +336,30 @@ public sealed class MulticastPacketSource : IPacketSource
 
     public async ValueTask<UmdfPacket> ReceiveAsync(CancellationToken ct = default)
     {
-        byte[] buffer = ArrayPool<byte>.Shared.Rent(MaxDatagramSize);
-        try
+        while (true)
         {
-            int received = await _socket.ReceiveAsync(buffer.AsMemory(), SocketFlags.None, ct);
-            var lease = new ArrayPoolPacketLease(buffer);
-            return UmdfPacket.CreateOwned(
-                new ReadOnlyMemory<byte>(buffer, 0, received),
-                _channelType,
-                _channelGroup,
-                Environment.TickCount64,
-                lease);
-        }
-        catch
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-            throw;
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_maxDatagramBytes);
+            try
+            {
+                var result = await _socket.ReceiveMessageFromAsync(
+                    buffer.AsMemory(0, _maxDatagramBytes),
+                    SocketFlags.None,
+                    new IPEndPoint(IPAddress.Any, 0),
+                    ct);
+                if (IsKernelTruncated((int)result.SocketFlags, result.ReceivedBytes, _maxDatagramBytes))
+                {
+                    long tn = Interlocked.Increment(ref _truncatedDatagramCount);
+                    LogTruncatedRateLimited(tn, result.ReceivedBytes);
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    continue;
+                }
+                return CreatePacket(buffer, result.ReceivedBytes, Environment.TickCount64);
+            }
+            catch
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+                throw;
+            }
         }
     }
 
@@ -353,22 +372,29 @@ public sealed class MulticastPacketSource : IPacketSource
     /// </summary>
     public UmdfPacket Receive()
     {
-        byte[] buffer = ArrayPool<byte>.Shared.Rent(MaxDatagramSize);
-        try
+        while (true)
         {
-            int received = _socket.Receive(buffer, 0, MaxDatagramSize, SocketFlags.None);
-            var lease = new ArrayPoolPacketLease(buffer);
-            return UmdfPacket.CreateOwned(
-                new ReadOnlyMemory<byte>(buffer, 0, received),
-                _channelType,
-                _channelGroup,
-                Environment.TickCount64,
-                lease);
-        }
-        catch
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-            throw;
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(_maxDatagramBytes);
+            try
+            {
+                SocketFlags flags = SocketFlags.None;
+                EndPoint remote = new IPEndPoint(IPAddress.Any, 0);
+                int received = _socket.ReceiveMessageFrom(
+                    buffer, 0, _maxDatagramBytes, ref flags, ref remote, out _);
+                if (IsKernelTruncated((int)flags, received, _maxDatagramBytes))
+                {
+                    long tn = Interlocked.Increment(ref _truncatedDatagramCount);
+                    LogTruncatedRateLimited(tn, received);
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    continue;
+                }
+                return CreatePacket(buffer, received, Environment.TickCount64);
+            }
+            catch
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+                throw;
+            }
         }
     }
 
@@ -431,9 +457,9 @@ public sealed class MulticastPacketSource : IPacketSource
             int received = (int)mmsghdrs[i].msg_len;
             int msgFlags = mmsghdrs[i].msg_hdr.msg_flags;
 
-            if (IsKernelTruncated(msgFlags, received, MaxDatagramSize))
+            if (IsKernelTruncated(msgFlags, received, _maxDatagramBytes))
             {
-                // Datagram exceeded our receive buffer — kernel truncated it.
+                // Datagram exceeded our per-datagram buffer — kernel truncated it.
                 // Dropping is the only safe option: a partial UMDF SBE message would
                 // mis-parse downstream. Reuse the buffer in-place (no rent/return)
                 // since no lease is created and the iovec is still bound to it.
@@ -442,23 +468,37 @@ public sealed class MulticastPacketSource : IPacketSource
                 continue;
             }
 
-            var lease = new PinnedPoolPacketLease(buf, pool);
-            destination[delivered++] = UmdfPacket.CreateOwned(
-                new ReadOnlyMemory<byte>(buf, 0, received),
-                _channelType,
-                _channelGroup,
-                ticks,
-                lease);
-
-            // Refill the slot for the next syscall: rent a fresh buffer and rebind iovec.
-            // Address is stable for POH arrays, so we capture it once via fixed and store.
-            var newBuf = pool.Rent();
-            pending[i] = newBuf;
-            unsafe
+            if (_copyBatchPayloads)
             {
-                fixed (byte* p = newBuf)
+                byte[] payload = ArrayPool<byte>.Shared.Rent(received);
+                buf.AsSpan(0, received).CopyTo(payload);
+                destination[delivered++] = UmdfPacket.CreateOwned(
+                    new ReadOnlyMemory<byte>(payload, 0, received),
+                    _channelType,
+                    _channelGroup,
+                    ticks,
+                    new ArrayPoolPacketLease(payload));
+            }
+            else
+            {
+                var lease = new PinnedPoolPacketLease(buf, pool);
+                destination[delivered++] = UmdfPacket.CreateOwned(
+                    new ReadOnlyMemory<byte>(buf, 0, received),
+                    _channelType,
+                    _channelGroup,
+                    ticks,
+                    lease);
+
+                // Refill the slot for the next syscall: rent a fresh buffer and rebind iovec.
+                // Address is stable for POH arrays, so we capture it once via fixed and store.
+                var newBuf = pool.Rent();
+                pending[i] = newBuf;
+                unsafe
                 {
-                    iovecs[i].iov_base = (IntPtr)p;
+                    fixed (byte* p = newBuf)
+                    {
+                        iovecs[i].iov_base = (IntPtr)p;
+                    }
                 }
             }
         }
@@ -471,34 +511,34 @@ public sealed class MulticastPacketSource : IPacketSource
     }
 
     /// <summary>
-    /// True if the kernel signalled that the datagram was truncated to the receive buffer.
+    /// True if the kernel signalled that the datagram was truncated to the per-datagram buffer.
     /// Prefers the direct MSG_TRUNC flag (<see cref="LinuxNative.MSG_TRUNC"/>) when set in
     /// <paramref name="msgFlags"/>; otherwise falls back to a heuristic on older kernels /
     /// libc combinations that don't propagate per-message flags through recvmmsg: the
-    /// returned length being exactly the buffer cap is suspect for the UMDF workload
-    /// (genuine UMDF datagrams are bounded by Ethernet MTU well below 9 KiB).
+    /// returned length being exactly a configured sub-maximum cap is suspect.
     /// Exposed as internal so the truncation policy can be unit-tested with synthetic flags.
     /// </summary>
     internal static bool IsKernelTruncated(int msgFlags, int receivedLen, int bufferCap)
     {
         if ((msgFlags & LinuxNative.MSG_TRUNC) != 0) return true;
-        // Heuristic fallback: a datagram exactly filling the cap is treated as suspect.
-        // For UMDF (max payload << 9 KiB) this never triggers in steady state.
-        return receivedLen >= bufferCap;
+        // At the IPv4 UDP protocol maximum, equality is a valid complete datagram;
+        // no larger payload can exist. For smaller configured caps, equality remains
+        // a conservative fallback for platforms that fail to surface MSG_TRUNC.
+        return bufferCap < MaximumUdpPayloadBytes && receivedLen >= bufferCap;
     }
 
     private void LogTruncatedRateLimited(long counter, int receivedLen)
     {
         if (counter == 1 || (counter & 63) == 0)
             _logger.LogWarning(
-                "Dropped truncated UDP datagram on {ChannelType} (group {ChannelGroup}): kernel truncated to {ReceivedLen} bytes (cap {Cap}); upstream sender exceeds the receive buffer (TruncatedDatagramCount={Count}).",
-                _channelType, _channelGroup, receivedLen, MaxDatagramSize, counter);
+                "Dropped truncated UDP datagram on {ChannelType} (group {ChannelGroup}): kernel truncated to {ReceivedLen} bytes (maxDatagramBytes={Cap}); upstream sender exceeds the configured per-datagram cap (TruncatedDatagramCount={Count}).",
+                _channelType, _channelGroup, receivedLen, _maxDatagramBytes, counter);
     }
 
     private void EnsureBatchStateInitialized()
     {
         if (_batchBufferPool is not null) return;
-        _batchBufferPool = new PinnedBufferPool(MaxDatagramSize);
+        _batchBufferPool = new PinnedBufferPool(_maxDatagramBytes);
         _batchIovecs = new LinuxNative.Iovec[MaxBatchSize];
         _batchMmsghdrs = new LinuxNative.Mmsghdr[MaxBatchSize];
         _batchPendingBuffers = new byte[MaxBatchSize][];
@@ -525,8 +565,31 @@ public sealed class MulticastPacketSource : IPacketSource
                     _batchIovecs[i].iov_base = (IntPtr)p;
                 }
             }
-            _batchIovecs[i].iov_len = (nuint)MaxDatagramSize;
+            _batchIovecs[i].iov_len = (nuint)_maxDatagramBytes;
         }
+    }
+
+    private UmdfPacket CreatePacket(byte[] receiveBuffer, int received, long ticks)
+    {
+        if (!_copyBatchPayloads)
+        {
+            return UmdfPacket.CreateOwned(
+                new ReadOnlyMemory<byte>(receiveBuffer, 0, received),
+                _channelType,
+                _channelGroup,
+                ticks,
+                new ArrayPoolPacketLease(receiveBuffer));
+        }
+
+        byte[] payload = ArrayPool<byte>.Shared.Rent(received);
+        receiveBuffer.AsSpan(0, received).CopyTo(payload);
+        ArrayPool<byte>.Shared.Return(receiveBuffer);
+        return UmdfPacket.CreateOwned(
+            new ReadOnlyMemory<byte>(payload, 0, received),
+            _channelType,
+            _channelGroup,
+            ticks,
+            new ArrayPoolPacketLease(payload));
     }
 
     internal static byte[] BuildSourceMembershipRequest(IPAddress multicastGroup, IPAddress localAddress, IPAddress sourceAddress)

--- a/tests/B3.Umdf.Server.Tests/PerSymbolFanoutGateTests.cs
+++ b/tests/B3.Umdf.Server.Tests/PerSymbolFanoutGateTests.cs
@@ -100,6 +100,33 @@ public class PerSymbolFanoutGateTests
     }
 
     [Fact]
+    public void Gate_ValidSnapshotsAfterTransientRecoveryLoss_ReleaseSuppression()
+    {
+        var (registry, _, gh) = NewWiring();
+        for (ulong securityId = 1; securityId <= 3; securityId++)
+            registry.HealFromSnapshot(securityId, SymbolGapKind.Mbo, 100);
+
+        var gate = new PerSymbolFanoutGate(registry, gh, highRatio: 0.50, lowRatio: 0.0);
+        for (ulong securityId = 1; securityId <= 3; securityId++)
+            registry.Observe(securityId, SymbolGapKind.Mbo, 110);
+
+        gate.Evaluate();
+        Assert.True(gate.IsEngaged);
+        Assert.True(gh.IsFanoutSuppressed);
+
+        // Lost/truncated snapshot rotations do not mutate the registry. Once complete,
+        // valid snapshots resume, the normal Stale→Healthy path clears the ratio gate.
+        gate.Evaluate();
+        for (ulong securityId = 1; securityId <= 3; securityId++)
+            Assert.True(registry.HealFromSnapshot(securityId, SymbolGapKind.Mbo, 120).Accepted);
+
+        gate.Evaluate();
+        Assert.Equal(0, registry.StaleSymbolCount);
+        Assert.False(gate.IsEngaged);
+        Assert.False(gh.IsFanoutSuppressed);
+    }
+
+    [Fact]
     public void Gate_RejectsLowGreaterThanHigh()
     {
         var (registry, _, gh) = NewWiring();

--- a/tests/B3.Umdf.Transport.Tests/MulticastFeedConfigTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/MulticastFeedConfigTests.cs
@@ -54,11 +54,13 @@ public class MulticastFeedConfigTests
             Assert.Null(eqtIncrA.SourceAddress);
             Assert.Null(eqtIncrA.LocalAddress);
             Assert.Equal(16 * 1024 * 1024, eqtIncrA.ReceiveBufferBytes);
+            Assert.Equal(MulticastPacketSource.JumboDatagramBytes, eqtIncrA.MaxDatagramBytes);
             Assert.Equal(1, eqtIncrA.ReceiveSocketCount);
 
             // EQT SnapshotRecovery channel uses receiveSocketCount=4
             var eqtSnap = channelConfigs[3];
             Assert.Equal(ChannelType.SnapshotRecovery, eqtSnap.Type);
+            Assert.Equal(MulticastPacketSource.MaximumUdpPayloadBytes, eqtSnap.MaxDatagramBytes);
             Assert.Equal(4, eqtSnap.ReceiveSocketCount);
 
             // DRV group 1 with source filter and explicit local interface
@@ -73,10 +75,39 @@ public class MulticastFeedConfigTests
             // Group IDs
             Assert.Equal([0, 1], config.GetGroupIds());
         }
+
         finally
         {
             File.Delete(tmpFile);
         }
+    }
+
+    [Fact]
+    public void ToChannelConfigs_ParsesExplicitMaxDatagramBytes()
+    {
+        var config = new MulticastFeedConfig
+        {
+            ChannelGroups =
+            [
+                new ChannelGroupConfig
+                {
+                    Name = "G0",
+                    Channels =
+                    [
+                        new ChannelEntryConfig
+                        {
+                            ChannelId = 84,
+                            Type = ChannelType.SnapshotRecovery,
+                            MulticastGroup = "224.0.20.87",
+                            Port = 30087,
+                            MaxDatagramBytes = 32 * 1024,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        Assert.Equal(32 * 1024, Assert.Single(config.ToChannelConfigs()).MaxDatagramBytes);
     }
 
     [Fact]

--- a/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceTruncationTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceTruncationTests.cs
@@ -7,45 +7,110 @@ namespace B3.Umdf.Transport.Tests;
 
 /// <summary>
 /// Tests for the oversized-datagram detection path in <see cref="MulticastPacketSource"/>.
-/// Covers the in-process truncation-flag helper directly, plus a loopback-multicast
-/// integration test that exercises the kernel MSG_TRUNC path end-to-end.
+/// Covers the policy helper directly plus real loopback UDP delivery at and above
+/// a configured cap.
 /// </summary>
 public class MulticastPacketSourceTruncationTests
 {
     [Fact]
-    public void IsKernelTruncated_DirectMsgTruncFlag_ReturnsTrue()
+    public void IsOversizedOrTruncated_DirectMsgTruncFlag_ReturnsTrue()
     {
         // Direct flag: regardless of length vs cap, the kernel told us the datagram was truncated.
-        Assert.True(MulticastPacketSource.IsKernelTruncated(LinuxNative.MSG_TRUNC, receivedLen: 100, bufferCap: 9216));
+        Assert.True(MulticastPacketSource.IsOversizedOrTruncated(
+            LinuxNative.MSG_TRUNC, receivedLen: 100, maxDatagramBytes: 9216));
     }
 
     [Fact]
-    public void IsKernelTruncated_NoFlagAndShortDatagram_ReturnsFalse()
+    public void IsOversizedOrTruncated_NoFlagAndShortDatagram_ReturnsFalse()
     {
-        Assert.False(MulticastPacketSource.IsKernelTruncated(msgFlags: 0, receivedLen: 1500, bufferCap: 9216));
+        Assert.False(MulticastPacketSource.IsOversizedOrTruncated(
+            msgFlags: 0, receivedLen: 1500, maxDatagramBytes: 9216));
     }
 
     [Fact]
-    public void IsKernelTruncated_NoFlagButReceivedAtCap_HeuristicReturnsTrue()
+    public void IsOversizedOrTruncated_NoFlagAndExactlyAtCap_ReturnsFalse()
     {
-        // Heuristic fallback for kernels that don't propagate per-message MSG_TRUNC through recvmmsg.
-        Assert.True(MulticastPacketSource.IsKernelTruncated(msgFlags: 0, receivedLen: 9216, bufferCap: 9216));
+        Assert.False(MulticastPacketSource.IsOversizedOrTruncated(
+            msgFlags: 0, receivedLen: 9216, maxDatagramBytes: 9216));
     }
 
     [Fact]
-    public void IsKernelTruncated_OtherFlagsDoNotTrigger()
+    public void IsOversizedOrTruncated_NoFlagAndAboveCap_ReturnsTrue()
+    {
+        Assert.True(MulticastPacketSource.IsOversizedOrTruncated(
+            msgFlags: 0, receivedLen: 9217, maxDatagramBytes: 9216));
+    }
+
+    [Fact]
+    public void IsOversizedOrTruncated_OtherFlagsDoNotTrigger()
     {
         // Flags unrelated to truncation (e.g. MSG_WAITFORONE) must not be misread.
-        Assert.False(MulticastPacketSource.IsKernelTruncated(LinuxNative.MSG_WAITFORONE, receivedLen: 100, bufferCap: 9216));
+        Assert.False(MulticastPacketSource.IsOversizedOrTruncated(
+            LinuxNative.MSG_WAITFORONE, receivedLen: 100, maxDatagramBytes: 9216));
     }
 
     [Fact]
-    public void IsKernelTruncated_MaximumUdpPayloadAtCap_IsValid()
+    public void IsOversizedOrTruncated_MaximumUdpPayloadAtCap_IsValid()
     {
-        Assert.False(MulticastPacketSource.IsKernelTruncated(
+        Assert.False(MulticastPacketSource.IsOversizedOrTruncated(
             msgFlags: 0,
             receivedLen: MulticastPacketSource.MaximumUdpPayloadBytes,
-            bufferCap: MulticastPacketSource.MaximumUdpPayloadBytes));
+            maxDatagramBytes: MulticastPacketSource.MaximumUdpPayloadBytes));
+    }
+
+    [Fact]
+    public void ReceiveBatch_ExactConfiguredCap_RealSocketDeliversIntact()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        const int cap = 1024;
+        int port = GetEphemeralPort();
+        using var src = NewSource(ChannelType.IncrementalA, cap, port);
+        using var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        var expected = Enumerable.Range(0, cap).Select(i => (byte)(i % 251)).ToArray();
+        sender.SendTo(expected, new IPEndPoint(IPAddress.Loopback, port));
+
+        var batch = new UmdfPacket[1];
+        Assert.Equal(1, src.ReceiveBatch(batch));
+        try
+        {
+            Assert.Equal(expected, batch[0].Data.ToArray());
+            Assert.Equal(0, src.TruncatedDatagramCount);
+        }
+        finally
+        {
+            batch[0].Release();
+        }
+    }
+
+    [Fact]
+    public void ReceiveBatch_CapPlusOne_RealSocketDropsThenAcceptsValidTraffic()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        const int cap = 1024;
+        int port = GetEphemeralPort();
+        using var src = NewSource(ChannelType.IncrementalA, cap, port);
+        using var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        var endpoint = new IPEndPoint(IPAddress.Loopback, port);
+        sender.SendTo(new byte[cap + 1], endpoint);
+
+        var batch = new UmdfPacket[1];
+        Assert.Equal(0, src.ReceiveBatch(batch));
+        Assert.Equal(1, src.TruncatedDatagramCount);
+
+        byte[] valid = [0x11, 0x22, 0x33];
+        sender.SendTo(valid, endpoint);
+        Assert.Equal(1, src.ReceiveBatch(batch));
+        try
+        {
+            Assert.Equal(valid, batch[0].Data.ToArray());
+            Assert.Equal(1, src.TruncatedDatagramCount);
+        }
+        finally
+        {
+            batch[0].Release();
+        }
     }
 
     [Fact]
@@ -118,17 +183,27 @@ public class MulticastPacketSourceTruncationTests
         }
     }
 
-    private static MulticastPacketSource NewSource(ChannelType type, int maxDatagramBytes = 0)
+    private static MulticastPacketSource NewSource(
+        ChannelType type,
+        int maxDatagramBytes = 0,
+        int port = 0)
     {
         var config = new ChannelConfig(
             ChannelId: 99,
             Type: type,
-            MulticastGroup: IPAddress.Any,
-            Port: 0,
+            MulticastGroup: IPAddress.Loopback,
+            Port: port,
             ReceiveBufferBytes: 1 * 1024 * 1024,
             Transport: TransportKind.Unicast,
             MaxDatagramBytes: maxDatagramBytes);
         return new MulticastPacketSource(config, NullLogger<MulticastPacketSource>.Instance);
+    }
+
+    private static int GetEphemeralPort()
+    {
+        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.LocalEndPoint!).Port;
     }
 
     private static void WriteDatagram(IntPtr msgvec, byte[] payload, SocketFlags flags)

--- a/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceTruncationTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/MulticastPacketSourceTruncationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Transport.Tests;
@@ -39,104 +40,105 @@ public class MulticastPacketSourceTruncationTests
     }
 
     [Fact]
-    public void ReceiveBatch_OversizedMulticastDatagram_DropsAndIncrementsCounter()
+    public void IsKernelTruncated_MaximumUdpPayloadAtCap_IsValid()
+    {
+        Assert.False(MulticastPacketSource.IsKernelTruncated(
+            msgFlags: 0,
+            receivedLen: MulticastPacketSource.MaximumUdpPayloadBytes,
+            bufferCap: MulticastPacketSource.MaximumUdpPayloadBytes));
+    }
+
+    [Fact]
+    public void ReceiveBatch_SnapshotDatagramAboveLegacyCap_IsDeliveredIntact()
     {
         if (!OperatingSystem.IsLinux()) return;
 
-        var group = IPAddress.Parse("239.99.99.101");
-        int port = GetEphemeralPort();
-        var loopback = IPAddress.Loopback;
+        using var src = NewSource(ChannelType.SnapshotRecovery);
+        const int payloadLength = 32 * 1024;
+        var expected = new byte[payloadLength];
+        for (int i = 0; i < expected.Length; i++)
+            expected[i] = (byte)(i % 251);
 
-        var config = new ChannelConfig(
-            ChannelId: 99,
-            Type: ChannelType.IncrementalA,
-            MulticastGroup: group,
-            Port: port,
-            SourceAddress: null,
-            LocalAddress: loopback,
-            ReceiveBufferBytes: 1 * 1024 * 1024,
-            ChannelGroup: 0,
-            ReceiveSocketCount: 1);
+        src._recvmmsgInvoker = (int fd, IntPtr msgvec, uint vlen, int flags, out int errno) =>
+        {
+            errno = 0;
+            WriteDatagram(msgvec, expected, SocketFlags.None);
+            return 1;
+        };
 
-        MulticastPacketSource src;
+        var batch = new UmdfPacket[1];
+        Assert.Equal(1, src.ReceiveBatch(batch));
         try
         {
-            src = new MulticastPacketSource(config, NullLogger<MulticastPacketSource>.Instance);
+            Assert.Equal(payloadLength, batch[0].Data.Length);
+            Assert.Equal(expected, batch[0].Data.ToArray());
+            Assert.Equal(0, src.TruncatedDatagramCount);
         }
-        catch (SocketException)
+        finally
         {
-            // Environment may not allow binding loopback multicast (e.g. some sandboxes).
-            return;
-        }
-
-        using (src)
-        using (var sender = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
-        {
-            sender.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastInterface, loopback.GetAddressBytes());
-            sender.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 1);
-            // Increase the sender's send buffer so the kernel does not reject the oversized payload.
-            sender.SendBufferSize = 256 * 1024;
-
-            var dest = new IPEndPoint(group, port);
-
-            // 1) A normal-sized datagram for the receiver to drain — proves end-to-end works.
-            var smallPayload = new byte[] { 0xAA, 0xBB };
-            sender.SendTo(smallPayload, dest);
-
-            // 2) An oversized datagram, well beyond the receive buffer cap (9 KiB).
-            // We need it to physically fit in a UDP datagram (≤65507 bytes after IP+UDP headers)
-            // AND exceed MaxDatagramSize. 32 KiB satisfies both.
-            var bigPayload = new byte[32 * 1024];
-            for (int i = 0; i < bigPayload.Length; i++) bigPayload[i] = 0x55;
-            try
-            {
-                sender.SendTo(bigPayload, dest);
-            }
-            catch (SocketException)
-            {
-                // If the kernel rejects the big send (loopback MTU or similar), we can't exercise
-                // the integration path on this host; the unit-level helper tests above still cover
-                // the truncation policy.
-                return;
-            }
-
-            // 3) Another normal datagram so we're guaranteed to dequeue the truncated one too.
-            sender.SendTo(smallPayload, dest);
-
-            Thread.Sleep(150);
-
-            var batch = new UmdfPacket[MulticastPacketSource.MaxBatchSize];
-            int delivered = 0;
-            int rounds = 0;
-            // Drain a few batches; the truncated one shouldn't appear in destination,
-            // but should bump the counter exactly once.
-            while (rounds++ < 5 && delivered < 2)
-            {
-                int n = src.ReceiveBatch(batch);
-                for (int i = 0; i < n; i++)
-                {
-                    // Only small payloads should ever be delivered.
-                    Assert.Equal(2, batch[i].Data.Length);
-                    batch[i].Lease?.Release();
-                }
-                delivered += n;
-            }
-
-            // Whether MSG_TRUNC was set or the heuristic fired, the counter should be ≥1.
-            // If the kernel silently dropped the oversized datagram before recvmmsg ever saw it
-            // (e.g. discarded at socket buffer enqueue), the counter may stay at 0; in that case
-            // the integration path isn't observable on this host but no test failure should result.
-            // Skip assertion in that environmental case.
-            if (src.TruncatedDatagramCount == 0) return;
-            Assert.True(src.TruncatedDatagramCount >= 1,
-                $"Expected at least one truncated datagram, got {src.TruncatedDatagramCount}");
+            batch[0].Release();
         }
     }
 
-    private static int GetEphemeralPort()
+    [Fact]
+    public void ReceiveBatch_TruncatedDatagramThenValidTraffic_RecoversWithoutRestart()
     {
-        using var probe = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
-        probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-        return ((IPEndPoint)probe.LocalEndPoint!).Port;
+        if (!OperatingSystem.IsLinux()) return;
+
+        using var src = NewSource(ChannelType.IncrementalA, maxDatagramBytes: 1024);
+        int invocation = 0;
+        byte[] valid = [0x11, 0x22, 0x33, 0x44];
+        src._recvmmsgInvoker = (int fd, IntPtr msgvec, uint vlen, int flags, out int errno) =>
+        {
+            errno = 0;
+            invocation++;
+            if (invocation == 1)
+            {
+                WriteDatagram(msgvec, new byte[1024], (SocketFlags)LinuxNative.MSG_TRUNC);
+                return 1;
+            }
+
+            WriteDatagram(msgvec, valid, SocketFlags.None);
+            return 1;
+        };
+
+        var batch = new UmdfPacket[1];
+        Assert.Equal(0, src.ReceiveBatch(batch));
+        Assert.Equal(1, src.TruncatedDatagramCount);
+
+        Assert.Equal(1, src.ReceiveBatch(batch));
+        try
+        {
+            Assert.Equal(valid, batch[0].Data.ToArray());
+            Assert.Equal(1, src.TruncatedDatagramCount);
+        }
+        finally
+        {
+            batch[0].Release();
+        }
+    }
+
+    private static MulticastPacketSource NewSource(ChannelType type, int maxDatagramBytes = 0)
+    {
+        var config = new ChannelConfig(
+            ChannelId: 99,
+            Type: type,
+            MulticastGroup: IPAddress.Any,
+            Port: 0,
+            ReceiveBufferBytes: 1 * 1024 * 1024,
+            Transport: TransportKind.Unicast,
+            MaxDatagramBytes: maxDatagramBytes);
+        return new MulticastPacketSource(config, NullLogger<MulticastPacketSource>.Instance);
+    }
+
+    private static void WriteDatagram(IntPtr msgvec, byte[] payload, SocketFlags flags)
+    {
+        var header = Marshal.PtrToStructure<LinuxNative.Mmsghdr>(msgvec);
+        var iovec = Marshal.PtrToStructure<LinuxNative.Iovec>(header.msg_hdr.msg_iov);
+        Assert.True((nuint)payload.Length <= iovec.iov_len);
+        Marshal.Copy(payload, 0, iovec.iov_base, payload.Length);
+        header.msg_len = (uint)payload.Length;
+        header.msg_hdr.msg_flags = (int)flags;
+        Marshal.StructureToPtr(header, msgvec, fDeleteOld: false);
     }
 }


### PR DESCRIPTION
## Summary
- accept the full IPv4 UDP payload range by default on `SnapshotRecovery` while preserving atomic datagram semantics
- add configurable `maxDatagramBytes`, bounded-copy handling for large receive slots, explicit truncation logs/counter/metric, and safe defaults for other channels
- use one-byte receive lookahead for custom caps so exact-cap datagrams are valid and cap-plus-one datagrams are dropped whole
- verify truncated traffic is dropped, subsequent valid traffic is received without restart, and valid snapshots release the stale-ratio fanout gate

## Tests
- targeted transport/recovery tests (26 passed; exact-cap socket cases repeated 5 times)
- `dotnet test tests/B3.Umdf.Transport.Tests/B3.Umdf.Transport.Tests.csproj --no-restore --nologo` (39 passed)
- `dotnet test B3MarketDataPlatform.slnx --no-restore --nologo` (775 passed)

Closes #74