### PR TITLE
feat: surface instrument halt/resume state (partial #73)

### DIFF
--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -223,6 +223,12 @@ from UMDF" or "not applicable to the current phase".
 ```csharp
 client.InstrumentStatus += status =>
 {
+    if (status.IsSnapshot)
+    {
+        Console.WriteLine($"{status.Symbol}: bootstrapped halted={status.IsHalted}");
+        return;
+    }
+
     Console.WriteLine(
         $"{status.Symbol}: {(status.IsHalted ? "HALTED" : "RESUMED")} " +
         $"phase {status.PreviousStatus?.ToString() ?? "unknown"} -> {status.NewStatus}, " +
@@ -251,5 +257,14 @@ instead of inventing a reason from the marker.
 
 The latest administrative state is retained in the server's `InstrumentInfo`
 cache. Every new `Info` subscribe — including automatic re-subscribe after a
-WebSocket reconnect — receives the cached typed status after `InfoSnapshot`.
+WebSocket reconnect — receives the cached typed status after `InfoSnapshot`
+with `DeliveryKind=Snapshot` / `IsSnapshot=true`. It retains the original
+source timestamp and RptSeq for provenance; do not repeat live transition side
+effects for snapshot delivery. Live source changes use
+`DeliveryKind=LiveTransition`.
+
+Check `client.LastServerHello?.Capabilities` for
+`ServerCapabilities.InstrumentStatus` before relying on this stream. If the bit
+is absent, the server predates this feature; if present but no event arrives,
+the server has not yet observed administrative status for that symbol.
 Existing `InfoSnapshot` delivery remains unchanged for compatibility.

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -40,6 +40,8 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 
 client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}{(t.Flags.HasFlag(TradeFlags.AuctionPrint) ? " (auction)" : "")}");
 client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice} top={i.TheoreticalOpeningPrice} imb={i.AuctionImbalanceCondition}");
+client.InstrumentStatus += s => Console.WriteLine(
+    $"{s.Symbol} {(s.IsHalted ? "halted" : "resumed")} status={s.NewStatus} reason={s.Reason}");
 client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
 client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");
 
@@ -93,8 +95,9 @@ also enforces its own queue limits described in
 
 ## Scope of v1
 
-In: `Trade`, `TradeBust`, `InfoSnapshot`, `SecurityDefinition`, `PriceBand`,
-`Auction`, `ServerStatus`, `SubscribeError`, `ConnectionStateChanged`,
+In: `Trade`, `TradeBust`, `InfoSnapshot`, `InstrumentStatus`,
+`SecurityDefinition`, `PriceBand`, `Auction`, `ServerStatus`,
+`SubscribeError`, `ConnectionStateChanged`,
 reconnect+replay, DI extension, bounded back-pressure.
 
 Out (intentional): MBO/MBP order-book streams, recovery REST, auth
@@ -212,3 +215,33 @@ The two UMDF templates can fire independently — each bump yields a push
 with whatever is currently populated. Null fields mean "not yet received
 from UMDF" or "not applicable to the current phase".
 
+## Instrument halt/resume transitions
+
+`MarketDataClient.InstrumentStatus` is included with
+`SubscribeFlags.Info`; no new subscription bit is required:
+
+```csharp
+client.InstrumentStatus += status =>
+{
+    Console.WriteLine(
+        $"{status.Symbol}: {(status.IsHalted ? "HALTED" : "RESUMED")} " +
+        $"phase {status.PreviousStatus?.ToString() ?? "unknown"} -> {status.NewStatus}, " +
+        $"sourceNs={status.SourceTimestampNanos}");
+};
+
+await client.SubscribeAsync("PETR4", SubscribeFlags.Info);
+```
+
+The platform decodes the existing schema-generated UMDF
+`SecurityStatus_3` template (id 3), not a separate `InstrumentStatus_NN`
+template. B3MatchingPlatform marks halt with `securityTradingEvent=1` and
+resume with `securityTradingEvent=2`; these map to
+`InstrumentStatusReason.InstrumentHalted` and `InstrumentResumed`.
+`PreviousStatus` is null on first sight, `NewStatus` is the frame's
+`securityTradingStatus`, and `SourceTimestampNanos` is its `transactTime`.
+
+The source currently preserves the underlying trading phase during halt and
+does not encode the operator's detailed `RegulatoryHalt`/`NewsHold` reason.
+Consequently previous/new status can both be `OPEN`, and `Reason` exposes the
+exact halt/resume marker available on the wire. Existing `InfoSnapshot`
+delivery remains unchanged for compatibility.

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -41,7 +41,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}{(t.Flags.HasFlag(TradeFlags.AuctionPrint) ? " (auction)" : "")}");
 client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice} top={i.TheoreticalOpeningPrice} imb={i.AuctionImbalanceCondition}");
 client.InstrumentStatus += s => Console.WriteLine(
-    $"{s.Symbol} {(s.IsHalted ? "halted" : "resumed")} status={s.NewStatus} reason={s.Reason}");
+    $"{s.Symbol} transition={s.Transition} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
 client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
 client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");
 
@@ -236,12 +236,20 @@ The platform decodes the existing schema-generated UMDF
 `SecurityStatus_3` template (id 3), not a separate `InstrumentStatus_NN`
 template. B3MatchingPlatform marks halt with `securityTradingEvent=1` and
 resume with `securityTradingEvent=2`; these map to
-`InstrumentStatusReason.InstrumentHalted` and `InstrumentResumed`.
+`InstrumentStatusTransitionKind.Halted` and `Resumed`.
 `PreviousStatus` is null on first sight, `NewStatus` is the frame's
 `securityTradingStatus`, and `SourceTimestampNanos` is its `transactTime`.
 
 The source currently preserves the underlying trading phase during halt and
 does not encode the operator's detailed `RegulatoryHalt`/`NewsHold` reason.
-Consequently previous/new status can both be `OPEN`, and `Reason` exposes the
-exact halt/resume marker available on the wire. Existing `InfoSnapshot`
-delivery remains unchanged for compatibility.
+Consequently previous/new status can both be `OPEN`; `Transition` identifies
+halt vs. resume while `HaltReason` remains null. This upstream prerequisite is
+tracked by
+[`B3MatchingPlatform#581`](https://github.com/pedrosakuma/B3MatchingPlatform/issues/581).
+The APIs intentionally keep transition kind and detailed halt reason separate
+instead of inventing a reason from the marker.
+
+The latest administrative state is retained in the server's `InstrumentInfo`
+cache. Every new `Info` subscribe — including automatic re-subscribe after a
+WebSocket reconnect — receives the cached typed status after `InfoSnapshot`.
+Existing `InfoSnapshot` delivery remains unchanged for compatibility.

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -108,6 +108,7 @@ Get               0x0003        Unsubscribed        0x0012
                                 SecurityDefinition  0x00B0
                                 PriceBand           0x00B1
                                 Auction             0x00B2
+                                InstrumentStatus    0x00B3
 ```
 
 ## Client → Server
@@ -133,7 +134,7 @@ two known `u32` fields are ignored (min-length rule).
 |-------|------|---------|
 | `0x00` | None | Treated as `All` |
 | `0x01` | Book | `BookSnapshot` + order incrementals (`OrderAdded`/`Updated`/`Deleted`, `MarketTierUpdate`, `BookCleared`). **Does NOT include `Trade`/`TradeBust`** — those require `Trades` (`0x10`). |
-| `0x02` | Info | `InfoSnapshot` + incremental market-data / status updates |
+| `0x02` | Info | `InfoSnapshot` + incremental market-data / status updates, including non-conflated `InstrumentStatus` halt/resume transitions |
 | `0x03` | All  | `Book` + `Info` (legacy default; **does not** include News, MBP, Trades, SecurityDefinition, PriceBand, or Auction) |
 | `0x04` | News | `NewsBegin` / `NewsChunk` / `NewsEnd` reassembled news deliveries (per-symbol *and* global) |
 | `0x08` | Mbp | `LevelSnapshot` + `LevelUpdate`/`LevelDeleted` aggregated price-level stream (conflated by `(secId, side, price)`). See [`docs/perf/mbp-stream.md`](perf/mbp-stream.md). Shared frames (`BookCleared`, `MarketTierUpdate`, `CandleUpdate`) are also delivered. **Does NOT include `Trade`/`TradeBust`** — those require `Trades` (`0x10`). |
@@ -252,6 +253,32 @@ bitfield from `AuctionImbalance_19` (low 16 bits): `0x0100` =
 `Balanced`. The SDK decodes it into the
 `B3.MarketData.WebSocketClient.AuctionImbalanceCondition` enum;
 unrecognised combinations map to `Unknown`.
+
+### InstrumentStatus (included in `DataFlags.Info`)
+
+| Message | Type | Payload |
+|---------|------|---------|
+| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][reason u8][sourceTimestampNanos u64][rptSeq u32]` |
+
+This is the dedicated, non-conflated transition surface for administrative
+single-instrument halt/resume. It is decoded from the existing schema-generated
+UMDF **`SecurityStatus_3` template (id 3)**; there is no separate
+`InstrumentStatus_NN` template in B3 schema 2.2.0. The matching venue uses the
+otherwise schema-reserved `securityTradingEvent` values `1` (halt) and `2`
+(resume), while `securityTradingStatus`, `transactTime`, and `rptSeq` supply
+`newStatus`, `sourceTimestampNanos`, and `rptSeq`.
+
+`previousStatus=255` means the platform had no prior status cached. `rptSeq=0`
+means absent/snapshot. The venue preserves the underlying trading phase during
+an administrative halt, so `previousStatus` and `newStatus` may both be `17`
+(OPEN); consumers should use `reason`/the SDK's `IsHalted` property to identify
+the transition.
+
+The current source frame does **not** carry the operator's detailed halt reason
+(`RegulatoryHalt`, `NewsHold`, etc.). `reason` therefore exposes the exact
+available marker: `1` = instrument halted, `2` = instrument resumed. The normal
+`InfoSnapshot.TradingStatus` update remains unchanged for compatibility, and
+older clients safely skip the additive `0x00B3` opcode.
 
 ### SecurityDefinition (opt-in via `DataFlags.SecurityDefinition`)
 

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -258,7 +258,7 @@ unrecognised combinations map to `Unknown`.
 
 | Message | Type | Payload |
 |---------|------|---------|
-| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][reason u8][sourceTimestampNanos u64][rptSeq u32]` |
+| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]` |
 
 This is the dedicated, non-conflated transition surface for administrative
 single-instrument halt/resume. It is decoded from the existing schema-generated
@@ -268,17 +268,40 @@ otherwise schema-reserved `securityTradingEvent` values `1` (halt) and `2`
 (resume), while `securityTradingStatus`, `transactTime`, and `rptSeq` supply
 `newStatus`, `sourceTimestampNanos`, and `rptSeq`.
 
-`previousStatus=255` means the platform had no prior status cached. `rptSeq=0`
-means absent/snapshot. The venue preserves the underlying trading phase during
-an administrative halt, so `previousStatus` and `newStatus` may both be `17`
-(OPEN); consumers should use `reason`/the SDK's `IsHalted` property to identify
-the transition.
+`previousStatus=255` means the platform had no prior status cached,
+`haltReason=255` means the upstream frame supplied no detailed operator reason,
+and `rptSeq=0` means absent/snapshot. The venue preserves the underlying trading
+phase during an administrative halt, so `previousStatus` and `newStatus` may
+both be `17` (OPEN); consumers should use `transition`/the SDK's `IsHalted`
+property to identify the current administrative state.
 
 The current source frame does **not** carry the operator's detailed halt reason
-(`RegulatoryHalt`, `NewsHold`, etc.). `reason` therefore exposes the exact
-available marker: `1` = instrument halted, `2` = instrument resumed. The normal
-`InfoSnapshot.TradingStatus` update remains unchanged for compatibility, and
-older clients safely skip the additive `0x00B3` opcode.
+(`RegulatoryHalt`, `NewsHold`, etc.). `transition` exposes the exact available
+marker (`1` = halted, `2` = resumed), while `haltReason` is null/255. Transition
+kind is deliberately not presented as a reason.
+
+Authoritative upstream evidence (B3MatchingPlatform commit
+`0d423c8f6cecf647d57adf85ebdd6f539b0c8214`):
+
+- [`InstrumentHaltedEvent`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Exchange.Matching/Events.cs)
+  carries `HaltReason`, but
+  [`ChannelDispatcher.Sinks.OnInstrumentHalted`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs)
+  does not pass it to the encoder.
+- [`UmdfFrameBuilder.WriteInstrumentHalted`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Umdf.WireEncoder/UmdfFrameBuilder.cs)
+  emits `SecurityStatus_3` with only `securityTradingEvent=1`.
+- Schema 2.2.0 defines no detailed halt-reason field and repository code search
+  finds no `InstrumentStatus_NN` template.
+
+The missing upstream contract is tracked by
+[`B3MatchingPlatform#581`](https://github.com/pedrosakuma/B3MatchingPlatform/issues/581);
+until it lands, this frame cannot satisfy the detailed-reason portion of
+`B3MarketDataPlatform#73`.
+
+The current state is cached and emitted after `InfoSnapshot` on every Info
+subscribe/re-subscribe. The normal `InfoSnapshot.TradingStatus` update remains
+unchanged for compatibility, and older clients safely skip the additive
+`0x00B3` opcode. SDK decoders validate the minimum payload and symbol length;
+malformed frames are logged and skipped without tearing down the connection.
 
 ### SecurityDefinition (opt-in via `DataFlags.SecurityDefinition`)
 

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -194,7 +194,10 @@ Total length = 18 bytes (8 header + 4 flags + 1 symLen + 5 symbol).
 
 **ServerHello** is the **first** server-initiated frame on every connection. It
 advertises the server's `protocolVersion` and a `serverCapabilities` bitmask
-(`0x01` SnapshotOnSubscribe, `0x02` SymbolDelistedNotification; append-only).
+(`0x01` SnapshotOnSubscribe, `0x02` SymbolDelistedNotification,
+`0x04` InstrumentStatus; append-only). Clients use the InstrumentStatus bit to
+distinguish an older server that cannot emit `0x00B3` from a capable server that
+has simply not observed an administrative status yet.
 `SubscribeOk.flags` echoes the **accepted** `DataFlags` (`u32`) after the server
 masks off unknown/unimplemented bits requested by the client.
 
@@ -258,7 +261,7 @@ unrecognised combinations map to `Unknown`.
 
 | Message | Type | Payload |
 |---------|------|---------|
-| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]` |
+| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32][deliveryKind u8]` |
 
 This is the dedicated, non-conflated transition surface for administrative
 single-instrument halt/resume. It is decoded from the existing schema-generated
@@ -270,10 +273,17 @@ otherwise schema-reserved `securityTradingEvent` values `1` (halt) and `2`
 
 `previousStatus=255` means the platform had no prior status cached,
 `haltReason=255` means the upstream frame supplied no detailed operator reason,
-and `rptSeq=0` means absent/snapshot. The venue preserves the underlying trading
+and `rptSeq=0` means unavailable. The venue preserves the underlying trading
 phase during an administrative halt, so `previousStatus` and `newStatus` may
 both be `17` (OPEN); consumers should use `transition`/the SDK's `IsHalted`
 property to identify the current administrative state.
+
+`deliveryKind` is append-only: `0` = live source transition, `1` = cached
+subscribe/reconnect snapshot. Snapshot frames deliberately retain the original
+source timestamp and RptSeq for provenance; consumers MUST check
+`deliveryKind`/`InstrumentStatusEvent.IsSnapshot` before running one-shot
+transition side effects. SDKs decoding a legacy frame without this trailing
+byte default it to live transition.
 
 The current source frame does **not** carry the operator's detailed halt reason
 (`RegulatoryHalt`, `NewsHold`, etc.). `transition` exposes the exact available
@@ -297,8 +307,9 @@ The missing upstream contract is tracked by
 until it lands, this frame cannot satisfy the detailed-reason portion of
 `B3MarketDataPlatform#73`.
 
-The current state is cached and emitted after `InfoSnapshot` on every Info
-subscribe/re-subscribe. The normal `InfoSnapshot.TradingStatus` update remains
+The current state is cached and emitted with `deliveryKind=1` after
+`InfoSnapshot` on every Info subscribe/re-subscribe. Live frames use
+`deliveryKind=0`. The normal `InfoSnapshot.TradingStatus` update remains
 unchanged for compatibility, and older clients safely skip the additive
 `0x00B3` opcode. SDK decoders validate the minimum payload and symbol length;
 malformed frames are logged and skipped without tearing down the connection.

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -12,6 +12,7 @@ public enum ServerCapabilities : uint
     None = 0,
     SnapshotOnSubscribe = 0x0001,
     SymbolDelistedNotification = 0x0002,
+    InstrumentStatus = 0x0004,
 }
 
 /// <summary>Connection state surfaced via <see cref="MarketDataClient.ConnectionStateChanged"/>.</summary>
@@ -743,6 +744,17 @@ public enum InstrumentHaltReason : byte
 }
 
 /// <summary>
+/// Distinguishes a live source transition from cached state replayed during
+/// subscribe/reconnect bootstrap.
+/// </summary>
+public enum InstrumentStatusDeliveryKind : byte
+{
+    LiveTransition = 0,
+    Snapshot = 1,
+    Unknown = byte.MaxValue,
+}
+
+/// <summary>
 /// A non-conflated instrument halt/resume transition decoded from UMDF
 /// <c>SecurityStatus_3</c>.
 /// </summary>
@@ -783,8 +795,22 @@ public sealed class InstrumentStatusEvent
     /// <summary>Exchange source timestamp, UTC nanoseconds since Unix epoch.</summary>
     public ulong SourceTimestampNanos { get; init; }
 
-    /// <summary>Per-instrument UMDF sequence, or null for snapshot/zero.</summary>
+    /// <summary>
+    /// Original per-instrument UMDF sequence, or null when unavailable.
+    /// Snapshot delivery may replay the original non-zero value; use
+    /// <see cref="IsSnapshot"/> before triggering transition side effects.
+    /// </summary>
     public uint? RptSeq { get; init; }
 
+    /// <summary>
+    /// Delivery context. Snapshot events describe already-known current state;
+    /// consumers must not repeat one-shot transition side effects for them.
+    /// </summary>
+    public InstrumentStatusDeliveryKind DeliveryKind { get; init; }
+
+    /// <summary>Unmodified delivery-kind byte for forward compatibility.</summary>
+    public byte RawDeliveryKind { get; init; }
+
     public bool IsHalted => Transition == InstrumentStatusTransitionKind.Halted;
+    public bool IsSnapshot => DeliveryKind == InstrumentStatusDeliveryKind.Snapshot;
 }

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -716,3 +716,53 @@ public sealed class AuctionEvent
     /// either source. Null when not provided.</summary>
     public long? RptSeq { get; init; }
 }
+
+/// <summary>
+/// Proprietary <c>securityTradingEvent</c> markers carried by the existing
+/// UMDF <c>SecurityStatus_3</c> template for administrative halt/resume.
+/// </summary>
+public enum InstrumentStatusReason : byte
+{
+    Unknown = 0,
+    InstrumentHalted = 1,
+    InstrumentResumed = 2,
+}
+
+/// <summary>
+/// A non-conflated instrument halt/resume transition decoded from UMDF
+/// <c>SecurityStatus_3</c>.
+/// </summary>
+public sealed class InstrumentStatusEvent
+{
+    public ulong SecurityId { get; init; }
+    public string Symbol { get; init; } = "";
+    public DateTime ReceivedUtc { get; init; }
+
+    /// <summary>Status cached before this source frame, or null on first sight.</summary>
+    public int? PreviousStatus { get; init; }
+
+    /// <summary>
+    /// <c>SecurityStatus_3.securityTradingStatus</c>. The matching venue preserves
+    /// the underlying trading phase during an administrative halt, so halt/open
+    /// can legitimately report the same previous and new status.
+    /// </summary>
+    public int NewStatus { get; init; }
+
+    /// <summary>
+    /// Halt/resume marker from <c>SecurityStatus_3.securityTradingEvent</c>.
+    /// The current source frame does not carry the operator's detailed
+    /// RegulatoryHalt/NewsHold/etc. reason.
+    /// </summary>
+    public InstrumentStatusReason Reason { get; init; }
+
+    /// <summary>Unmodified <c>securityTradingEvent</c> marker for forward compatibility.</summary>
+    public byte RawReasonCode { get; init; }
+
+    /// <summary>Exchange source timestamp, UTC nanoseconds since Unix epoch.</summary>
+    public ulong SourceTimestampNanos { get; init; }
+
+    /// <summary>Per-instrument UMDF sequence, or null for snapshot/zero.</summary>
+    public uint? RptSeq { get; init; }
+
+    public bool IsHalted => Reason == InstrumentStatusReason.InstrumentHalted;
+}

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -718,14 +718,28 @@ public sealed class AuctionEvent
 }
 
 /// <summary>
-/// Proprietary <c>securityTradingEvent</c> markers carried by the existing
-/// UMDF <c>SecurityStatus_3</c> template for administrative halt/resume.
+/// Administrative state transition carried by the proprietary
+/// <c>SecurityStatus_3.securityTradingEvent</c> extension.
 /// </summary>
-public enum InstrumentStatusReason : byte
+public enum InstrumentStatusTransitionKind : byte
 {
     Unknown = 0,
-    InstrumentHalted = 1,
-    InstrumentResumed = 2,
+    Halted = 1,
+    Resumed = 2,
+}
+
+/// <summary>
+/// Operator-supplied administrative halt reason. The current upstream UMDF
+/// contract does not transmit this value, so <see cref="InstrumentStatusEvent.HaltReason"/>
+/// remains null until B3MatchingPlatform issue #581 supplies it.
+/// </summary>
+public enum InstrumentHaltReason : byte
+{
+    Unknown = 0,
+    RegulatoryHalt = 1,
+    VolatilityCircuitBreaker = 2,
+    NewsHold = 3,
+    PendingDisclosure = 4,
 }
 
 /// <summary>
@@ -749,14 +763,22 @@ public sealed class InstrumentStatusEvent
     public int NewStatus { get; init; }
 
     /// <summary>
-    /// Halt/resume marker from <c>SecurityStatus_3.securityTradingEvent</c>.
-    /// The current source frame does not carry the operator's detailed
-    /// RegulatoryHalt/NewsHold/etc. reason.
+    /// Halt/resume transition marker from
+    /// <c>SecurityStatus_3.securityTradingEvent</c>.
     /// </summary>
-    public InstrumentStatusReason Reason { get; init; }
+    public InstrumentStatusTransitionKind Transition { get; init; }
 
-    /// <summary>Unmodified <c>securityTradingEvent</c> marker for forward compatibility.</summary>
-    public byte RawReasonCode { get; init; }
+    /// <summary>Unmodified transition marker for forward compatibility.</summary>
+    public byte RawTransitionCode { get; init; }
+
+    /// <summary>
+    /// Detailed operator halt reason, or null because the current upstream
+    /// <c>SecurityStatus_3</c> frame does not carry one.
+    /// </summary>
+    public InstrumentHaltReason? HaltReason { get; init; }
+
+    /// <summary>Unmodified detailed reason code, or null when absent on the wire.</summary>
+    public byte? RawHaltReasonCode { get; init; }
 
     /// <summary>Exchange source timestamp, UTC nanoseconds since Unix epoch.</summary>
     public ulong SourceTimestampNanos { get; init; }
@@ -764,5 +786,5 @@ public sealed class InstrumentStatusEvent
     /// <summary>Per-instrument UMDF sequence, or null for snapshot/zero.</summary>
     public uint? RptSeq { get; init; }
 
-    public bool IsHalted => Reason == InstrumentStatusReason.InstrumentHalted;
+    public bool IsHalted => Transition == InstrumentStatusTransitionKind.Halted;
 }

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -93,7 +93,10 @@ public sealed class MarketDataClient : IAsyncDisposable
     /// <summary>
     /// Administrative instrument halt/resume transitions decoded from UMDF
     /// <c>SecurityStatus_3</c>. Delivered to subscriptions that include
-    /// <see cref="SubscribeFlags.Info"/>.
+    /// <see cref="SubscribeFlags.Info"/> when
+    /// <see cref="ServerCapabilities.InstrumentStatus"/> is advertised.
+    /// Inspect <see cref="InstrumentStatusEvent.IsSnapshot"/> before running
+    /// one-shot transition side effects.
     /// </summary>
     public event Action<InstrumentStatusEvent>? InstrumentStatus;
     public event Action<ServerStatusEvent>? ServerStatus;

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -562,7 +562,13 @@ public sealed class MarketDataClient : IAsyncDisposable
             }
             case MessageType.InstrumentStatus:
             {
-                var ev = WireFormat.ReadInstrumentStatus(payload, receivedUtc);
+                if (!WireFormat.TryReadInstrumentStatus(payload, receivedUtc, out var ev))
+                {
+                    _logger.LogWarning(
+                        "Malformed InstrumentStatus payload ({Length} bytes); dropping frame.",
+                        payload.Length);
+                    break;
+                }
                 Enqueue(() => InstrumentStatus?.Invoke(ev));
                 break;
             }

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -90,6 +90,12 @@ public sealed class MarketDataClient : IAsyncDisposable
     /// Requires opt-in via <see cref="SubscribeFlags.Auction"/>.
     /// </summary>
     public event Action<AuctionEvent>? Auction;
+    /// <summary>
+    /// Administrative instrument halt/resume transitions decoded from UMDF
+    /// <c>SecurityStatus_3</c>. Delivered to subscriptions that include
+    /// <see cref="SubscribeFlags.Info"/>.
+    /// </summary>
+    public event Action<InstrumentStatusEvent>? InstrumentStatus;
     public event Action<ServerStatusEvent>? ServerStatus;
     public event Action<ServerHelloEvent>? ServerHello;
     public event Action<SymbolDelistedEvent>? SymbolDelisted;
@@ -552,6 +558,12 @@ public sealed class MarketDataClient : IAsyncDisposable
                 // Auction embeds Symbol on the wire — no _securityIdToSymbol needed.
                 var ev = WireFormat.ReadAuction(payload, receivedUtc);
                 Enqueue(() => Auction?.Invoke(ev));
+                break;
+            }
+            case MessageType.InstrumentStatus:
+            {
+                var ev = WireFormat.ReadInstrumentStatus(payload, receivedUtc);
+                Enqueue(() => InstrumentStatus?.Invoke(ev));
                 break;
             }
             // ── L3 / order-by-order (MBO) ─────────────────────────

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -27,7 +27,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
 client.LevelUpdate += l => Console.WriteLine($"{l.Symbol} {l.Side} {l.Price} qty={l.TotalQty}");
 client.InstrumentStatus += s => Console.WriteLine(
-    $"{s.Symbol} transition={s.Transition} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
+    $"{s.Symbol} transition={s.Transition} snapshot={s.IsSnapshot} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
 
 await client.ConnectAsync();
 await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Mbp);

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -26,6 +26,8 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 
 client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
 client.LevelUpdate += l => Console.WriteLine($"{l.Symbol} {l.Side} {l.Price} qty={l.TotalQty}");
+client.InstrumentStatus += s => Console.WriteLine(
+    $"{s.Symbol} {(s.IsHalted ? "halted" : "resumed")} status={s.NewStatus} sourceNs={s.SourceTimestampNanos}");
 
 await client.ConnectAsync();
 await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Mbp);
@@ -42,7 +44,8 @@ Includes:
   (`BookSnapshot`, `OrderAdded/Updated/Deleted`, `BookCleared`,
   `MarketTierUpdate`), MBP (`LevelSnapshot`, `LevelUpdate`,
   `LevelDeleted`), candles (snapshot + update), rankings, per-symbol
-  stale status, recovery progress, and reassembled news.
+  stale status, instrument halt/resume transitions, recovery progress, and
+  reassembled news.
 - **Opt-in materialized book layer (`IBookFeed`/`IBookView`)** —
   maintains an in-memory L3 book per symbol from the MBO event stream
   and exposes derived top-of-book. Stale-flag bridged from the

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -27,7 +27,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
 client.LevelUpdate += l => Console.WriteLine($"{l.Symbol} {l.Side} {l.Price} qty={l.TotalQty}");
 client.InstrumentStatus += s => Console.WriteLine(
-    $"{s.Symbol} {(s.IsHalted ? "halted" : "resumed")} status={s.NewStatus} sourceNs={s.SourceTimestampNanos}");
+    $"{s.Symbol} transition={s.Transition} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
 
 await client.ConnectAsync();
 await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Mbp);

--- a/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
+++ b/src/B3.MarketData.WebSocketClient/SubscribeFlags.cs
@@ -21,7 +21,9 @@ public enum SubscribeFlags : uint
 
     /// <summary>
     /// <c>InfoSnapshot</c> + incremental info updates (carries
-    /// <c>LastTradePrice</c>, <c>LastTradeSize</c>, status, etc.).
+    /// <c>LastTradePrice</c>, <c>LastTradeSize</c>, status, etc.), including
+    /// dedicated <see cref="MarketDataClient.InstrumentStatus"/> halt/resume
+    /// transitions.
     /// </summary>
     Info = 0x02,
 

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -540,18 +540,33 @@ internal static class WireFormat
     }
 
     /// <summary>
-    /// Parse an <see cref="MessageType.InstrumentStatus"/> frame.
+    /// Safely parse an <see cref="MessageType.InstrumentStatus"/> frame.
     /// Layout:
     /// <c>[securityId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
-    /// [reason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
     /// </summary>
-    public static InstrumentStatusEvent ReadInstrumentStatus(
+    public static bool TryReadInstrumentStatus(
         ReadOnlySpan<byte> payload,
-        DateTime receivedUtc)
+        DateTime receivedUtc,
+        out InstrumentStatusEvent status)
     {
+        const int prefixSize = 8 + 1;
+        const int fixedTailSize = 1 + 1 + 1 + 1 + 8 + 4;
+        if (payload.Length < prefixSize + fixedTailSize)
+        {
+            status = null!;
+            return false;
+        }
+
         ulong securityId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
         int offset = 8;
         int symbolLength = payload[offset++];
+        if (symbolLength > payload.Length - offset - fixedTailSize)
+        {
+            status = null!;
+            return false;
+        }
+
         string symbol = symbolLength == 0
             ? string.Empty
             : Encoding.UTF8.GetString(payload.Slice(offset, symbolLength));
@@ -559,25 +574,33 @@ internal static class WireFormat
 
         byte previousStatus = payload[offset++];
         byte newStatus = payload[offset++];
-        byte reason = payload[offset++];
+        byte transition = payload[offset++];
+        byte haltReason = payload[offset++];
         ulong sourceTimestampNanos = BinaryPrimitives.ReadUInt64LittleEndian(payload[offset..]);
         offset += 8;
         uint rptSeq = BinaryPrimitives.ReadUInt32LittleEndian(payload[offset..]);
 
-        return new InstrumentStatusEvent
+        status = new InstrumentStatusEvent
         {
             SecurityId = securityId,
             Symbol = symbol,
             ReceivedUtc = receivedUtc,
             PreviousStatus = previousStatus == byte.MaxValue ? null : previousStatus,
             NewStatus = newStatus,
-            Reason = Enum.IsDefined(typeof(InstrumentStatusReason), reason)
-                ? (InstrumentStatusReason)reason
-                : InstrumentStatusReason.Unknown,
-            RawReasonCode = reason,
+            Transition = Enum.IsDefined(typeof(InstrumentStatusTransitionKind), transition)
+                ? (InstrumentStatusTransitionKind)transition
+                : InstrumentStatusTransitionKind.Unknown,
+            RawTransitionCode = transition,
+            HaltReason = haltReason == byte.MaxValue
+                ? null
+                : Enum.IsDefined(typeof(InstrumentHaltReason), haltReason)
+                    ? (InstrumentHaltReason)haltReason
+                    : InstrumentHaltReason.Unknown,
+            RawHaltReasonCode = haltReason == byte.MaxValue ? null : haltReason,
             SourceTimestampNanos = sourceTimestampNanos,
             RptSeq = rptSeq == 0 ? null : rptSeq,
         };
+        return true;
     }
 
     // SBE ImbalanceCondition bit positions (uint16):

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -543,7 +543,9 @@ internal static class WireFormat
     /// Safely parse an <see cref="MessageType.InstrumentStatus"/> frame.
     /// Layout:
     /// <c>[securityId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
-    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]
+    /// [deliveryKind u8?]</c>. A missing trailing delivery kind is treated as
+    /// <see cref="InstrumentStatusDeliveryKind.LiveTransition"/> for compatibility.
     /// </summary>
     public static bool TryReadInstrumentStatus(
         ReadOnlySpan<byte> payload,
@@ -579,6 +581,10 @@ internal static class WireFormat
         ulong sourceTimestampNanos = BinaryPrimitives.ReadUInt64LittleEndian(payload[offset..]);
         offset += 8;
         uint rptSeq = BinaryPrimitives.ReadUInt32LittleEndian(payload[offset..]);
+        offset += 4;
+        byte deliveryKind = payload.Length > offset
+            ? payload[offset]
+            : (byte)InstrumentStatusDeliveryKind.LiveTransition;
 
         status = new InstrumentStatusEvent
         {
@@ -599,6 +605,10 @@ internal static class WireFormat
             RawHaltReasonCode = haltReason == byte.MaxValue ? null : haltReason,
             SourceTimestampNanos = sourceTimestampNanos,
             RptSeq = rptSeq == 0 ? null : rptSeq,
+            DeliveryKind = Enum.IsDefined(typeof(InstrumentStatusDeliveryKind), deliveryKind)
+                ? (InstrumentStatusDeliveryKind)deliveryKind
+                : InstrumentStatusDeliveryKind.Unknown,
+            RawDeliveryKind = deliveryKind,
         };
         return true;
     }

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -539,6 +539,47 @@ internal static class WireFormat
         };
     }
 
+    /// <summary>
+    /// Parse an <see cref="MessageType.InstrumentStatus"/> frame.
+    /// Layout:
+    /// <c>[securityId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
+    /// [reason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// </summary>
+    public static InstrumentStatusEvent ReadInstrumentStatus(
+        ReadOnlySpan<byte> payload,
+        DateTime receivedUtc)
+    {
+        ulong securityId = BinaryPrimitives.ReadUInt64LittleEndian(payload);
+        int offset = 8;
+        int symbolLength = payload[offset++];
+        string symbol = symbolLength == 0
+            ? string.Empty
+            : Encoding.UTF8.GetString(payload.Slice(offset, symbolLength));
+        offset += symbolLength;
+
+        byte previousStatus = payload[offset++];
+        byte newStatus = payload[offset++];
+        byte reason = payload[offset++];
+        ulong sourceTimestampNanos = BinaryPrimitives.ReadUInt64LittleEndian(payload[offset..]);
+        offset += 8;
+        uint rptSeq = BinaryPrimitives.ReadUInt32LittleEndian(payload[offset..]);
+
+        return new InstrumentStatusEvent
+        {
+            SecurityId = securityId,
+            Symbol = symbol,
+            ReceivedUtc = receivedUtc,
+            PreviousStatus = previousStatus == byte.MaxValue ? null : previousStatus,
+            NewStatus = newStatus,
+            Reason = Enum.IsDefined(typeof(InstrumentStatusReason), reason)
+                ? (InstrumentStatusReason)reason
+                : InstrumentStatusReason.Unknown,
+            RawReasonCode = reason,
+            SourceTimestampNanos = sourceTimestampNanos,
+            RptSeq = rptSeq == 0 ? null : rptSeq,
+        };
+    }
+
     // SBE ImbalanceCondition bit positions (uint16):
     //   bit 8 (0x0100) = ImbalanceMoreBuyers
     //   bit 9 (0x0200) = ImbalanceMoreSellers

--- a/src/B3.MarketData.Wire/WireV2.cs
+++ b/src/B3.MarketData.Wire/WireV2.cs
@@ -140,6 +140,7 @@ public enum ServerCapabilities : uint
     None = 0,
     SnapshotOnSubscribe = 0x0001,
     SymbolDelistedNotification = 0x0002,
+    InstrumentStatus = 0x0004,
 }
 
 /// <summary>Optional client features advertised in <see cref="MessageType.ClientHello"/>. Append-only; 0 today.</summary>

--- a/src/B3.MarketData.Wire/WireV2.cs
+++ b/src/B3.MarketData.Wire/WireV2.cs
@@ -97,6 +97,7 @@ public enum MessageType : ushort
     SecurityDefinition = 0x00B0,
     PriceBand = 0x00B1,
     Auction = 0x00B2,
+    InstrumentStatus = 0x00B3,
 
     // Server -> Client: news (fragmented)
     NewsBegin = 0x0090,

--- a/src/B3.Umdf.Book/CompositeMarketDataEventHandler.cs
+++ b/src/B3.Umdf.Book/CompositeMarketDataEventHandler.cs
@@ -14,6 +14,14 @@ public sealed class CompositeMarketDataEventHandler : IMarketDataEventHandler
         foreach (var h in _handlers) h.OnSecurityStatusChanged(securityId, info);
     }
 
+    public void OnInstrumentStatusChanged(
+        ulong securityId,
+        InstrumentInfo info,
+        in InstrumentStatusUpdate update)
+    {
+        foreach (var h in _handlers) h.OnInstrumentStatusChanged(securityId, info, in update);
+    }
+
     public void OnMarketDataUpdated(ulong securityId, InstrumentInfo info)
     {
         foreach (var h in _handlers) h.OnMarketDataUpdated(securityId, info);

--- a/src/B3.Umdf.Book/IMarketDataEventHandler.cs
+++ b/src/B3.Umdf.Book/IMarketDataEventHandler.cs
@@ -3,6 +3,14 @@ namespace B3.Umdf.Book;
 public interface IMarketDataEventHandler
 {
     void OnSecurityStatusChanged(ulong securityId, InstrumentInfo info) { }
+    /// <summary>
+    /// Fired for the halt/resume extension carried by <c>SecurityStatus_3</c>
+    /// (<c>securityTradingEvent</c> values 1 and 2).
+    /// </summary>
+    void OnInstrumentStatusChanged(
+        ulong securityId,
+        InstrumentInfo info,
+        in InstrumentStatusUpdate update) { }
     void OnMarketDataUpdated(ulong securityId, InstrumentInfo info) { }
 
     /// <summary>

--- a/src/B3.Umdf.Book/InstrumentInfo.cs
+++ b/src/B3.Umdf.Book/InstrumentInfo.cs
@@ -80,6 +80,12 @@ public sealed class InstrumentInfo
     public int? TradingStatus { get; set; }
     public int? TradingEvent { get; set; }
     public ulong? TradSesOpenTime { get; set; }
+    /// <summary>
+    /// Last administrative halt/resume state decoded from the proprietary
+    /// <c>SecurityStatus_3.securityTradingEvent</c> extension. Retained so
+    /// late/reconnecting Info subscribers can bootstrap current state.
+    /// </summary>
+    public InstrumentStatusUpdate? AdministrativeStatus { get; set; }
 
     // SecurityDefinition / group tracking
     public string? SecurityGroup { get; set; }
@@ -208,6 +214,7 @@ public sealed class InstrumentInfo
         TradingStatus = null;
         TradingEvent = null;
         TradSesOpenTime = null;
+        AdministrativeStatus = null;
         SecurityGroup = null;
         FollowsGroupStatus = true;
         Symbol = null;

--- a/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
+++ b/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
@@ -9,9 +9,13 @@ namespace B3.Umdf.Book;
 public readonly record struct InstrumentStatusUpdate(
     int? PreviousStatus,
     int NewStatus,
-    byte ReasonCode,
+    byte TransitionCode,
+    byte? HaltReasonCode,
     ulong SourceTimestampNanos,
-    uint? RptSeq);
+    uint? RptSeq)
+{
+    public bool IsHalted => TransitionCode == InstrumentStatusDecoder.InstrumentHaltedTransitionCode;
+}
 
 /// <summary>
 /// Decodes the proprietary halt/resume markers emitted by B3MatchingPlatform
@@ -19,8 +23,8 @@ public readonly record struct InstrumentStatusUpdate(
 /// </summary>
 public static class InstrumentStatusDecoder
 {
-    public const byte InstrumentHaltedReasonCode = 1;
-    public const byte InstrumentResumedReasonCode = 2;
+    public const byte InstrumentHaltedTransitionCode = 1;
+    public const byte InstrumentResumedTransitionCode = 2;
 
     public static bool TryDecode(
         in SecurityStatus_3DataReader reader,
@@ -28,11 +32,11 @@ public static class InstrumentStatusDecoder
         out InstrumentStatusUpdate update)
     {
         ref readonly var message = ref reader.Data;
-        byte reasonCode = message.SecurityTradingEvent is { } tradingEvent
+        byte transitionCode = message.SecurityTradingEvent is { } tradingEvent
             ? (byte)tradingEvent
             : byte.MaxValue;
 
-        if (reasonCode is not (InstrumentHaltedReasonCode or InstrumentResumedReasonCode))
+        if (transitionCode is not (InstrumentHaltedTransitionCode or InstrumentResumedTransitionCode))
         {
             update = default;
             return false;
@@ -41,7 +45,8 @@ public static class InstrumentStatusDecoder
         update = new InstrumentStatusUpdate(
             previousStatus,
             (int)message.SecurityTradingStatus,
-            reasonCode,
+            transitionCode,
+            null,
             message.TransactTime.Time ?? 0,
             message.RptSeq);
         return true;

--- a/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
+++ b/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
@@ -1,0 +1,49 @@
+using B3.Umdf.Mbo.Sbe.V16;
+
+namespace B3.Umdf.Book;
+
+/// <summary>
+/// Semantic halt/resume transition decoded from the exchange's
+/// <c>SecurityStatus_3</c> template.
+/// </summary>
+public readonly record struct InstrumentStatusUpdate(
+    int? PreviousStatus,
+    int NewStatus,
+    byte ReasonCode,
+    ulong SourceTimestampNanos,
+    uint? RptSeq);
+
+/// <summary>
+/// Decodes the proprietary halt/resume markers emitted by B3MatchingPlatform
+/// in the existing UMDF <c>SecurityStatus_3</c> template.
+/// </summary>
+public static class InstrumentStatusDecoder
+{
+    public const byte InstrumentHaltedReasonCode = 1;
+    public const byte InstrumentResumedReasonCode = 2;
+
+    public static bool TryDecode(
+        in SecurityStatus_3DataReader reader,
+        int? previousStatus,
+        out InstrumentStatusUpdate update)
+    {
+        ref readonly var message = ref reader.Data;
+        byte reasonCode = message.SecurityTradingEvent is { } tradingEvent
+            ? (byte)tradingEvent
+            : byte.MaxValue;
+
+        if (reasonCode is not (InstrumentHaltedReasonCode or InstrumentResumedReasonCode))
+        {
+            update = default;
+            return false;
+        }
+
+        update = new InstrumentStatusUpdate(
+            previousStatus,
+            (int)message.SecurityTradingStatus,
+            reasonCode,
+            message.TransactTime.Time ?? 0,
+            message.RptSeq);
+        return true;
+    }
+}

--- a/src/B3.Umdf.Book/MarketDataManager.cs
+++ b/src/B3.Umdf.Book/MarketDataManager.cs
@@ -486,7 +486,10 @@ public sealed class MarketDataManager : IFeedEventHandler
 
         info.BumpVersion();
         if (InstrumentStatusDecoder.TryDecode(in reader, previousStatus, out var instrumentStatus))
+        {
+            info.AdministrativeStatus = instrumentStatus;
             _eventHandler?.OnInstrumentStatusChanged(securityId, info, in instrumentStatus);
+        }
         _eventHandler?.OnSecurityStatusChanged(securityId, info);
     }
 

--- a/src/B3.Umdf.Book/MarketDataManager.cs
+++ b/src/B3.Umdf.Book/MarketDataManager.cs
@@ -441,6 +441,7 @@ public sealed class MarketDataManager : IFeedEventHandler
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
         var info = GetOrCreateInfo(securityId);
+        int? previousStatus = info.TradingStatus;
 
         if (msg.RptSeq is { } rs)
         {
@@ -484,6 +485,8 @@ public sealed class MarketDataManager : IFeedEventHandler
         }
 
         info.BumpVersion();
+        if (InstrumentStatusDecoder.TryDecode(in reader, previousStatus, out var instrumentStatus))
+            _eventHandler?.OnInstrumentStatusChanged(securityId, info, in instrumentStatus);
         _eventHandler?.OnSecurityStatusChanged(securityId, info);
     }
 

--- a/src/B3.Umdf.Server/GroupConflationHandler.cs
+++ b/src/B3.Umdf.Server/GroupConflationHandler.cs
@@ -480,6 +480,14 @@ public sealed class GroupConflationHandler : IBookEventHandler, IMarketDataEvent
         _parent.NotifyInfoUpdated(securityId);
     }
 
+    public void OnInstrumentStatusChanged(
+        ulong securityId,
+        InstrumentInfo info,
+        in InstrumentStatusUpdate update)
+    {
+        _parent.PublishInstrumentStatus(securityId, info.Symbol, in update);
+    }
+
     public void OnMarketDataUpdated(ulong securityId, InstrumentInfo info)
     {
         if (info.TradingStatus is { } status)

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -172,6 +172,22 @@ internal static class SnapshotEmitter
         return session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len));
     }
 
+    /// <summary>
+    /// Send the cached current administrative halt/resume state to a late or
+    /// reconnecting Info subscriber. No-op until a source transition was observed.
+    /// </summary>
+    public static bool SendInstrumentStatusSnapshot(
+        ClientSession session,
+        ulong securityId,
+        InstrumentInfo info)
+    {
+        if (info.AdministrativeStatus is not { } status) return true;
+        var buf = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int len = WireProtocol.WriteInstrumentStatus(
+            buf, securityId, info.Symbol, in status);
+        return session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len));
+    }
+
     /// <summary>Send the cached <see cref="MessageType.SecurityDefinition"/> frame
     /// for one security. Used for the bootstrap push on Subscribe when the
     /// caller already asserted <see cref="DataFlags.SecurityDefinition"/> is set.</summary>

--- a/src/B3.Umdf.Server/SnapshotEmitter.cs
+++ b/src/B3.Umdf.Server/SnapshotEmitter.cs
@@ -29,7 +29,9 @@ internal static class SnapshotEmitter
     /// tests can assert against it without re-deriving the bitmask.
     /// </summary>
     internal const ServerCapabilities AdvertisedCapabilities =
-        ServerCapabilities.SnapshotOnSubscribe | ServerCapabilities.SymbolDelistedNotification;
+        ServerCapabilities.SnapshotOnSubscribe
+        | ServerCapabilities.SymbolDelistedNotification
+        | ServerCapabilities.InstrumentStatus;
 
     /// <summary>
     /// Send a <see cref="MessageType.ServerHello"/> as the very first server-initiated
@@ -184,7 +186,7 @@ internal static class SnapshotEmitter
         if (info.AdministrativeStatus is not { } status) return true;
         var buf = new byte[WireProtocol.InstrumentStatusMaxSize];
         int len = WireProtocol.WriteInstrumentStatus(
-            buf, securityId, info.Symbol, in status);
+            buf, securityId, info.Symbol, in status, isSnapshot: true);
         return session.TryEnqueue(new ReadOnlyMemory<byte>(buf, 0, len));
     }
 

--- a/src/B3.Umdf.Server/SubscriptionManager.cs
+++ b/src/B3.Umdf.Server/SubscriptionManager.cs
@@ -501,6 +501,36 @@ public sealed class SubscriptionManager : IDisposable
     }
 
     /// <summary>
+    /// Publishes a non-conflated halt/resume transition to existing Info
+    /// subscribers. The dedicated frame is additive: legacy clients skip its
+    /// unknown opcode and continue receiving the normal InfoSnapshot update.
+    /// </summary>
+    internal void PublishInstrumentStatus(
+        ulong securityId,
+        string? symbol,
+        in InstrumentStatusUpdate update)
+    {
+        if (!_subscriptions.TryGetValue(securityId, out var clients)) return;
+
+        byte[]? buffer = null;
+        int length = 0;
+        foreach (var (clientId, state) in clients)
+        {
+            if (!state.WantsInfo || !_clients.TryGetValue(clientId, out var session))
+                continue;
+
+            if (buffer is null)
+            {
+                buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+                length = WireProtocol.WriteInstrumentStatus(
+                    buffer, securityId, symbol, in update);
+            }
+
+            session.TryEnqueue(new ReadOnlyMemory<byte>(buffer, 0, length));
+        }
+    }
+
+    /// <summary>
     /// Wake <see cref="DataFlags.SecurityDefinition"/> subscribers for a security
     /// so their write loop emits a fresh <see cref="MessageType.SecurityDefinition"/>
     /// frame on the next cycle. Called by <c>GroupConflationHandler.OnSecurityDefinitionChanged</c>

--- a/src/B3.Umdf.Server/SubscriptionManager.cs
+++ b/src/B3.Umdf.Server/SubscriptionManager.cs
@@ -752,6 +752,8 @@ public sealed class SubscriptionManager : IDisposable
                     {
                         if (!SnapshotEmitter.SendInfoSnapshot(session, securityId, info))
                             return false;
+                        if (!SnapshotEmitter.SendInstrumentStatusSnapshot(session, securityId, info))
+                            return false;
                         break;
                     }
                 }

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -1006,14 +1006,17 @@ public static class WireProtocol
     // ───────────────────────────────────────────────────────────────────────
 
     public const byte InstrumentStatusUnavailable = byte.MaxValue;
+    public const byte InstrumentStatusDeliveryLiveTransition = 0;
+    public const byte InstrumentStatusDeliverySnapshot = 1;
     public const int InstrumentStatusMaxSize =
-        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 1 + 8 + 4;
+        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 1 + 8 + 4 + 1;
 
     /// <summary>
     /// Serialize a halt/resume transition decoded from <c>SecurityStatus_3</c>.
     /// Layout:
     /// <c>[secId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
-    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]
+    /// [deliveryKind u8]</c>.
     /// Unavailable previous status / halt reason / RptSeq are encoded as
     /// 255 / 255 / 0 respectively.
     /// </summary>
@@ -1021,7 +1024,8 @@ public static class WireProtocol
         Span<byte> dest,
         ulong securityId,
         string? symbol,
-        in InstrumentStatusUpdate update)
+        in InstrumentStatusUpdate update,
+        bool isSnapshot = false)
     {
         int offset = FramingHeaderSize;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
@@ -1040,6 +1044,9 @@ public static class WireProtocol
         dest[offset++] = update.HaltReasonCode ?? InstrumentStatusUnavailable;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], update.SourceTimestampNanos); offset += 8;
         BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], update.RptSeq ?? 0); offset += 4;
+        dest[offset++] = isSnapshot
+            ? InstrumentStatusDeliverySnapshot
+            : InstrumentStatusDeliveryLiveTransition;
 
         WriteFramingHeader(dest, offset, MessageType.InstrumentStatus);
         return offset;

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -1007,14 +1007,15 @@ public static class WireProtocol
 
     public const byte InstrumentStatusUnavailable = byte.MaxValue;
     public const int InstrumentStatusMaxSize =
-        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 8 + 4;
+        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 1 + 8 + 4;
 
     /// <summary>
     /// Serialize a halt/resume transition decoded from <c>SecurityStatus_3</c>.
     /// Layout:
     /// <c>[secId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
-    /// [reason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
-    /// A previous status or RptSeq that was unavailable is encoded as 255 or 0.
+    /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// Unavailable previous status / halt reason / RptSeq are encoded as
+    /// 255 / 255 / 0 respectively.
     /// </summary>
     public static int WriteInstrumentStatus(
         Span<byte> dest,
@@ -1035,7 +1036,8 @@ public static class WireProtocol
             ? checked((byte)previous)
             : InstrumentStatusUnavailable;
         dest[offset++] = checked((byte)update.NewStatus);
-        dest[offset++] = update.ReasonCode;
+        dest[offset++] = update.TransitionCode;
+        dest[offset++] = update.HaltReasonCode ?? InstrumentStatusUnavailable;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], update.SourceTimestampNanos); offset += 8;
         BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], update.RptSeq ?? 0); offset += 4;
 

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -1001,6 +1001,48 @@ public static class WireProtocol
         return totalLen;
     }
 
+    // ───────────────────────────────────────────────────────────────────────
+    //  InstrumentStatus frame (0x00B3) — SecurityStatus_3 halt/resume marker
+    // ───────────────────────────────────────────────────────────────────────
+
+    public const byte InstrumentStatusUnavailable = byte.MaxValue;
+    public const int InstrumentStatusMaxSize =
+        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 8 + 4;
+
+    /// <summary>
+    /// Serialize a halt/resume transition decoded from <c>SecurityStatus_3</c>.
+    /// Layout:
+    /// <c>[secId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
+    /// [reason u8][sourceTimestampNanos u64][rptSeq u32]</c>.
+    /// A previous status or RptSeq that was unavailable is encoded as 255 or 0.
+    /// </summary>
+    public static int WriteInstrumentStatus(
+        Span<byte> dest,
+        ulong securityId,
+        string? symbol,
+        in InstrumentStatusUpdate update)
+    {
+        int offset = FramingHeaderSize;
+        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], securityId); offset += 8;
+
+        var symBytes = Encoding.UTF8.GetBytes(symbol ?? string.Empty);
+        if (symBytes.Length > 255)
+            symBytes = symBytes[..255];
+        dest[offset++] = (byte)symBytes.Length;
+        symBytes.CopyTo(dest[offset..]); offset += symBytes.Length;
+
+        dest[offset++] = update.PreviousStatus is { } previous
+            ? checked((byte)previous)
+            : InstrumentStatusUnavailable;
+        dest[offset++] = checked((byte)update.NewStatus);
+        dest[offset++] = update.ReasonCode;
+        BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], update.SourceTimestampNanos); offset += 8;
+        BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], update.RptSeq ?? 0); offset += 4;
+
+        WriteFramingHeader(dest, offset, MessageType.InstrumentStatus);
+        return offset;
+    }
+
 }
 
 public readonly struct RankingEntry

--- a/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
@@ -1,0 +1,65 @@
+using B3.MarketData.Wire;
+using B3.Umdf.Book;
+using B3.Umdf.Server;
+
+namespace B3.MarketData.WebSocketClient.Tests;
+
+public class InstrumentStatusWireRoundTripTests
+{
+    [Fact]
+    public void Roundtrip_Halt_AllFieldsPreserved()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: 21,
+            NewStatus: 17,
+            ReasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+            SourceTimestampNanos: 1_750_000_000_123_456_789,
+            RptSeq: 77);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 12345, symbol: "PETR4", in update);
+
+        Assert.True(WireFormat.TryReadHeader(buffer, out var wireLength, out var type));
+        Assert.Equal((uint)length, wireLength);
+        Assert.Equal(MessageType.InstrumentStatus, type);
+        Assert.Equal((ushort)0x00B3, (ushort)type);
+
+        var decoded = WireFormat.ReadInstrumentStatus(
+            buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
+            new DateTime(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal(12345UL, decoded.SecurityId);
+        Assert.Equal("PETR4", decoded.Symbol);
+        Assert.Equal(21, decoded.PreviousStatus);
+        Assert.Equal(17, decoded.NewStatus);
+        Assert.Equal(InstrumentStatusReason.InstrumentHalted, decoded.Reason);
+        Assert.Equal(1, decoded.RawReasonCode);
+        Assert.True(decoded.IsHalted);
+        Assert.Equal(1_750_000_000_123_456_789UL, decoded.SourceTimestampNanos);
+        Assert.Equal(77u, decoded.RptSeq);
+    }
+
+    [Fact]
+    public void Roundtrip_FirstSightResume_UsesNullSentinels()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: null,
+            NewStatus: 17,
+            ReasonCode: InstrumentStatusDecoder.InstrumentResumedReasonCode,
+            SourceTimestampNanos: 123,
+            RptSeq: null);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 7, symbol: "VALE3", in update);
+
+        var decoded = WireFormat.ReadInstrumentStatus(
+            buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
+            DateTime.UnixEpoch);
+
+        Assert.Null(decoded.PreviousStatus);
+        Assert.Equal(InstrumentStatusReason.InstrumentResumed, decoded.Reason);
+        Assert.False(decoded.IsHalted);
+        Assert.Null(decoded.RptSeq);
+    }
+}

--- a/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using B3.MarketData.Wire;
 using B3.Umdf.Book;
 using B3.Umdf.Server;
@@ -40,6 +41,8 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Null(decoded.HaltReason);
         Assert.Null(decoded.RawHaltReasonCode);
         Assert.True(decoded.IsHalted);
+        Assert.Equal(InstrumentStatusDeliveryKind.LiveTransition, decoded.DeliveryKind);
+        Assert.False(decoded.IsSnapshot);
         Assert.Equal(1_750_000_000_123_456_789UL, decoded.SourceTimestampNanos);
         Assert.Equal(77u, decoded.RptSeq);
     }
@@ -56,7 +59,7 @@ public class InstrumentStatusWireRoundTripTests
             RptSeq: null);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
-            buffer, securityId: 7, symbol: "VALE3", in update);
+            buffer, securityId: 7, symbol: "VALE3", in update, isSnapshot: true);
 
         Assert.True(WireFormat.TryReadInstrumentStatus(
             buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
@@ -66,6 +69,8 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Null(decoded.PreviousStatus);
         Assert.Equal(InstrumentStatusTransitionKind.Resumed, decoded.Transition);
         Assert.False(decoded.IsHalted);
+        Assert.Equal(InstrumentStatusDeliveryKind.Snapshot, decoded.DeliveryKind);
+        Assert.True(decoded.IsSnapshot);
         Assert.Null(decoded.RptSeq);
     }
 
@@ -91,6 +96,50 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Equal(InstrumentStatusTransitionKind.Halted, decoded.Transition);
         Assert.Equal(InstrumentHaltReason.NewsHold, decoded.HaltReason);
         Assert.Equal((byte)InstrumentHaltReason.NewsHold, decoded.RawHaltReasonCode);
+    }
+
+    [Fact]
+    public void TryRead_LegacyFrameWithoutDeliveryKind_DefaultsToLiveTransition()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: 17,
+            NewStatus: 17,
+            TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+            HaltReasonCode: null,
+            SourceTimestampNanos: 123,
+            RptSeq: 1);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 7, symbol: "VALE3", in update, isSnapshot: true);
+        var payload = buffer.AsSpan(
+            WireFormat.FramingHeaderSize,
+            length - WireFormat.FramingHeaderSize - 1);
+
+        Assert.True(WireFormat.TryReadInstrumentStatus(
+            payload, DateTime.UnixEpoch, out var decoded));
+        Assert.Equal(InstrumentStatusDeliveryKind.LiveTransition, decoded.DeliveryKind);
+        Assert.False(decoded.IsSnapshot);
+    }
+
+    [Fact]
+    public void ServerCapabilities_InstrumentStatus_UsesAppendOnlyBit()
+    {
+        Assert.Equal(0x0004u, (uint)B3.MarketData.WebSocketClient.ServerCapabilities.InstrumentStatus);
+        Assert.Equal(0x0004u, (uint)B3.MarketData.Wire.ServerCapabilities.InstrumentStatus);
+    }
+
+    [Fact]
+    public void ServerHello_WithoutInstrumentStatusBit_IdentifiesOlderServer()
+    {
+        Span<byte> payload = stackalloc byte[9];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload, WireFormat.ProtocolVersion);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[4..], 0x0003);
+        payload[8] = 0;
+
+        var (_, capabilities, _) = WireFormat.ReadServerHello(payload);
+
+        Assert.False(capabilities.HasFlag(
+            B3.MarketData.WebSocketClient.ServerCapabilities.InstrumentStatus));
     }
 
     [Theory]

--- a/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
@@ -12,7 +12,8 @@ public class InstrumentStatusWireRoundTripTests
         var update = new InstrumentStatusUpdate(
             PreviousStatus: 21,
             NewStatus: 17,
-            ReasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+            TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+            HaltReasonCode: null,
             SourceTimestampNanos: 1_750_000_000_123_456_789,
             RptSeq: 77);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
@@ -25,16 +26,19 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Equal(MessageType.InstrumentStatus, type);
         Assert.Equal((ushort)0x00B3, (ushort)type);
 
-        var decoded = WireFormat.ReadInstrumentStatus(
+        Assert.True(WireFormat.TryReadInstrumentStatus(
             buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
-            new DateTime(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc));
+            new DateTime(2026, 7, 27, 0, 0, 0, DateTimeKind.Utc),
+            out var decoded));
 
         Assert.Equal(12345UL, decoded.SecurityId);
         Assert.Equal("PETR4", decoded.Symbol);
         Assert.Equal(21, decoded.PreviousStatus);
         Assert.Equal(17, decoded.NewStatus);
-        Assert.Equal(InstrumentStatusReason.InstrumentHalted, decoded.Reason);
-        Assert.Equal(1, decoded.RawReasonCode);
+        Assert.Equal(InstrumentStatusTransitionKind.Halted, decoded.Transition);
+        Assert.Equal(1, decoded.RawTransitionCode);
+        Assert.Null(decoded.HaltReason);
+        Assert.Null(decoded.RawHaltReasonCode);
         Assert.True(decoded.IsHalted);
         Assert.Equal(1_750_000_000_123_456_789UL, decoded.SourceTimestampNanos);
         Assert.Equal(77u, decoded.RptSeq);
@@ -46,20 +50,66 @@ public class InstrumentStatusWireRoundTripTests
         var update = new InstrumentStatusUpdate(
             PreviousStatus: null,
             NewStatus: 17,
-            ReasonCode: InstrumentStatusDecoder.InstrumentResumedReasonCode,
+            TransitionCode: InstrumentStatusDecoder.InstrumentResumedTransitionCode,
+            HaltReasonCode: null,
             SourceTimestampNanos: 123,
             RptSeq: null);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
             buffer, securityId: 7, symbol: "VALE3", in update);
 
-        var decoded = WireFormat.ReadInstrumentStatus(
+        Assert.True(WireFormat.TryReadInstrumentStatus(
             buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
-            DateTime.UnixEpoch);
+            DateTime.UnixEpoch,
+            out var decoded));
 
         Assert.Null(decoded.PreviousStatus);
-        Assert.Equal(InstrumentStatusReason.InstrumentResumed, decoded.Reason);
+        Assert.Equal(InstrumentStatusTransitionKind.Resumed, decoded.Transition);
         Assert.False(decoded.IsHalted);
         Assert.Null(decoded.RptSeq);
+    }
+
+    [Fact]
+    public void Roundtrip_FutureDetailedReason_IsSeparateFromTransition()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: 17,
+            NewStatus: 17,
+            TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+            HaltReasonCode: (byte)InstrumentHaltReason.NewsHold,
+            SourceTimestampNanos: 123,
+            RptSeq: 1);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 7, symbol: "VALE3", in update);
+
+        Assert.True(WireFormat.TryReadInstrumentStatus(
+            buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
+            DateTime.UnixEpoch,
+            out var decoded));
+
+        Assert.Equal(InstrumentStatusTransitionKind.Halted, decoded.Transition);
+        Assert.Equal(InstrumentHaltReason.NewsHold, decoded.HaltReason);
+        Assert.Equal((byte)InstrumentHaltReason.NewsHold, decoded.RawHaltReasonCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(8)]
+    [InlineData(24)]
+    public void TryRead_TruncatedPayload_ReturnsFalse(int length)
+    {
+        Assert.False(WireFormat.TryReadInstrumentStatus(
+            new byte[length], DateTime.UnixEpoch, out _));
+    }
+
+    [Fact]
+    public void TryRead_SymbolLengthExceedsPayload_ReturnsFalse()
+    {
+        var payload = new byte[25];
+        payload[8] = 10;
+
+        Assert.False(WireFormat.TryReadInstrumentStatus(
+            payload, DateTime.UnixEpoch, out _));
     }
 }

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -3,6 +3,8 @@ using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
+using B3.Umdf.Book;
+using B3.Umdf.Server;
 using B3.MarketData.WebSocketClient;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -64,6 +66,44 @@ public class MarketDataClientIntegrationTests
         Assert.Equal(1L, trade.TradeId);
         Assert.True(client.TryGetSecurityId("PETR4", out var resolved));
         Assert.Equal(12345UL, resolved);
+    }
+
+    [Fact]
+    public async Task InstrumentStatus_IsSurfacedAsTypedInfoEvent()
+    {
+        const ulong sourceTimestamp = 1_750_000_000_123_456_789;
+        var port = FindFreePort();
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var symbol = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 12345, symbol, ct);
+            await TestWsServer.SendInstrumentStatusAsync(
+                ws, 12345, symbol, previousStatus: 17, newStatus: 17,
+                reasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+                sourceTimestamp, rptSeq: 9, ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        var received = new TaskCompletionSource<InstrumentStatusEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+        });
+        client.InstrumentStatus += status => received.TrySetResult(status);
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4", SubscribeFlags.Info);
+
+        var status = await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("PETR4", status.Symbol);
+        Assert.Equal(17, status.PreviousStatus);
+        Assert.Equal(17, status.NewStatus);
+        Assert.Equal(InstrumentStatusReason.InstrumentHalted, status.Reason);
+        Assert.True(status.IsHalted);
+        Assert.Equal(sourceTimestamp, status.SourceTimestampNanos);
+        Assert.Equal(9u, status.RptSeq);
     }
 
     [Fact]
@@ -415,6 +455,26 @@ internal sealed class TestWsServer : IAsyncDisposable
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(24), qty);
         BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(32), tradeId);
         return ws.SendAsync(buf, WebSocketMessageType.Binary, true, ct);
+    }
+
+    public static Task SendInstrumentStatusAsync(
+        WebSocket ws,
+        ulong securityId,
+        string symbol,
+        int? previousStatus,
+        int newStatus,
+        byte reasonCode,
+        ulong sourceTimestamp,
+        uint? rptSeq,
+        CancellationToken ct)
+    {
+        var update = new InstrumentStatusUpdate(
+            previousStatus, newStatus, reasonCode, sourceTimestamp, rptSeq);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId, symbol, in update);
+        return ws.SendAsync(
+            buffer.AsMemory(0, length), WebSocketMessageType.Binary, true, ct).AsTask();
     }
 
     /// <summary>

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
 using System.Net.WebSockets;
@@ -79,7 +80,7 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendSubscribeOkAsync(ws, securityId: 12345, symbol, ct);
             await TestWsServer.SendInstrumentStatusAsync(
                 ws, 12345, symbol, previousStatus: 17, newStatus: 17,
-                reasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+                transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
                 sourceTimestamp, rptSeq: 9, ct);
             await Task.Delay(Timeout.Infinite, ct);
         });
@@ -100,10 +101,107 @@ public class MarketDataClientIntegrationTests
         Assert.Equal("PETR4", status.Symbol);
         Assert.Equal(17, status.PreviousStatus);
         Assert.Equal(17, status.NewStatus);
-        Assert.Equal(InstrumentStatusReason.InstrumentHalted, status.Reason);
+        Assert.Equal(InstrumentStatusTransitionKind.Halted, status.Transition);
+        Assert.Null(status.HaltReason);
         Assert.True(status.IsHalted);
         Assert.Equal(sourceTimestamp, status.SourceTimestampNanos);
         Assert.Equal(9u, status.RptSeq);
+    }
+
+    [Fact]
+    public async Task InstrumentStatus_ReconnectResubscribe_ReplaysCurrentHaltState()
+    {
+        var port = FindFreePort();
+        int subscribesSeen = 0;
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var symbol = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            int subscribeNumber = Interlocked.Increment(ref subscribesSeen);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 42, symbol, ct);
+            await TestWsServer.SendInstrumentStatusAsync(
+                ws, 42, symbol, previousStatus: 17, newStatus: 17,
+                transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+                sourceTimestamp: 123, rptSeq: 9, ct);
+
+            if (subscribeNumber == 1)
+            {
+                await Task.Delay(100, ct);
+                await ws.CloseAsync(
+                    WebSocketCloseStatus.EndpointUnavailable, "force reconnect", ct);
+                return;
+            }
+
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        int statusCount = 0;
+        var statuses = new ConcurrentQueue<InstrumentStatusEvent>();
+        var replayed = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+            ReconnectInitialDelay = TimeSpan.FromMilliseconds(50),
+            ReconnectMaxDelay = TimeSpan.FromMilliseconds(200),
+        });
+        client.InstrumentStatus += status =>
+        {
+            statuses.Enqueue(status);
+            if (Interlocked.Increment(ref statusCount) == 2)
+                replayed.TrySetResult(true);
+        };
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4", SubscribeFlags.Info);
+
+        await replayed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(subscribesSeen >= 2);
+        Assert.Equal(2, Volatile.Read(ref statusCount));
+        Assert.All(statuses, status =>
+        {
+            Assert.True(status.IsHalted);
+            Assert.Null(status.HaltReason);
+        });
+    }
+
+    [Fact]
+    public async Task MalformedInstrumentStatus_IsDroppedWithoutReconnect()
+    {
+        var port = FindFreePort();
+        int subscribesSeen = 0;
+        await using var server = await TestWsServer.StartAsync(port, async (ws, ct) =>
+        {
+            var symbol = await TestWsServer.ReadSubscribeAsync(ws, ct);
+            Interlocked.Increment(ref subscribesSeen);
+            await TestWsServer.SendSubscribeOkAsync(ws, securityId: 42, symbol, ct);
+            await TestWsServer.SendMalformedInstrumentStatusAsync(ws, ct);
+            await TestWsServer.SendTradeAsync(
+                ws, securityId: 42, price: 12345, qty: 10, tradeId: 1, ct);
+            await Task.Delay(Timeout.Infinite, ct);
+        });
+
+        int instrumentStatuses = 0;
+        var tradeReceived = new TaskCompletionSource<TradeEvent>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var client = new MarketDataClient(new MarketDataClientOptions
+        {
+            Endpoint = new Uri($"ws://127.0.0.1:{port}/ws"),
+            ReconnectInitialDelay = TimeSpan.FromMilliseconds(50),
+        });
+        client.InstrumentStatus += _ => Interlocked.Increment(ref instrumentStatuses);
+        client.Trade += trade => tradeReceived.TrySetResult(trade);
+
+        await client.ConnectAsync();
+        await WaitUntil(() => client.State == ConnectionState.Connected, TimeSpan.FromSeconds(5));
+        await client.SubscribeAsync("PETR4", SubscribeFlags.Info | SubscribeFlags.Trades);
+
+        var trade = await tradeReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Task.Delay(200);
+        Assert.Equal(42UL, trade.SecurityId);
+        Assert.Equal(0, Volatile.Read(ref instrumentStatuses));
+        Assert.Equal(1, Volatile.Read(ref subscribesSeen));
+        Assert.Equal(ConnectionState.Connected, client.State);
     }
 
     [Fact]
@@ -463,18 +561,33 @@ internal sealed class TestWsServer : IAsyncDisposable
         string symbol,
         int? previousStatus,
         int newStatus,
-        byte reasonCode,
+        byte transitionCode,
         ulong sourceTimestamp,
         uint? rptSeq,
         CancellationToken ct)
     {
         var update = new InstrumentStatusUpdate(
-            previousStatus, newStatus, reasonCode, sourceTimestamp, rptSeq);
+            previousStatus, newStatus, transitionCode, null,
+            sourceTimestamp, rptSeq);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
             buffer, securityId, symbol, in update);
         return ws.SendAsync(
             buffer.AsMemory(0, length), WebSocketMessageType.Binary, true, ct).AsTask();
+    }
+
+    public static Task SendMalformedInstrumentStatusAsync(
+        WebSocket ws,
+        CancellationToken ct)
+    {
+        const int length = 8 + 8 + 1;
+        var buffer = new byte[length];
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, length);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            buffer.AsSpan(4), (ushort)B3.MarketData.Wire.MessageType.InstrumentStatus);
+        BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(8), 42);
+        buffer[16] = 20;
+        return ws.SendAsync(buffer, WebSocketMessageType.Binary, true, ct);
     }
 
     /// <summary>

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -81,7 +81,7 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendInstrumentStatusAsync(
                 ws, 12345, symbol, previousStatus: 17, newStatus: 17,
                 transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
-                sourceTimestamp, rptSeq: 9, ct);
+                sourceTimestamp, rptSeq: 9, isSnapshot: false, ct: ct);
             await Task.Delay(Timeout.Infinite, ct);
         });
 
@@ -104,6 +104,7 @@ public class MarketDataClientIntegrationTests
         Assert.Equal(InstrumentStatusTransitionKind.Halted, status.Transition);
         Assert.Null(status.HaltReason);
         Assert.True(status.IsHalted);
+        Assert.False(status.IsSnapshot);
         Assert.Equal(sourceTimestamp, status.SourceTimestampNanos);
         Assert.Equal(9u, status.RptSeq);
     }
@@ -121,7 +122,7 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendInstrumentStatusAsync(
                 ws, 42, symbol, previousStatus: 17, newStatus: 17,
                 transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
-                sourceTimestamp: 123, rptSeq: 9, ct);
+                sourceTimestamp: 123, rptSeq: 9, isSnapshot: true, ct: ct);
 
             if (subscribeNumber == 1)
             {
@@ -162,6 +163,7 @@ public class MarketDataClientIntegrationTests
         {
             Assert.True(status.IsHalted);
             Assert.Null(status.HaltReason);
+            Assert.True(status.IsSnapshot);
         });
     }
 
@@ -322,7 +324,7 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendServerHelloAsync(
                 ws,
                 protocolVersion: 1,
-                capabilities: 0x03, // SnapshotOnSubscribe | SymbolDelistedNotification
+                capabilities: 0x07, // SnapshotOnSubscribe | SymbolDelistedNotification | InstrumentStatus
                 buildVersion: "1.2.3-test",
                 ct);
             await Task.Delay(Timeout.Infinite, ct);
@@ -340,7 +342,11 @@ public class MarketDataClientIntegrationTests
 
         var hello = await helloReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Equal(1U, hello.ProtocolVersion);
-        Assert.Equal(ServerCapabilities.SnapshotOnSubscribe | ServerCapabilities.SymbolDelistedNotification, hello.Capabilities);
+        Assert.Equal(
+            ServerCapabilities.SnapshotOnSubscribe
+            | ServerCapabilities.SymbolDelistedNotification
+            | ServerCapabilities.InstrumentStatus,
+            hello.Capabilities);
         Assert.Equal("1.2.3-test", hello.BuildVersion);
 
         // LastServerHello property snapshots the most-recently-received hello so
@@ -564,6 +570,7 @@ internal sealed class TestWsServer : IAsyncDisposable
         byte transitionCode,
         ulong sourceTimestamp,
         uint? rptSeq,
+        bool isSnapshot,
         CancellationToken ct)
     {
         var update = new InstrumentStatusUpdate(
@@ -571,7 +578,7 @@ internal sealed class TestWsServer : IAsyncDisposable
             sourceTimestamp, rptSeq);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
-            buffer, securityId, symbol, in update);
+            buffer, securityId, symbol, in update, isSnapshot);
         return ws.SendAsync(
             buffer.AsMemory(0, length), WebSocketMessageType.Binary, true, ct).AsTask();
     }

--- a/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
+++ b/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
@@ -1,0 +1,135 @@
+using System.Buffers.Binary;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Transport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Book.Tests;
+
+public class InstrumentStatusDecoderTests
+{
+    [Theory]
+    [InlineData(InstrumentStatusDecoder.InstrumentHaltedReasonCode)]
+    [InlineData(InstrumentStatusDecoder.InstrumentResumedReasonCode)]
+    public void TryDecode_SecurityStatusExtension_PreservesExactFields(byte reasonCode)
+    {
+        const ulong sourceTimestamp = 1_750_000_000_123_456_789;
+        var body = BuildBody(
+            securityId: 12345,
+            status: SecurityTradingStatus.OPEN,
+            eventCode: reasonCode,
+            sourceTimestamp,
+            rptSeq: 77);
+
+        Assert.True(SecurityStatus_3Data.TryParse(body, out var reader));
+        Assert.True(InstrumentStatusDecoder.TryDecode(in reader, previousStatus: 21, out var update));
+
+        Assert.Equal(21, update.PreviousStatus);
+        Assert.Equal((int)SecurityTradingStatus.OPEN, update.NewStatus);
+        Assert.Equal(reasonCode, update.ReasonCode);
+        Assert.Equal(sourceTimestamp, update.SourceTimestampNanos);
+        Assert.Equal(77u, update.RptSeq);
+    }
+
+    [Fact]
+    public void TryDecode_StandardSecurityTradingEvent_IsNotInstrumentTransition()
+    {
+        var body = BuildBody(
+            securityId: 1,
+            status: SecurityTradingStatus.OPEN,
+            eventCode: (byte)SecurityTradingEvent.SECURITY_STATUS_CHANGE,
+            sourceTimestamp: 123,
+            rptSeq: 1);
+
+        Assert.True(SecurityStatus_3Data.TryParse(body, out var reader));
+        Assert.False(InstrumentStatusDecoder.TryDecode(in reader, previousStatus: null, out _));
+    }
+
+    [Fact]
+    public void MarketDataManager_SurfacesPreviousAndNewStatusDeterministically()
+    {
+        var handler = new CapturingHandler();
+        var manager = new MarketDataManager(
+            handler,
+            stateRegistry: new SymbolStateRegistry(NullLogger.Instance));
+
+        manager.OnPacket(
+            in EmptyPacket,
+            BuildFrame(42, SecurityTradingStatus.RESERVED,
+                (byte)SecurityTradingEvent.SECURITY_STATUS_CHANGE, 100, 1),
+            SecurityStatus_3Data.MESSAGE_ID);
+        manager.OnPacket(
+            in EmptyPacket,
+            BuildFrame(42, SecurityTradingStatus.OPEN,
+                InstrumentStatusDecoder.InstrumentHaltedReasonCode, 200, 2),
+            SecurityStatus_3Data.MESSAGE_ID);
+
+        Assert.Equal(1, handler.Count);
+        Assert.Equal(42UL, handler.SecurityId);
+        Assert.Equal((int)SecurityTradingStatus.RESERVED, handler.Update.PreviousStatus);
+        Assert.Equal((int)SecurityTradingStatus.OPEN, handler.Update.NewStatus);
+        Assert.Equal(InstrumentStatusDecoder.InstrumentHaltedReasonCode, handler.Update.ReasonCode);
+        Assert.Equal(200UL, handler.Update.SourceTimestampNanos);
+        Assert.Equal(2u, handler.Update.RptSeq);
+    }
+
+    private static byte[] BuildFrame(
+        ulong securityId,
+        SecurityTradingStatus status,
+        byte eventCode,
+        ulong sourceTimestamp,
+        uint rptSeq)
+    {
+        var frame = new byte[MessageHeader.MESSAGE_SIZE + SecurityStatus_3Data.MESSAGE_SIZE];
+        SecurityStatus_3Data.WriteHeader(frame);
+        BuildBody(securityId, status, eventCode, sourceTimestamp, rptSeq)
+            .CopyTo(frame, MessageHeader.MESSAGE_SIZE);
+        return frame;
+    }
+
+    private static byte[] BuildBody(
+        ulong securityId,
+        SecurityTradingStatus status,
+        byte eventCode,
+        ulong sourceTimestamp,
+        uint rptSeq)
+    {
+        var message = new SecurityStatus_3Data
+        {
+            SecurityID = securityId,
+            SecurityTradingStatus = status,
+        };
+        message.SetSecurityTradingEvent((SecurityTradingEvent)eventCode);
+        message.SetRptSeq(rptSeq);
+
+        var body = new byte[SecurityStatus_3Data.MESSAGE_SIZE];
+        Assert.True(message.TryEncode(body, out var written));
+        Assert.Equal(SecurityStatus_3Data.MESSAGE_SIZE, written);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(24), sourceTimestamp);
+        return body;
+    }
+
+    private static readonly UmdfPacket EmptyPacket = new()
+    {
+        Data = ReadOnlyMemory<byte>.Empty,
+        Channel = ChannelType.IncrementalA,
+        ChannelGroup = 1,
+        ReceivedTimestampTicks = 0,
+    };
+
+    private sealed class CapturingHandler : IMarketDataEventHandler
+    {
+        public int Count { get; private set; }
+        public ulong SecurityId { get; private set; }
+        public InstrumentStatusUpdate Update { get; private set; }
+
+        public void OnInstrumentStatusChanged(
+            ulong securityId,
+            InstrumentInfo info,
+            in InstrumentStatusUpdate update)
+        {
+            Count++;
+            SecurityId = securityId;
+            Update = update;
+        }
+    }
+}

--- a/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
+++ b/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
@@ -8,15 +8,15 @@ namespace B3.Umdf.Book.Tests;
 public class InstrumentStatusDecoderTests
 {
     [Theory]
-    [InlineData(InstrumentStatusDecoder.InstrumentHaltedReasonCode)]
-    [InlineData(InstrumentStatusDecoder.InstrumentResumedReasonCode)]
-    public void TryDecode_SecurityStatusExtension_PreservesExactFields(byte reasonCode)
+    [InlineData(InstrumentStatusDecoder.InstrumentHaltedTransitionCode)]
+    [InlineData(InstrumentStatusDecoder.InstrumentResumedTransitionCode)]
+    public void TryDecode_SecurityStatusExtension_PreservesExactFields(byte transitionCode)
     {
         const ulong sourceTimestamp = 1_750_000_000_123_456_789;
         var body = BuildBody(
             securityId: 12345,
             status: SecurityTradingStatus.OPEN,
-            eventCode: reasonCode,
+            eventCode: transitionCode,
             sourceTimestamp,
             rptSeq: 77);
 
@@ -25,7 +25,8 @@ public class InstrumentStatusDecoderTests
 
         Assert.Equal(21, update.PreviousStatus);
         Assert.Equal((int)SecurityTradingStatus.OPEN, update.NewStatus);
-        Assert.Equal(reasonCode, update.ReasonCode);
+        Assert.Equal(transitionCode, update.TransitionCode);
+        Assert.Null(update.HaltReasonCode);
         Assert.Equal(sourceTimestamp, update.SourceTimestampNanos);
         Assert.Equal(77u, update.RptSeq);
     }
@@ -60,16 +61,23 @@ public class InstrumentStatusDecoderTests
         manager.OnPacket(
             in EmptyPacket,
             BuildFrame(42, SecurityTradingStatus.OPEN,
-                InstrumentStatusDecoder.InstrumentHaltedReasonCode, 200, 2),
+                InstrumentStatusDecoder.InstrumentHaltedTransitionCode, 200, 2),
+            SecurityStatus_3Data.MESSAGE_ID);
+        manager.OnPacket(
+            in EmptyPacket,
+            BuildFrame(42, SecurityTradingStatus.OPEN,
+                (byte)SecurityTradingEvent.SECURITY_STATUS_CHANGE, 300, 3),
             SecurityStatus_3Data.MESSAGE_ID);
 
         Assert.Equal(1, handler.Count);
         Assert.Equal(42UL, handler.SecurityId);
         Assert.Equal((int)SecurityTradingStatus.RESERVED, handler.Update.PreviousStatus);
         Assert.Equal((int)SecurityTradingStatus.OPEN, handler.Update.NewStatus);
-        Assert.Equal(InstrumentStatusDecoder.InstrumentHaltedReasonCode, handler.Update.ReasonCode);
+        Assert.Equal(InstrumentStatusDecoder.InstrumentHaltedTransitionCode, handler.Update.TransitionCode);
+        Assert.Null(handler.Update.HaltReasonCode);
         Assert.Equal(200UL, handler.Update.SourceTimestampNanos);
         Assert.Equal(2u, handler.Update.RptSeq);
+        Assert.Equal(handler.Update, manager.InstrumentData[42].AdministrativeStatus);
     }
 
     private static byte[] BuildFrame(

--- a/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
+++ b/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using B3.Umdf.Book;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.Server.Tests;
+
+public class InstrumentStatusBootstrapTests
+{
+    private const ulong SecurityId = 42;
+    private const string Symbol = "PETR4";
+
+    [Fact]
+    public async Task InfoSubscribe_EmitsCachedAdministrativeStatus()
+    {
+        using var manager = new SubscriptionManager();
+        var group = manager.CreateGroupHandler();
+        var registry = new SymbolStateRegistry(NullLogger.Instance);
+        var bookManager = new BookManager(
+            stateRegistry: registry,
+            staleBuffer: new StaleMboBuffer(NullLogger.Instance));
+        var marketDataManager = new MarketDataManager(stateRegistry: registry);
+        group.SetBookManager(bookManager);
+
+        var info = marketDataManager.GetOrCreateInfo(SecurityId);
+        info.Symbol = Symbol;
+        info.TradingStatus = 17;
+        info.AdministrativeStatus = new InstrumentStatusUpdate(
+            PreviousStatus: 17,
+            NewStatus: 17,
+            TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+            HaltReasonCode: null,
+            SourceTimestampNanos: 123,
+            RptSeq: 9);
+
+        var symbols = new SymbolRegistry();
+        RegisterSymbol(symbols, Symbol, SecurityId);
+        manager.SetDataSources(
+            new[] { bookManager },
+            new[] { marketDataManager },
+            symbols,
+            new[] { group });
+        manager.SetReady();
+
+        var socket = new RecordingWebSocket();
+        using var session = new ClientSession(socket, channelCapacity: 64);
+        manager.RegisterClient(session);
+        var writeTask = session.RunWriteLoopAsync();
+
+        manager.HandleSubscribe(
+            session.Id, Symbol, DataFlags.Info, bookManager, group,
+            bookBatchCutoffSequence: 0);
+
+        await WaitUntil(
+            () => socket.HasMessageType(MessageType.InstrumentStatus),
+            TimeSpan.FromSeconds(2));
+        Assert.Equal(1, socket.CountByType(MessageType.InstrumentStatus));
+
+        session.Dispose();
+        await writeTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    private static void RegisterSymbol(
+        SymbolRegistry registry,
+        string symbol,
+        ulong securityId)
+    {
+        var bySymbol = (ConcurrentDictionary<string, ulong>)typeof(SymbolRegistry)
+            .GetField("_bySymbol", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(registry)!;
+        var byId = (ConcurrentDictionary<ulong, string>)typeof(SymbolRegistry)
+            .GetField("_byId", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(registry)!;
+        bySymbol[symbol] = securityId;
+        byId[securityId] = symbol;
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(20);
+        }
+        Assert.True(predicate(), "Timed out waiting for instrument status snapshot.");
+    }
+}

--- a/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
+++ b/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
@@ -55,6 +55,11 @@ public class InstrumentStatusBootstrapTests
             () => socket.HasMessageType(MessageType.InstrumentStatus),
             TimeSpan.FromSeconds(2));
         Assert.Equal(1, socket.CountByType(MessageType.InstrumentStatus));
+        var frame = socket.LastFrame(MessageType.InstrumentStatus);
+        Assert.NotNull(frame);
+        Assert.Equal(
+            WireProtocol.InstrumentStatusDeliverySnapshot,
+            frame![^1]);
 
         session.Dispose();
         await writeTask.WaitAsync(TimeSpan.FromSeconds(2));

--- a/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
+++ b/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
@@ -273,7 +273,8 @@ public class SubscriptionManagerTests
         var update = new InstrumentStatusUpdate(
             PreviousStatus: 17,
             NewStatus: 17,
-            ReasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+            TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+            HaltReasonCode: null,
             SourceTimestampNanos: 123,
             RptSeq: 9);
         sm.PublishInstrumentStatus(securityId, "PETR4", in update);

--- a/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
+++ b/tests/B3.Umdf.Server.Tests/SubscriptionManagerTests.cs
@@ -256,6 +256,33 @@ public class SubscriptionManagerTests
     }
 
     [Fact]
+    public void PublishInstrumentStatus_RoutesOnlyToInfoSubscribers()
+    {
+        using var sm = new SubscriptionManager();
+        using var infoSubscriber = new ClientSession(new FakeWebSocket(), channelCapacity: 16);
+        using var bookOnlySubscriber = new ClientSession(new FakeWebSocket(), channelCapacity: 16);
+        sm.RegisterClient(infoSubscriber);
+        sm.RegisterClient(bookOnlySubscriber);
+
+        const ulong securityId = 42;
+        sm.AddSubscriptionForTest(infoSubscriber.Id, securityId, DataFlags.Info);
+        sm.AddSubscriptionForTest(bookOnlySubscriber.Id, securityId, DataFlags.Book);
+        int infoBefore = infoSubscriber.QueueDepth;
+        int bookBefore = bookOnlySubscriber.QueueDepth;
+
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: 17,
+            NewStatus: 17,
+            ReasonCode: InstrumentStatusDecoder.InstrumentHaltedReasonCode,
+            SourceTimestampNanos: 123,
+            RptSeq: 9);
+        sm.PublishInstrumentStatus(securityId, "PETR4", in update);
+
+        Assert.Equal(infoBefore + 1, infoSubscriber.QueueDepth);
+        Assert.Equal(bookBefore, bookOnlySubscriber.QueueDepth);
+    }
+
+    [Fact]
     public void AppSettings_DefaultValues()
     {
         var settings = new AppSettings();

--- a/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
+++ b/tests/B3.Umdf.Server.Tests/WebSocketHostIntegrationTests.cs
@@ -265,6 +265,7 @@ public class WebSocketHostIntegrationTests
             Assert.False(string.IsNullOrEmpty(buildVersion), "ServerHello.buildVersion must be non-empty");
             Assert.True(capabilities.HasFlag(ServerCapabilities.SnapshotOnSubscribe));
             Assert.True(capabilities.HasFlag(ServerCapabilities.SymbolDelistedNotification));
+            Assert.True(capabilities.HasFlag(ServerCapabilities.InstrumentStatus));
 
             await ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
         }


### PR DESCRIPTION
## Status

Partial implementation for issue #73. Issue #73 must remain open because the current upstream UMDF contract does not transmit the operator halt reason, which is the issue's core motivation. The prerequisite is tracked in pedrosakuma/B3MatchingPlatform#581.

## Authoritative upstream finding

- B3MatchingPlatform repository code search finds no `InstrumentStatus_NN` template.
- schema 2.2.0 contains only `SecurityStatus_3` (id 3), with status/event/timestamps/RptSeq and no detailed halt-reason field.
- `InstrumentHaltedEvent` carries `HaltReason`, but `ChannelDispatcher.Sinks.OnInstrumentHalted` discards it when calling `UmdfFrameBuilder.WriteInstrumentHalted`.
- the encoder writes only proprietary `securityTradingEvent=1` (halt) or `2` (resume).

Evidence and pinned source links are documented in `docs/WEBSOCKET-PROTOCOL.md`.

## Implemented

- decode halt/resume transition markers from schema-generated `SecurityStatus_3`
- keep transition kind separate from nullable detailed `HaltReason`; never invent reason data
- retain current administrative state/metadata in `InstrumentInfo`
- emit cached typed status after `InfoSnapshot` on subscribe and reconnect/re-subscribe
- append-only `deliveryKind` byte plus SDK `DeliveryKind`/`IsSnapshot`, so replayed state cannot trigger live-transition side effects
- legacy frames without the appended byte decode as `LiveTransition`
- advertise support with append-only `ServerCapabilities.InstrumentStatus = 0x0004`, mirrored by server and SDK
- additive WebSocket `InstrumentStatus` frame (`0x00B3`) for existing `Info` subscribers
- bounds-checked `TryReadInstrumentStatus` validates minimum payload and symbol length
- malformed frames are logged/skipped without reconnecting; later frames still decode
- protocol/client documentation updated with capability, delivery, bootstrap, and blocker semantics

## Validation

- full solution build: passed
- `B3.Umdf.Sbe.Tests`: 16 passed
- `B3.Umdf.Book.Tests`: 269 passed
- `B3.Umdf.Server.Tests`: 194 passed
- `B3.MarketData.WebSocketClient.Tests`: 98 passed

Server/client suites were run with `DOTNET_USE_POLLING_FILE_WATCHER=1` because the shared host had exhausted its inotify-instance quota.