### PR TITLE
feat: preserve V17 instrument status integration (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,9 @@ values reference and topology notes.
 
 ## B3 schema
 
-This project uses the [B3 Market Data Messages v2.2.0](https://www.b3.com.br/en_us/solutions/platforms/puma-trading-system/for-developers-and-vendors/binary-umdf/)
-SBE XML schema. The schema's `<!DOCTYPE xml>` declaration is removed
-because .NET's `XmlReader` prohibits DTD processing by default. This is
-the only modification to the original B3 schema.
+This project uses the B3 Market Data Messages v2.3.0 / schema V17 SBE XML
+contract mirrored from the matching venue. It includes the authoritative
+`InstrumentStatus_58` administrative halt state and reason extension.
 
 ## Documentation
 

--- a/benchmarks/B3.Umdf.Book.Benchmarks/BookManagerOnPacketBenchmarks.cs
+++ b/benchmarks/B3.Umdf.Book.Benchmarks/BookManagerOnPacketBenchmarks.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/benchmarks/B3.Umdf.Book.Benchmarks/HotSymbolOnPacketBenchmarks.cs
+++ b/benchmarks/B3.Umdf.Book.Benchmarks/HotSymbolOnPacketBenchmarks.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/benchmarks/B3.Umdf.Book.Benchmarks/MbpBandwidthBenchmarks.cs
+++ b/benchmarks/B3.Umdf.Book.Benchmarks/MbpBandwidthBenchmarks.cs
@@ -1,5 +1,5 @@
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/benchmarks/B3.Umdf.Book.Benchmarks/OnPacketAllocProbe.cs
+++ b/benchmarks/B3.Umdf.Book.Benchmarks/OnPacketAllocProbe.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/docs/CLIENT-SDK.md
+++ b/docs/CLIENT-SDK.md
@@ -41,7 +41,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 client.Trade        += t => Console.WriteLine($"{t.Symbol} @ {t.Price} x {t.Qty}{(t.Flags.HasFlag(TradeFlags.AuctionPrint) ? " (auction)" : "")}");
 client.InfoSnapshot += i => Console.WriteLine($"{i.Symbol} last={i.LastTradePrice} top={i.TheoreticalOpeningPrice} imb={i.AuctionImbalanceCondition}");
 client.InstrumentStatus += s => Console.WriteLine(
-    $"{s.Symbol} transition={s.Transition} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
+    $"{s.Symbol} state={s.AdministrativeState} transition={s.Transition} haltReason={s.HaltReason?.ToString() ?? "none"} snapshot={s.IsSnapshot}");
 client.ServerStatus += s => Console.WriteLine($"server ready={s.Ready}");
 client.SubscribeError += e => Console.WriteLine($"{e.Symbol} -> {e.ErrorCode}");
 
@@ -247,42 +247,41 @@ client.InstrumentStatus += status =>
 {
     if (status.IsSnapshot)
     {
-        Console.WriteLine($"{status.Symbol}: bootstrapped halted={status.IsHalted}");
+        Console.WriteLine(
+            $"{status.Symbol}: bootstrapped state={status.AdministrativeState} reason={status.HaltReason}");
         return;
     }
 
     Console.WriteLine(
         $"{status.Symbol}: {(status.IsHalted ? "HALTED" : "RESUMED")} " +
         $"phase {status.PreviousStatus?.ToString() ?? "unknown"} -> {status.NewStatus}, " +
+        $"reason={status.HaltReason}, session={status.TradingSessionId}, " +
         $"sourceNs={status.SourceTimestampNanos}");
 };
 
 await client.SubscribeAsync("PETR4", SubscribeFlags.Info);
 ```
 
-The platform decodes the existing schema-generated UMDF
-`SecurityStatus_3` template (id 3), not a separate `InstrumentStatus_NN`
-template. B3MatchingPlatform marks halt with `securityTradingEvent=1` and
-resume with `securityTradingEvent=2`; these map to
-`InstrumentStatusTransitionKind.Halted` and `Resumed`.
-`PreviousStatus` is null on first sight, `NewStatus` is the frame's
-`securityTradingStatus`, and `SourceTimestampNanos` is its `transactTime`.
+The platform decodes schema 2.3.0 / V17 `InstrumentStatus_58` as the
+authoritative contract. `AdministrativeState` is the resulting current state;
+`Transition` is `Halted`/`Resumed` for live changes and `Unknown` for recovery
+snapshots; `HaltReason` carries the operator reason while halted.
+`TradingSessionId`, `SourceTimestampNanos`, and `RptSeq` preserve the remaining
+source metadata. Unknown future state/transition/reason codes map to typed
+`Unknown` values while their `Raw*` properties preserve the byte.
 
-The source currently preserves the underlying trading phase during halt and
-does not encode the operator's detailed `RegulatoryHalt`/`NewsHold` reason.
-Consequently previous/new status can both be `OPEN`; `Transition` identifies
-halt vs. resume while `HaltReason` remains null. This upstream prerequisite is
-tracked by
-[`B3MatchingPlatform#581`](https://github.com/pedrosakuma/B3MatchingPlatform/issues/581).
-The APIs intentionally keep transition kind and detailed halt reason separate
-instead of inventing a reason from the marker.
+The legacy `SecurityStatus_3` halt/resume markers remain supported during
+rolling deployment. They do not carry a reason or trading session. When both
+templates occur in one rollout packet, template 58 wins and only one client
+event is emitted.
 
 The latest administrative state is retained in the server's `InstrumentInfo`
 cache. Every new `Info` subscribe — including automatic re-subscribe after a
 WebSocket reconnect — receives the cached typed status after `InfoSnapshot`
-with `DeliveryKind=Snapshot` / `IsSnapshot=true`. It retains the original
-source timestamp and RptSeq for provenance; do not repeat live transition side
-effects for snapshot delivery. Live source changes use
+with `DeliveryKind=Snapshot` / `IsSnapshot=true`, including state learned from
+UMDF recovery. It retains source timestamp, detailed reason, session, and
+RptSeq when available; do not repeat live transition side effects for snapshot
+delivery. Live source changes use
 `DeliveryKind=LiveTransition`.
 
 Check `client.LastServerHello?.Capabilities` for

--- a/docs/WEBSOCKET-PROTOCOL.md
+++ b/docs/WEBSOCKET-PROTOCOL.md
@@ -289,51 +289,37 @@ unrecognised combinations map to `Unknown`.
 
 | Message | Type | Payload |
 |---------|------|---------|
-| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32][deliveryKind u8]` |
+| **InstrumentStatus** | `0x00B3` | `[secId u64][symLen u8][symbol UTF-8][previousStatus u8][newStatus u8][transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32][deliveryKind u8][administrativeState u8][tradingSessionId u8]` |
 
 This is the dedicated, non-conflated transition surface for administrative
-single-instrument halt/resume. It is decoded from the existing schema-generated
-UMDF **`SecurityStatus_3` template (id 3)**; there is no separate
-`InstrumentStatus_NN` template in B3 schema 2.2.0. The matching venue uses the
-otherwise schema-reserved `securityTradingEvent` values `1` (halt) and `2`
-(resume), while `securityTradingStatus`, `transactTime`, and `rptSeq` supply
-`newStatus`, `sourceTimestampNanos`, and `rptSeq`.
+single-instrument halt/resume. Schema 2.3.0 / V17
+**`InstrumentStatus_58` (id 58)** is authoritative and supplies current
+administrative state, optional live transition, detailed halt reason, source
+timestamp, RptSeq, trading session, and the UMDF `RecoveryMsg` marker.
+`SecurityStatus_3` remains decoded as a rolling-deployment fallback.
 
 `previousStatus=255` means the platform had no prior status cached,
-`haltReason=255` means the upstream frame supplied no detailed operator reason,
-and `rptSeq=0` means unavailable. The venue preserves the underlying trading
-phase during an administrative halt, so `previousStatus` and `newStatus` may
-both be `17` (OPEN); consumers should use `transition`/the SDK's `IsHalted`
-property to identify the current administrative state.
+`transition=255` means a state-only snapshot, `haltReason=255` means absent,
+and `rptSeq=0` means unavailable. `administrativeState` is `0` (active), `1`
+(halted), or `255` (absent on an older frame). Halt reasons are `1` regulatory,
+`2` volatility circuit breaker, `3` news hold, and `4` pending disclosure.
+The venue preserves the underlying trading phase during an administrative
+halt, so previous/new status may both be `17` (OPEN); use
+`administrativeState` / `InstrumentStatusEvent.IsHalted`.
 
-`deliveryKind` is append-only: `0` = live source transition, `1` = cached
-subscribe/reconnect snapshot. Snapshot frames deliberately retain the original
-source timestamp and RptSeq for provenance; consumers MUST check
+`deliveryKind`, `administrativeState`, and `tradingSessionId` are append-only.
+Delivery `0` is a live source transition; `1` is a recovery, subscribe, or
+reconnect snapshot. Cached snapshots retain source timestamp and RptSeq when
+available; recovery snapshots normally carry null/zero RptSeq. Consumers MUST check
 `deliveryKind`/`InstrumentStatusEvent.IsSnapshot` before running one-shot
-transition side effects. SDKs decoding a legacy frame without this trailing
-byte default it to live transition.
+transition side effects. SDKs decoding older frames derive state from the
+legacy transition marker and leave trading session null.
 
-The current source frame does **not** carry the operator's detailed halt reason
-(`RegulatoryHalt`, `NewsHold`, etc.). `transition` exposes the exact available
-marker (`1` = halted, `2` = resumed), while `haltReason` is null/255. Transition
-kind is deliberately not presented as a reason.
-
-Authoritative upstream evidence (B3MatchingPlatform commit
-`0d423c8f6cecf647d57adf85ebdd6f539b0c8214`):
-
-- [`InstrumentHaltedEvent`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Exchange.Matching/Events.cs)
-  carries `HaltReason`, but
-  [`ChannelDispatcher.Sinks.OnInstrumentHalted`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs)
-  does not pass it to the encoder.
-- [`UmdfFrameBuilder.WriteInstrumentHalted`](https://github.com/pedrosakuma/B3MatchingPlatform/blob/0d423c8f6cecf647d57adf85ebdd6f539b0c8214/src/B3.Umdf.WireEncoder/UmdfFrameBuilder.cs)
-  emits `SecurityStatus_3` with only `securityTradingEvent=1`.
-- Schema 2.2.0 defines no detailed halt-reason field and repository code search
-  finds no `InstrumentStatus_NN` template.
-
-The missing upstream contract is tracked by
-[`B3MatchingPlatform#581`](https://github.com/pedrosakuma/B3MatchingPlatform/issues/581);
-until it lands, this frame cannot satisfy the detailed-reason portion of
-`B3MarketDataPlatform#73`.
+Upstream authoritative contract:
+[`B3MatchingPlatform` merge commit `8212925`](https://github.com/pedrosakuma/B3MatchingPlatform/commit/8212925a45baf52b1ee004419cadfab84063847d).
+During rollout, a live packet may contain legacy template 3 first and template
+58 second with the same SecurityID/RptSeq. The platform suppresses the legacy
+copy so clients receive one authoritative event with the detailed reason.
 
 The current state is cached and emitted with `deliveryKind=1` after
 `InfoSnapshot` on every Info subscribe/re-subscribe. Live frames use

--- a/schemas/b3-market-data-messages-2.3.0.xml
+++ b/schemas/b3-market-data-messages-2.3.0.xml
@@ -161,6 +161,8 @@ History
         |               | - mDEntryPositionNo field is replaced by a 4-byte padding in all messages (it was deprecated in version 15).
         |               | - MDEntryPositionNo type removed due to lack of use after related mDEntryPositionNo field removed.
         |               | - Changed behavior for the Trade and ForwardTrade message: if a trade is amended, the value of the transactTime field (tag 60) is set manually by MktOps.
+2.3.0   | 2026-07-27    | - Schema version changed from 16 to 17.
+        |               | - B3MatchingPlatform InstrumentStatus_58 extension added for authoritative administrative halt state, transition kind and reason.
 =================================================================================
 -->
 
@@ -171,8 +173,8 @@ History
 	xmlns:sbe="http://fixprotocol.io/2016/sbe" 
 	package="b3.umdf.mbo.sbe" 
 	id="2"
-	version="16" 
-	semanticVersion="2.2.0"
+	version="17" 
+	semanticVersion="2.3.0"
 	description="B3 Market Data UMDF SBE messages" 
 	byteOrder="littleEndian" 
 	xsi:schemaLocation="http://fixprotocol.io/2016/sbe sbe.xsd">
@@ -420,6 +422,20 @@ History
 			<validValue name="TRADING_SESSION_CHANGE" description="Change of Trading Session.">4</validValue>
 			<validValue name="SECURITY_STATUS_CHANGE" description="Security Status maintained separately from Group Status.">101</validValue>
 			<validValue name="SECURITY_REJOINS_SECURITY_GROUP_STATUS" description="Security Status following Group Status.">102</validValue>
+		</enum>
+		<enum name="AdministrativeHaltState" encodingType="uint8" semanticType="Int" description="Current administrative halt overlay for an instrument.">
+			<validValue name="ACTIVE" description="Instrument is not administratively halted.">0</validValue>
+			<validValue name="HALTED" description="Instrument is administratively halted.">1</validValue>
+		</enum>
+		<enum name="AdministrativeTransitionKind" encodingType="uint8" semanticType="Int" description="Administrative halt transition represented by this update. Null in snapshot state publication.">
+			<validValue name="HALT" description="Instrument entered administrative halt.">1</validValue>
+			<validValue name="RESUME" description="Instrument left administrative halt.">2</validValue>
+		</enum>
+		<enum name="HaltReason" encodingType="uint8" semanticType="Int" description="Detailed reason for the current or newly-entered administrative halt. Null when the instrument is active.">
+			<validValue name="REGULATORY_HALT" description="Regulatory halt.">1</validValue>
+			<validValue name="VOLATILITY_CIRCUIT_BREAKER" description="Volatility circuit breaker.">2</validValue>
+			<validValue name="NEWS_HOLD" description="News hold.">3</validValue>
+			<validValue name="PENDING_DISCLOSURE" description="Pending disclosure.">4</validValue>
 		</enum>
 		<enum name="PriceBandType" encodingType="uint8" semanticType="Int" description="Indicates the type of price banding (tunnel).">
 			<validValue name="HARD_LIMIT" description="Hard Limit.">1</validValue>
@@ -673,6 +689,22 @@ History
 		<field name="tradSesOpenTime" id="342" type="UTCTimestampNanos" presence="optional" offset="16" description="Estimated end of the current auction. Only present when SecurityTradingStatus=21 (Pre-open/Reserved)."/>
 		<field name="transactTime" id="60" type="UTCTimestampNanos" description="Timestamp when status of the security changed."/>
 		<field name="rptSeq" id="83" type="RptSeq" description="Sequence number per instrument update. (Zeroed in snapshot feed)"/>
+	</sbe:message>
+	<!-- B3MatchingPlatform administrative halt status extension (issue #581). -->
+	<sbe:message name="InstrumentStatus_58" id="58" sinceVersion="17" description="Authoritative administrative halt state and transition for an instrument">
+		<field name="messageType" id="35" type="MessageType" presence="constant" valueRef="MessageType.SecurityStatus" sinceVersion="17"/>
+		<field name="applVerID" id="1128" type="ApplVerID" presence="constant" valueRef="ApplVerID.FIX50SP2" sinceVersion="17" description="Specifies the service pack release being applied at message level"/>
+		<field name="securityID" id="48" type="SecurityID" sinceVersion="17" description="Security ID as defined by B3."/>
+		<field name="securityIDSource" id="22" type="SecurityIDSource" presence="constant" valueRef="SecurityIDSource.EXCHANGE_SYMBOL" sinceVersion="17" description="Identifies the class of the SecurityID (Exchange Symbol)."/>
+		<field name="securityExchange" id="207" type="SecurityExchangeBVMF" sinceVersion="17" description="Market to which the symbol belongs."/>
+		<field name="matchEventIndicator" id="37035" type="MatchEventIndicator" sinceVersion="17" description="Set of indicators that identify market data events. RecoveryMsg is set in snapshot publication."/>
+		<field name="tradingSessionID" id="336" type="TradingSessionID" sinceVersion="17" description="Identifier for trading session."/>
+		<field name="securityTradingStatus" id="326" type="SecurityTradingStatus" sinceVersion="17" description="Underlying trading phase preserved across the administrative halt overlay."/>
+		<field name="administrativeHaltState" id="37781" type="AdministrativeHaltState" sinceVersion="17" description="Current administrative halt state after applying this update."/>
+		<field name="administrativeTransitionKind" id="37782" type="AdministrativeTransitionKind" presence="optional" sinceVersion="17" description="Administrative transition carried by an incremental update. Null in snapshot state publication."/>
+		<field name="haltReason" id="37783" type="HaltReason" presence="optional" sinceVersion="17" description="Detailed halt reason while administrativeHaltState=HALTED. Null while ACTIVE."/>
+		<field name="transactTime" id="60" type="UTCTimestampNanos" offset="16" sinceVersion="17" description="Transition timestamp for incremental updates; halt-start timestamp for halted snapshots; zero for active snapshots."/>
+		<field name="rptSeq" id="83" type="RptSeq" sinceVersion="17" description="Sequence number per instrument update. Zeroed in snapshot feed."/>
 	</sbe:message>
 	<!-- Trading Phase for a Security Group (35=f) -->
 	<sbe:message name="SecurityGroupPhase_10" id="10" description="Trading status for security groups">

--- a/src/B3.MarketData.WebSocketClient/Events.cs
+++ b/src/B3.MarketData.WebSocketClient/Events.cs
@@ -730,8 +730,8 @@ public sealed class AuctionEvent
 }
 
 /// <summary>
-/// Administrative state transition carried by the proprietary
-/// <c>SecurityStatus_3.securityTradingEvent</c> extension.
+/// Administrative transition carried by authoritative
+/// <c>InstrumentStatus_58</c> or the legacy template 3 fallback.
 /// </summary>
 public enum InstrumentStatusTransitionKind : byte
 {
@@ -741,9 +741,18 @@ public enum InstrumentStatusTransitionKind : byte
 }
 
 /// <summary>
-/// Operator-supplied administrative halt reason. The current upstream UMDF
-/// contract does not transmit this value, so <see cref="InstrumentStatusEvent.HaltReason"/>
-/// remains null until B3MatchingPlatform issue #581 supplies it.
+/// Current administrative halt overlay.
+/// </summary>
+public enum InstrumentAdministrativeState : byte
+{
+    Unknown = byte.MaxValue,
+    Active = 0,
+    Halted = 1,
+}
+
+/// <summary>
+/// Operator-supplied administrative halt reason from
+/// <c>InstrumentStatus_58.haltReason</c>.
 /// </summary>
 public enum InstrumentHaltReason : byte
 {
@@ -766,8 +775,8 @@ public enum InstrumentStatusDeliveryKind : byte
 }
 
 /// <summary>
-/// A non-conflated instrument halt/resume transition decoded from UMDF
-/// <c>SecurityStatus_3</c>.
+/// Administrative instrument state decoded from UMDF. Live updates are
+/// non-conflated transitions; recovery and reconnect deliveries are snapshots.
 /// </summary>
 public sealed class InstrumentStatusEvent
 {
@@ -779,15 +788,15 @@ public sealed class InstrumentStatusEvent
     public int? PreviousStatus { get; init; }
 
     /// <summary>
-    /// <c>SecurityStatus_3.securityTradingStatus</c>. The matching venue preserves
+    /// UMDF <c>securityTradingStatus</c>. The matching venue preserves
     /// the underlying trading phase during an administrative halt, so halt/open
     /// can legitimately report the same previous and new status.
     /// </summary>
     public int NewStatus { get; init; }
 
     /// <summary>
-    /// Halt/resume transition marker from
-    /// <c>SecurityStatus_3.securityTradingEvent</c>.
+    /// Halt/resume transition marker. Snapshot state has no transition and maps
+    /// to <see cref="InstrumentStatusTransitionKind.Unknown"/>.
     /// </summary>
     public InstrumentStatusTransitionKind Transition { get; init; }
 
@@ -795,13 +804,25 @@ public sealed class InstrumentStatusEvent
     public byte RawTransitionCode { get; init; }
 
     /// <summary>
-    /// Detailed operator halt reason, or null because the current upstream
-    /// <c>SecurityStatus_3</c> frame does not carry one.
+    /// Detailed operator halt reason. Null while active or when received from
+    /// the legacy template 3 fallback.
     /// </summary>
     public InstrumentHaltReason? HaltReason { get; init; }
 
     /// <summary>Unmodified detailed reason code, or null when absent on the wire.</summary>
     public byte? RawHaltReasonCode { get; init; }
+
+    /// <summary>Current administrative overlay after applying the update.</summary>
+    public InstrumentAdministrativeState AdministrativeState { get; init; }
+
+    /// <summary>Unmodified state code, or null when absent on an older frame.</summary>
+    public byte? RawAdministrativeStateCode { get; init; }
+
+    /// <summary>
+    /// UMDF trading session identifier, or null for legacy template 3 and older
+    /// WebSocket frames.
+    /// </summary>
+    public byte? TradingSessionId { get; init; }
 
     /// <summary>Exchange source timestamp, UTC nanoseconds since Unix epoch.</summary>
     public ulong SourceTimestampNanos { get; init; }
@@ -822,6 +843,11 @@ public sealed class InstrumentStatusEvent
     /// <summary>Unmodified delivery-kind byte for forward compatibility.</summary>
     public byte RawDeliveryKind { get; init; }
 
-    public bool IsHalted => Transition == InstrumentStatusTransitionKind.Halted;
+    public bool IsHalted => AdministrativeState switch
+    {
+        InstrumentAdministrativeState.Halted => true,
+        InstrumentAdministrativeState.Active => false,
+        _ => Transition == InstrumentStatusTransitionKind.Halted,
+    };
     public bool IsSnapshot => DeliveryKind == InstrumentStatusDeliveryKind.Snapshot;
 }

--- a/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
+++ b/src/B3.MarketData.WebSocketClient/MarketDataClient.cs
@@ -91,8 +91,9 @@ public sealed class MarketDataClient : IAsyncDisposable
     /// </summary>
     public event Action<AuctionEvent>? Auction;
     /// <summary>
-    /// Administrative instrument halt/resume transitions decoded from UMDF
-    /// <c>SecurityStatus_3</c>. Delivered to subscriptions that include
+    /// Administrative instrument state decoded from authoritative UMDF
+    /// <c>InstrumentStatus_58</c> or the legacy template 3 fallback. Delivered
+    /// to subscriptions that include
     /// <see cref="SubscribeFlags.Info"/> when
     /// <see cref="ServerCapabilities.InstrumentStatus"/> is advertised.
     /// Inspect <see cref="InstrumentStatusEvent.IsSnapshot"/> before running

--- a/src/B3.MarketData.WebSocketClient/README.md
+++ b/src/B3.MarketData.WebSocketClient/README.md
@@ -27,7 +27,7 @@ await using var client = new MarketDataClient(new MarketDataClientOptions
 client.Trade += t => Console.WriteLine($"{t.Symbol}  {t.Price:F4} x {t.Qty}");
 client.LevelUpdate += l => Console.WriteLine($"{l.Symbol} {l.Side} {l.Price} qty={l.TotalQty}");
 client.InstrumentStatus += s => Console.WriteLine(
-    $"{s.Symbol} transition={s.Transition} snapshot={s.IsSnapshot} status={s.NewStatus} haltReason={s.HaltReason?.ToString() ?? "unavailable"}");
+    $"{s.Symbol} state={s.AdministrativeState} transition={s.Transition} snapshot={s.IsSnapshot} haltReason={s.HaltReason?.ToString() ?? "none"}");
 
 await client.ConnectAsync();
 await client.SubscribeAsync("PETR4", SubscribeFlags.Trades | SubscribeFlags.Info | SubscribeFlags.Mbp);

--- a/src/B3.MarketData.WebSocketClient/WireFormat.cs
+++ b/src/B3.MarketData.WebSocketClient/WireFormat.cs
@@ -571,8 +571,8 @@ internal static class WireFormat
     /// Layout:
     /// <c>[securityId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
     /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]
-    /// [deliveryKind u8?]</c>. A missing trailing delivery kind is treated as
-    /// <see cref="InstrumentStatusDeliveryKind.LiveTransition"/> for compatibility.
+    /// [deliveryKind u8?][administrativeState u8?][tradingSessionId u8?]</c>.
+    /// Trailing fields are append-only and default from legacy transition data.
     /// </summary>
     public static bool TryReadInstrumentStatus(
         ReadOnlySpan<byte> payload,
@@ -610,8 +610,22 @@ internal static class WireFormat
         uint rptSeq = BinaryPrimitives.ReadUInt32LittleEndian(payload[offset..]);
         offset += 4;
         byte deliveryKind = payload.Length > offset
-            ? payload[offset]
+            ? payload[offset++]
             : (byte)InstrumentStatusDeliveryKind.LiveTransition;
+        bool hasAdministrativeState = payload.Length > offset;
+        byte administrativeState = hasAdministrativeState
+            ? payload[offset++]
+            : transition switch
+            {
+                (byte)InstrumentStatusTransitionKind.Halted =>
+                    (byte)InstrumentAdministrativeState.Halted,
+                (byte)InstrumentStatusTransitionKind.Resumed =>
+                    (byte)InstrumentAdministrativeState.Active,
+                _ => byte.MaxValue,
+            };
+        byte tradingSessionId = payload.Length > offset
+            ? payload[offset]
+            : byte.MaxValue;
 
         status = new InstrumentStatusEvent
         {
@@ -630,6 +644,18 @@ internal static class WireFormat
                     ? (InstrumentHaltReason)haltReason
                     : InstrumentHaltReason.Unknown,
             RawHaltReasonCode = haltReason == byte.MaxValue ? null : haltReason,
+            AdministrativeState = administrativeState == byte.MaxValue
+                ? InstrumentAdministrativeState.Unknown
+                : Enum.IsDefined(typeof(InstrumentAdministrativeState), administrativeState)
+                    ? (InstrumentAdministrativeState)administrativeState
+                    : InstrumentAdministrativeState.Unknown,
+            RawAdministrativeStateCode = !hasAdministrativeState
+                || administrativeState == byte.MaxValue
+                ? null
+                : administrativeState,
+            TradingSessionId = tradingSessionId == byte.MaxValue
+                ? null
+                : tradingSessionId,
             SourceTimestampNanos = sourceTimestampNanos,
             RptSeq = rptSeq == 0 ? null : rptSeq,
             DeliveryKind = Enum.IsDefined(typeof(InstrumentStatusDeliveryKind), deliveryKind)

--- a/src/B3.Umdf.Book/BookManager.cs
+++ b/src/B3.Umdf.Book/BookManager.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -583,6 +583,7 @@ public sealed class BookManager : IFeedEventHandler, IMarketDataEventHandler
         public void OnSequenceReset_1(in SequenceReset_1DataReader reader, int blockLength, int version) { }
         public void OnSequence_2(in Sequence_2DataReader reader, int blockLength, int version) { }
         public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) { }
+        public void OnInstrumentStatus_58(in InstrumentStatus_58DataReader reader, int blockLength, int version) { }
         public void OnNews_5(in News_5DataReader reader, int blockLength, int version) { }
         public void OnSecurityGroupPhase_10(in SecurityGroupPhase_10DataReader reader, int blockLength, int version) { }
         public void OnOpeningPrice_15(in OpeningPrice_15DataReader reader, int blockLength, int version) { }

--- a/src/B3.Umdf.Book/IMarketDataEventHandler.cs
+++ b/src/B3.Umdf.Book/IMarketDataEventHandler.cs
@@ -4,8 +4,8 @@ public interface IMarketDataEventHandler
 {
     void OnSecurityStatusChanged(ulong securityId, InstrumentInfo info) { }
     /// <summary>
-    /// Fired for the halt/resume extension carried by <c>SecurityStatus_3</c>
-    /// (<c>securityTradingEvent</c> values 1 and 2).
+    /// Fired for authoritative <c>InstrumentStatus_58</c> state or the legacy
+    /// <c>SecurityStatus_3</c> rollout fallback.
     /// </summary>
     void OnInstrumentStatusChanged(
         ulong securityId,

--- a/src/B3.Umdf.Book/InstrumentInfo.cs
+++ b/src/B3.Umdf.Book/InstrumentInfo.cs
@@ -81,8 +81,9 @@ public sealed class InstrumentInfo
     public int? TradingEvent { get; set; }
     public ulong? TradSesOpenTime { get; set; }
     /// <summary>
-    /// Last administrative halt/resume state decoded from the proprietary
-    /// <c>SecurityStatus_3.securityTradingEvent</c> extension. Retained so
+    /// Last administrative halt state decoded from authoritative
+    /// <c>InstrumentStatus_58</c> or the rolling-deployment
+    /// <c>SecurityStatus_3</c> fallback. Retains detailed reason and session so
     /// late/reconnecting Info subscribers can bootstrap current state.
     /// </summary>
     public InstrumentStatusUpdate? AdministrativeStatus { get; set; }
@@ -201,6 +202,7 @@ public sealed class InstrumentInfo
     public uint LastRptSeqOpenInterest;            // tpl 29
     public uint LastRptSeqExecutionStatistics;     // tpl 56
     public uint LastRptSeqSecurityStatus;          // tpl 3
+    public uint LastRptSeqInstrumentStatus;        // tpl 58
 
     // SecurityDefinition repeating groups
     public string? SecurityDescription { get; set; }
@@ -275,6 +277,7 @@ public sealed class InstrumentInfo
         LastRptSeqOpenInterest = 0;
         LastRptSeqExecutionStatistics = 0;
         LastRptSeqSecurityStatus = 0;
+        LastRptSeqInstrumentStatus = 0;
         SecurityDescription = null;
         Underlyings = null;
         Legs = null;

--- a/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
+++ b/src/B3.Umdf.Book/InstrumentStatusDecoder.cs
@@ -1,10 +1,10 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Book;
 
 /// <summary>
-/// Semantic halt/resume transition decoded from the exchange's
-/// <c>SecurityStatus_3</c> template.
+/// Administrative instrument state decoded from the exchange's legacy
+/// <c>SecurityStatus_3</c> or authoritative <c>InstrumentStatus_58</c> template.
 /// </summary>
 public readonly record struct InstrumentStatusUpdate(
     int? PreviousStatus,
@@ -12,19 +12,30 @@ public readonly record struct InstrumentStatusUpdate(
     byte TransitionCode,
     byte? HaltReasonCode,
     ulong SourceTimestampNanos,
-    uint? RptSeq)
+    uint? RptSeq,
+    byte? AdministrativeStateCode = null,
+    byte? TradingSessionId = null,
+    bool IsRecovery = false)
 {
-    public bool IsHalted => TransitionCode == InstrumentStatusDecoder.InstrumentHaltedTransitionCode;
+    public bool IsHalted => AdministrativeStateCode switch
+    {
+        InstrumentStatusDecoder.AdministrativeHaltedStateCode => true,
+        InstrumentStatusDecoder.AdministrativeActiveStateCode => false,
+        _ => TransitionCode == InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+    };
 }
 
 /// <summary>
-/// Decodes the proprietary halt/resume markers emitted by B3MatchingPlatform
-/// in the existing UMDF <c>SecurityStatus_3</c> template.
+/// Decodes B3MatchingPlatform administrative halt state. Template 58 is the
+/// authoritative V17 contract; template 3 remains supported during rollout.
 /// </summary>
 public static class InstrumentStatusDecoder
 {
+    public const byte UnavailableCode = byte.MaxValue;
     public const byte InstrumentHaltedTransitionCode = 1;
     public const byte InstrumentResumedTransitionCode = 2;
+    public const byte AdministrativeActiveStateCode = 0;
+    public const byte AdministrativeHaltedStateCode = 1;
 
     public static bool TryDecode(
         in SecurityStatus_3DataReader reader,
@@ -48,7 +59,47 @@ public static class InstrumentStatusDecoder
             transitionCode,
             null,
             message.TransactTime.Time ?? 0,
-            message.RptSeq);
+            message.RptSeq,
+            transitionCode == InstrumentHaltedTransitionCode
+                ? AdministrativeHaltedStateCode
+                : AdministrativeActiveStateCode);
+        return true;
+    }
+
+    public static bool TryDecode(
+        in InstrumentStatus_58DataReader reader,
+        int? previousStatus,
+        out InstrumentStatusUpdate update)
+    {
+        ref readonly var message = ref reader.Data;
+        byte stateCode = (byte)message.AdministrativeHaltState;
+        byte transitionCode = message.AdministrativeTransitionKind is { } transition
+            ? (byte)transition
+            : UnavailableCode;
+        byte? haltReasonCode = message.HaltReason is { } haltReason
+            ? (byte)haltReason
+            : null;
+        bool isRecovery = message.MatchEventIndicator.IsRecoveryMsg();
+
+        if (stateCode == AdministrativeHaltedStateCode && haltReasonCode is null
+            || stateCode == AdministrativeActiveStateCode && haltReasonCode is not null
+            || isRecovery && transitionCode != UnavailableCode
+            || !isRecovery && transitionCode == UnavailableCode)
+        {
+            update = default;
+            return false;
+        }
+
+        update = new InstrumentStatusUpdate(
+            previousStatus,
+            (int)message.SecurityTradingStatus,
+            transitionCode,
+            haltReasonCode,
+            message.TransactTime.Time ?? 0,
+            message.RptSeq,
+            stateCode,
+            (byte)message.TradingSessionID,
+            isRecovery);
         return true;
     }
 }

--- a/src/B3.Umdf.Book/MarketDataManager.cs
+++ b/src/B3.Umdf.Book/MarketDataManager.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Text;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -181,7 +181,7 @@ public sealed class MarketDataManager : IFeedEventHandler
     {
         try
         {
-            var handler = new MarketDataSbeHandler { Owner = this };
+            var handler = new MarketDataSbeHandler { Owner = this, Packet = packet };
             SbeDispatcher.Dispatch(sbePayload, ref handler);
         }
         catch (Exception ex)
@@ -199,9 +199,11 @@ public sealed class MarketDataManager : IFeedEventHandler
     private struct MarketDataSbeHandler : ISbeMessageHandler
     {
         public MarketDataManager Owner;
+        public UmdfPacket Packet;
 
         public void OnSecurityDefinition_12(in SecurityDefinition_12DataReader reader, int blockLength, int version) => Owner.HandleSecurityDefinition(in reader);
-        public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) => Owner.HandleSecurityStatus(in reader);
+        public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) => Owner.HandleSecurityStatus(in reader, in Packet);
+        public void OnInstrumentStatus_58(in InstrumentStatus_58DataReader reader, int blockLength, int version) => Owner.HandleInstrumentStatus(in reader);
         public void OnSecurityGroupPhase_10(in SecurityGroupPhase_10DataReader reader, int blockLength, int version) => Owner.HandleSecurityGroupPhase(in reader);
         public void OnOpeningPrice_15(in OpeningPrice_15DataReader reader, int blockLength, int version) => Owner.HandleOpeningPrice(in reader);
         public void OnTheoreticalOpeningPrice_16(in TheoreticalOpeningPrice_16DataReader reader, int blockLength, int version) => Owner.HandleTheoreticalOpeningPrice(in reader);
@@ -273,6 +275,7 @@ public sealed class MarketDataManager : IFeedEventHandler
             info.LastRptSeqOpenInterest = 0;
             info.LastRptSeqExecutionStatistics = 0;
             info.LastRptSeqSecurityStatus = 0;
+            info.LastRptSeqInstrumentStatus = 0;
         }
     }
     public void OnInstrumentDefinitionsComplete(int instrumentCount) { FreezeData(); }
@@ -436,10 +439,18 @@ public sealed class MarketDataManager : IFeedEventHandler
         _eventHandler?.OnSecurityDefinitionChanged(securityId, info);
     }
 
-    private void HandleSecurityStatus(in SecurityStatus_3DataReader reader)
+    private void HandleSecurityStatus(in SecurityStatus_3DataReader reader, in UmdfPacket packet)
     {
         ref readonly var msg = ref reader.Data;
         ulong securityId = (ulong)msg.SecurityID;
+
+        // During rollout the venue places legacy template 3 first and
+        // authoritative template 58 second in the same packet with the same
+        // SecurityID/RptSeq. Ignore the legacy copy so clients receive exactly
+        // one event and the detailed reason cannot be overwritten.
+        if (PacketContainsAuthoritativeStatus(in packet, securityId, msg.RptSeq))
+            return;
+
         var info = GetOrCreateInfo(securityId);
         int? previousStatus = info.TradingStatus;
 
@@ -491,6 +502,87 @@ public sealed class MarketDataManager : IFeedEventHandler
             _eventHandler?.OnInstrumentStatusChanged(securityId, info, in instrumentStatus);
         }
         _eventHandler?.OnSecurityStatusChanged(securityId, info);
+    }
+
+    private void HandleInstrumentStatus(in InstrumentStatus_58DataReader reader)
+    {
+        ref readonly var msg = ref reader.Data;
+        ulong securityId = (ulong)msg.SecurityID;
+        var info = GetOrCreateInfo(securityId);
+
+        if (!InstrumentStatusDecoder.TryDecode(
+                in reader, info.TradingStatus, out var instrumentStatus))
+            return;
+
+        if (instrumentStatus.RptSeq is { } rptSeq)
+        {
+            if (!RouteStat(
+                    securityId,
+                    SymbolGapKind.SecurityStatus,
+                    rptSeq,
+                    info.LastRptSeqInstrumentStatus))
+                return;
+            info.LastRptSeqInstrumentStatus = rptSeq;
+        }
+
+        info.TradingStatus = instrumentStatus.NewStatus;
+        info.TradingEvent = instrumentStatus.TransitionCode
+            == InstrumentStatusDecoder.UnavailableCode
+                ? null
+                : instrumentStatus.TransitionCode;
+        info.LastUpdateTimestamp = instrumentStatus.SourceTimestampNanos;
+        info.AdministrativeStatus = instrumentStatus;
+        info.BumpVersion();
+
+        _eventHandler?.OnInstrumentStatusChanged(
+            securityId, info, in instrumentStatus);
+        _eventHandler?.OnSecurityStatusChanged(securityId, info);
+    }
+
+    private static bool PacketContainsAuthoritativeStatus(
+        in UmdfPacket packet,
+        ulong securityId,
+        uint? rptSeq)
+    {
+        ReadOnlySpan<byte> span = packet.Data.Span;
+        int offset = UmdfPacketHeader.Size;
+        int minimumFrameSize = FramingHeader.MESSAGE_SIZE + MessageHeader.MESSAGE_SIZE;
+
+        while (offset + minimumFrameSize <= span.Length)
+        {
+            if (!FramingHeader.TryParse(span[offset..], out var framing, out _)
+                || framing.MessageLength < minimumFrameSize
+                || offset + framing.MessageLength > span.Length)
+                return false;
+
+            ReadOnlySpan<byte> sbe = span.Slice(
+                offset + FramingHeader.MESSAGE_SIZE,
+                framing.MessageLength - FramingHeader.MESSAGE_SIZE);
+            if (!MessageHeader.TryReadHeader(
+                    sbe,
+                    out ushort blockLength,
+                    out ushort templateId,
+                    out ushort schemaId,
+                    out ushort version))
+                return false;
+
+            if (templateId == InstrumentStatus_58Data.MESSAGE_ID
+                && schemaId == 2
+                && version >= 17
+                && InstrumentStatus_58Data.TryParse(
+                    sbe[MessageHeader.MESSAGE_SIZE..],
+                    blockLength,
+                    out var status)
+                && (ulong)status.Data.SecurityID == securityId
+                && status.Data.RptSeq == rptSeq
+                && InstrumentStatusDecoder.TryDecode(
+                    in status, previousStatus: null, out _))
+                return true;
+
+            offset += framing.MessageLength;
+        }
+
+        return false;
     }
 
     private void HandleSecurityGroupPhase(in SecurityGroupPhase_10DataReader reader)

--- a/src/B3.Umdf.Book/NewsReassembler.cs
+++ b/src/B3.Umdf.Book/NewsReassembler.cs
@@ -1,6 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Book;
 

--- a/src/B3.Umdf.Book/SnapshotApplier.cs
+++ b/src/B3.Umdf.Book/SnapshotApplier.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Umdf.Book;

--- a/src/B3.Umdf.Book/SymbolRegistry.cs
+++ b/src/B3.Umdf.Book/SymbolRegistry.cs
@@ -2,7 +2,7 @@ using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Text;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Book;

--- a/src/B3.Umdf.Feed/ChannelHandler.cs
+++ b/src/B3.Umdf.Feed/ChannelHandler.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/B3.Umdf.Feed/FeedHandler.cs
+++ b/src/B3.Umdf.Feed/FeedHandler.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/B3.Umdf.Feed/MessageDispatcher.cs
+++ b/src/B3.Umdf.Feed/MessageDispatcher.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed;

--- a/src/B3.Umdf.Feed/SbeFrameWalker.cs
+++ b/src/B3.Umdf.Feed/SbeFrameWalker.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed;

--- a/src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj
+++ b/src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>B3.Umdf.Sbe</RootNamespace>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\schemas\b3-market-data-messages-2.2.0.xml" />
+    <AdditionalFiles Include="..\..\schemas\b3-market-data-messages-2.3.0.xml" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Umdf.Sbe/ValidatingSbeDispatcher.cs
+++ b/src/B3.Umdf.Sbe/ValidatingSbeDispatcher.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Sbe;
 
@@ -48,14 +48,14 @@ public readonly record struct SbeHeaderRejection(
 /// </summary>
 public sealed class ValidatingSbeDispatcher
 {
-    /// <summary>SBE schema id for the B3 UMDF schema (b3-market-data-messages-2.2.0.xml, <c>id="2"</c>).</summary>
+    /// <summary>SBE schema id for the B3 UMDF schema (b3-market-data-messages-2.3.0.xml, <c>id="2"</c>).</summary>
     public const ushort DefaultSchemaId = 2;
     /// <summary>Highest <c>sinceVersion</c> that the bundled <c>SbeSourceGenerator</c> generates code for.</summary>
-    public const ushort DefaultMaxSupportedVersion = 16;
+    public const ushort DefaultMaxSupportedVersion = 17;
 
     /// <summary>
     /// Curated set of template ids the bundled SBE source generator emits decoders for in
-    /// <c>b3-market-data-messages-2.2.0.xml</c>. Mirrors the cases in the generated
+    /// <c>b3-market-data-messages-2.3.0.xml</c>. Mirrors the cases in the generated
     /// <c>SbeDispatcher.Dispatch</c> switch — kept here as data so we can detect
     /// "unsupported template" BEFORE handing the buffer off and bump the
     /// <see cref="SbeValidationMetrics.UnsupportedTemplateCount"/> counter exactly once per packet.
@@ -64,7 +64,7 @@ public sealed class ValidatingSbeDispatcher
     public static readonly FrozenSet<ushort> KnownTemplateIds = new ushort[]
     {
         0, 1, 2, 3, 5, 9, 10, 11, 12, 15, 16, 17, 19, 21, 22, 24, 25, 27, 28, 29, 30,
-        50, 51, 52, 53, 54, 55, 56, 57, 71,
+        50, 51, 52, 53, 54, 55, 56, 57, 58, 71,
     }.ToFrozenSet();
 
     /// <summary>

--- a/src/B3.Umdf.Server/GroupConflationHandler.cs
+++ b/src/B3.Umdf.Server/GroupConflationHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using MessageType = B3.MarketData.Wire.MessageType;
 
 namespace B3.Umdf.Server;

--- a/src/B3.Umdf.Server/WireProtocol.cs
+++ b/src/B3.Umdf.Server/WireProtocol.cs
@@ -1025,23 +1025,24 @@ public static class WireProtocol
     }
 
     // ───────────────────────────────────────────────────────────────────────
-    //  InstrumentStatus frame (0x00B3) — SecurityStatus_3 halt/resume marker
+    //  InstrumentStatus frame (0x00B3)
     // ───────────────────────────────────────────────────────────────────────
 
     public const byte InstrumentStatusUnavailable = byte.MaxValue;
     public const byte InstrumentStatusDeliveryLiveTransition = 0;
     public const byte InstrumentStatusDeliverySnapshot = 1;
     public const int InstrumentStatusMaxSize =
-        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 1 + 8 + 4 + 1;
+        FramingHeaderSize + 8 + 1 + 255 + 1 + 1 + 1 + 1 + 8 + 4 + 1 + 1 + 1;
 
     /// <summary>
-    /// Serialize a halt/resume transition decoded from <c>SecurityStatus_3</c>.
+    /// Serialize administrative instrument state decoded from
+    /// <c>InstrumentStatus_58</c> or legacy <c>SecurityStatus_3</c>.
     /// Layout:
     /// <c>[secId u64][symLen u8][symbol][previousStatus u8][newStatus u8]
     /// [transition u8][haltReason u8][sourceTimestampNanos u64][rptSeq u32]
-    /// [deliveryKind u8]</c>.
-    /// Unavailable previous status / halt reason / RptSeq are encoded as
-    /// 255 / 255 / 0 respectively.
+    /// [deliveryKind u8][administrativeState u8][tradingSessionId u8]</c>.
+    /// The last two bytes are append-only V17 fields. Unavailable byte fields
+    /// use 255; unavailable RptSeq uses 0.
     /// </summary>
     public static int WriteInstrumentStatus(
         Span<byte> dest,
@@ -1067,9 +1068,19 @@ public static class WireProtocol
         dest[offset++] = update.HaltReasonCode ?? InstrumentStatusUnavailable;
         BinaryPrimitives.WriteUInt64LittleEndian(dest[offset..], update.SourceTimestampNanos); offset += 8;
         BinaryPrimitives.WriteUInt32LittleEndian(dest[offset..], update.RptSeq ?? 0); offset += 4;
-        dest[offset++] = isSnapshot
+        dest[offset++] = isSnapshot || update.IsRecovery
             ? InstrumentStatusDeliverySnapshot
             : InstrumentStatusDeliveryLiveTransition;
+        dest[offset++] = update.AdministrativeStateCode
+            ?? (update.TransitionCode switch
+            {
+                InstrumentStatusDecoder.InstrumentHaltedTransitionCode =>
+                    InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+                InstrumentStatusDecoder.InstrumentResumedTransitionCode =>
+                    InstrumentStatusDecoder.AdministrativeActiveStateCode,
+                _ => InstrumentStatusUnavailable,
+            });
+        dest[offset++] = update.TradingSessionId ?? InstrumentStatusUnavailable;
 
         WriteFramingHeader(dest, offset, MessageType.InstrumentStatus);
         return offset;

--- a/src/B3.Umdf.Transport/UmdfPacket.cs
+++ b/src/B3.Umdf.Transport/UmdfPacket.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Transport;
 

--- a/src/B3.Umdf.Transport/UmdfPacketHeader.cs
+++ b/src/B3.Umdf.Transport/UmdfPacketHeader.cs
@@ -1,4 +1,4 @@
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Transport;
 

--- a/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/InstrumentStatusWireRoundTripTests.cs
@@ -14,9 +14,11 @@ public class InstrumentStatusWireRoundTripTests
             PreviousStatus: 21,
             NewStatus: 17,
             TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
-            HaltReasonCode: null,
+            HaltReasonCode: (byte)InstrumentHaltReason.RegulatoryHalt,
             SourceTimestampNanos: 1_750_000_000_123_456_789,
-            RptSeq: 77);
+            RptSeq: 77,
+            AdministrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+            TradingSessionId: 1);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
 
         int length = WireProtocol.WriteInstrumentStatus(
@@ -38,8 +40,11 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Equal(17, decoded.NewStatus);
         Assert.Equal(InstrumentStatusTransitionKind.Halted, decoded.Transition);
         Assert.Equal(1, decoded.RawTransitionCode);
-        Assert.Null(decoded.HaltReason);
-        Assert.Null(decoded.RawHaltReasonCode);
+        Assert.Equal(InstrumentHaltReason.RegulatoryHalt, decoded.HaltReason);
+        Assert.Equal((byte?)InstrumentHaltReason.RegulatoryHalt, decoded.RawHaltReasonCode);
+        Assert.Equal(InstrumentAdministrativeState.Halted, decoded.AdministrativeState);
+        Assert.Equal((byte?)InstrumentStatusDecoder.AdministrativeHaltedStateCode, decoded.RawAdministrativeStateCode);
+        Assert.Equal((byte?)1, decoded.TradingSessionId);
         Assert.True(decoded.IsHalted);
         Assert.Equal(InstrumentStatusDeliveryKind.LiveTransition, decoded.DeliveryKind);
         Assert.False(decoded.IsSnapshot);
@@ -56,7 +61,9 @@ public class InstrumentStatusWireRoundTripTests
             TransitionCode: InstrumentStatusDecoder.InstrumentResumedTransitionCode,
             HaltReasonCode: null,
             SourceTimestampNanos: 123,
-            RptSeq: null);
+            RptSeq: null,
+            AdministrativeStateCode: InstrumentStatusDecoder.AdministrativeActiveStateCode,
+            TradingSessionId: 1);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
             buffer, securityId: 7, symbol: "VALE3", in update, isSnapshot: true);
@@ -69,13 +76,14 @@ public class InstrumentStatusWireRoundTripTests
         Assert.Null(decoded.PreviousStatus);
         Assert.Equal(InstrumentStatusTransitionKind.Resumed, decoded.Transition);
         Assert.False(decoded.IsHalted);
+        Assert.Equal(InstrumentAdministrativeState.Active, decoded.AdministrativeState);
         Assert.Equal(InstrumentStatusDeliveryKind.Snapshot, decoded.DeliveryKind);
         Assert.True(decoded.IsSnapshot);
         Assert.Null(decoded.RptSeq);
     }
 
     [Fact]
-    public void Roundtrip_FutureDetailedReason_IsSeparateFromTransition()
+    public void Roundtrip_DetailedReason_IsSeparateFromTransition()
     {
         var update = new InstrumentStatusUpdate(
             PreviousStatus: 17,
@@ -83,7 +91,9 @@ public class InstrumentStatusWireRoundTripTests
             TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
             HaltReasonCode: (byte)InstrumentHaltReason.NewsHold,
             SourceTimestampNanos: 123,
-            RptSeq: 1);
+            RptSeq: 1,
+            AdministrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+            TradingSessionId: 1);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
             buffer, securityId: 7, symbol: "VALE3", in update);
@@ -113,12 +123,73 @@ public class InstrumentStatusWireRoundTripTests
             buffer, securityId: 7, symbol: "VALE3", in update, isSnapshot: true);
         var payload = buffer.AsSpan(
             WireFormat.FramingHeaderSize,
-            length - WireFormat.FramingHeaderSize - 1);
+            length - WireFormat.FramingHeaderSize - 3);
 
         Assert.True(WireFormat.TryReadInstrumentStatus(
             payload, DateTime.UnixEpoch, out var decoded));
         Assert.Equal(InstrumentStatusDeliveryKind.LiveTransition, decoded.DeliveryKind);
         Assert.False(decoded.IsSnapshot);
+        Assert.Equal(InstrumentAdministrativeState.Halted, decoded.AdministrativeState);
+        Assert.Null(decoded.RawAdministrativeStateCode);
+        Assert.Null(decoded.TradingSessionId);
+    }
+
+    [Fact]
+    public void Roundtrip_RecoveryMarkedUpdate_IsSnapshotWithNullTransition()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: null,
+            NewStatus: 17,
+            TransitionCode: InstrumentStatusDecoder.UnavailableCode,
+            HaltReasonCode: (byte)InstrumentHaltReason.VolatilityCircuitBreaker,
+            SourceTimestampNanos: 123,
+            RptSeq: null,
+            AdministrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+            TradingSessionId: 1,
+            IsRecovery: true);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 7, symbol: "VALE3", in update);
+
+        Assert.True(WireFormat.TryReadInstrumentStatus(
+            buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
+            DateTime.UnixEpoch,
+            out var decoded));
+
+        Assert.True(decoded.IsSnapshot);
+        Assert.True(decoded.IsHalted);
+        Assert.Equal(InstrumentStatusTransitionKind.Unknown, decoded.Transition);
+        Assert.Equal(InstrumentHaltReason.VolatilityCircuitBreaker, decoded.HaltReason);
+    }
+
+    [Fact]
+    public void Roundtrip_UnknownV17Codes_PreserveRawValues()
+    {
+        var update = new InstrumentStatusUpdate(
+            PreviousStatus: null,
+            NewStatus: 17,
+            TransitionCode: 9,
+            HaltReasonCode: 77,
+            SourceTimestampNanos: 123,
+            RptSeq: 1,
+            AdministrativeStateCode: 8,
+            TradingSessionId: 6);
+        var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
+        int length = WireProtocol.WriteInstrumentStatus(
+            buffer, securityId: 7, symbol: "VALE3", in update);
+
+        Assert.True(WireFormat.TryReadInstrumentStatus(
+            buffer.AsSpan(WireFormat.FramingHeaderSize, length - WireFormat.FramingHeaderSize),
+            DateTime.UnixEpoch,
+            out var decoded));
+
+        Assert.Equal(InstrumentStatusTransitionKind.Unknown, decoded.Transition);
+        Assert.Equal(9, decoded.RawTransitionCode);
+        Assert.Equal(InstrumentHaltReason.Unknown, decoded.HaltReason);
+        Assert.Equal((byte?)77, decoded.RawHaltReasonCode);
+        Assert.Equal(InstrumentAdministrativeState.Unknown, decoded.AdministrativeState);
+        Assert.Equal((byte?)8, decoded.RawAdministrativeStateCode);
+        Assert.Equal((byte?)6, decoded.TradingSessionId);
     }
 
     [Fact]

--- a/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
+++ b/tests/B3.MarketData.WebSocketClient.Tests/MarketDataClientIntegrationTests.cs
@@ -81,6 +81,9 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendInstrumentStatusAsync(
                 ws, 12345, symbol, previousStatus: 17, newStatus: 17,
                 transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+                haltReasonCode: (byte)InstrumentHaltReason.NewsHold,
+                administrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+                tradingSessionId: 1,
                 sourceTimestamp, rptSeq: 9, isSnapshot: false, ct: ct);
             await Task.Delay(Timeout.Infinite, ct);
         });
@@ -102,7 +105,9 @@ public class MarketDataClientIntegrationTests
         Assert.Equal(17, status.PreviousStatus);
         Assert.Equal(17, status.NewStatus);
         Assert.Equal(InstrumentStatusTransitionKind.Halted, status.Transition);
-        Assert.Null(status.HaltReason);
+        Assert.Equal(InstrumentHaltReason.NewsHold, status.HaltReason);
+        Assert.Equal(InstrumentAdministrativeState.Halted, status.AdministrativeState);
+        Assert.Equal((byte?)1, status.TradingSessionId);
         Assert.True(status.IsHalted);
         Assert.False(status.IsSnapshot);
         Assert.Equal(sourceTimestamp, status.SourceTimestampNanos);
@@ -121,8 +126,11 @@ public class MarketDataClientIntegrationTests
             await TestWsServer.SendSubscribeOkAsync(ws, securityId: 42, symbol, ct);
             await TestWsServer.SendInstrumentStatusAsync(
                 ws, 42, symbol, previousStatus: 17, newStatus: 17,
-                transitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
-                sourceTimestamp: 123, rptSeq: 9, isSnapshot: true, ct: ct);
+                transitionCode: InstrumentStatusDecoder.UnavailableCode,
+                haltReasonCode: (byte)InstrumentHaltReason.PendingDisclosure,
+                administrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+                tradingSessionId: 1,
+                sourceTimestamp: 123, rptSeq: null, isSnapshot: true, ct: ct);
 
             if (subscribeNumber == 1)
             {
@@ -162,7 +170,10 @@ public class MarketDataClientIntegrationTests
         Assert.All(statuses, status =>
         {
             Assert.True(status.IsHalted);
-            Assert.Null(status.HaltReason);
+            Assert.Equal(InstrumentHaltReason.PendingDisclosure, status.HaltReason);
+            Assert.Equal(InstrumentAdministrativeState.Halted, status.AdministrativeState);
+            Assert.Equal(InstrumentStatusTransitionKind.Unknown, status.Transition);
+            Assert.Equal((byte?)1, status.TradingSessionId);
             Assert.True(status.IsSnapshot);
         });
     }
@@ -568,14 +579,17 @@ internal sealed class TestWsServer : IAsyncDisposable
         int? previousStatus,
         int newStatus,
         byte transitionCode,
+        byte? haltReasonCode,
+        byte? administrativeStateCode,
+        byte? tradingSessionId,
         ulong sourceTimestamp,
         uint? rptSeq,
         bool isSnapshot,
         CancellationToken ct)
     {
         var update = new InstrumentStatusUpdate(
-            previousStatus, newStatus, transitionCode, null,
-            sourceTimestamp, rptSeq);
+            previousStatus, newStatus, transitionCode, haltReasonCode,
+            sourceTimestamp, rptSeq, administrativeStateCode, tradingSessionId);
         var buffer = new byte[WireProtocol.InstrumentStatusMaxSize];
         int length = WireProtocol.WriteInstrumentStatus(
             buffer, securityId, symbol, in update, isSnapshot);

--- a/tests/B3.Umdf.Book.Tests/BookManagerMassDeleteScopeTests.cs
+++ b/tests/B3.Umdf.Book.Tests/BookManagerMassDeleteScopeTests.cs
@@ -1,5 +1,5 @@
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Book.Tests/BookManagerOnPacketAllocationTests.cs
+++ b/tests/B3.Umdf.Book.Tests/BookManagerOnPacketAllocationTests.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Umdf.Book.Tests/EmptyBookCounterTests.cs
+++ b/tests/B3.Umdf.Book.Tests/EmptyBookCounterTests.cs
@@ -1,5 +1,5 @@
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
+++ b/tests/B3.Umdf.Book.Tests/InstrumentStatusDecoderTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Feed;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -46,6 +47,86 @@ public class InstrumentStatusDecoderTests
     }
 
     [Fact]
+    public void TryDecode_InstrumentStatus58_LiveHaltPreservesAuthoritativeFields()
+    {
+        const ulong sourceTimestamp = 1_750_000_000_987_654_321;
+        var body = BuildInstrumentStatusBody(
+            securityId: 12345,
+            status: SecurityTradingStatus.OPEN,
+            state: AdministrativeHaltState.HALTED,
+            transition: AdministrativeTransitionKind.HALT,
+            haltReason: HaltReason.NEWS_HOLD,
+            sourceTimestamp,
+            rptSeq: 77,
+            tradingSessionId: TradingSessionID.REGULAR_TRADING_SESSION,
+            isRecovery: false);
+
+        Assert.True(InstrumentStatus_58Data.TryParse(body, out var reader));
+        Assert.True(InstrumentStatusDecoder.TryDecode(
+            in reader, previousStatus: 21, out var update));
+
+        Assert.Equal(21, update.PreviousStatus);
+        Assert.Equal((int)SecurityTradingStatus.OPEN, update.NewStatus);
+        Assert.Equal((byte)AdministrativeHaltState.HALTED, update.AdministrativeStateCode);
+        Assert.Equal((byte)AdministrativeTransitionKind.HALT, update.TransitionCode);
+        Assert.Equal((byte)HaltReason.NEWS_HOLD, update.HaltReasonCode);
+        Assert.Equal(sourceTimestamp, update.SourceTimestampNanos);
+        Assert.Equal(77u, update.RptSeq);
+        Assert.Equal((byte)TradingSessionID.REGULAR_TRADING_SESSION, update.TradingSessionId);
+        Assert.False(update.IsRecovery);
+        Assert.True(update.IsHalted);
+    }
+
+    [Fact]
+    public void TryDecode_RecoverySnapshot_BootstrapsStateWithoutTransition()
+    {
+        var body = BuildInstrumentStatusBody(
+            securityId: 7,
+            status: SecurityTradingStatus.OPEN,
+            state: AdministrativeHaltState.HALTED,
+            transition: null,
+            haltReason: HaltReason.REGULATORY_HALT,
+            sourceTimestamp: 123,
+            rptSeq: null,
+            tradingSessionId: TradingSessionID.REGULAR_TRADING_SESSION,
+            isRecovery: true);
+
+        Assert.True(InstrumentStatus_58Data.TryParse(body, out var reader));
+        Assert.True(InstrumentStatusDecoder.TryDecode(
+            in reader, previousStatus: null, out var update));
+
+        Assert.Equal(InstrumentStatusDecoder.UnavailableCode, update.TransitionCode);
+        Assert.Equal((byte)HaltReason.REGULATORY_HALT, update.HaltReasonCode);
+        Assert.Null(update.RptSeq);
+        Assert.True(update.IsRecovery);
+        Assert.True(update.IsHalted);
+    }
+
+    [Fact]
+    public void TryDecode_UnknownEnumValues_PreservesRawCodes()
+    {
+        var body = BuildInstrumentStatusBody(
+            securityId: 7,
+            status: SecurityTradingStatus.OPEN,
+            state: (AdministrativeHaltState)9,
+            transition: (AdministrativeTransitionKind)8,
+            haltReason: (HaltReason)77,
+            sourceTimestamp: 123,
+            rptSeq: 9,
+            tradingSessionId: (TradingSessionID)6,
+            isRecovery: false);
+
+        Assert.True(InstrumentStatus_58Data.TryParse(body, out var reader));
+        Assert.True(InstrumentStatusDecoder.TryDecode(
+            in reader, previousStatus: null, out var update));
+
+        Assert.Equal((byte?)9, update.AdministrativeStateCode);
+        Assert.Equal(8, update.TransitionCode);
+        Assert.Equal((byte?)77, update.HaltReasonCode);
+        Assert.Equal((byte?)6, update.TradingSessionId);
+    }
+
+    [Fact]
     public void MarketDataManager_SurfacesPreviousAndNewStatusDeterministically()
     {
         var handler = new CapturingHandler();
@@ -80,6 +161,66 @@ public class InstrumentStatusDecoderTests
         Assert.Equal(handler.Update, manager.InstrumentData[42].AdministrativeStatus);
     }
 
+    [Fact]
+    public void MarketDataManager_DualTemplateRolloutPacket_EmitsOnlyAuthoritativeEvent()
+    {
+        var handler = new CapturingHandler();
+        var manager = new MarketDataManager(
+            handler,
+            stateRegistry: new SymbolStateRegistry(NullLogger.Instance));
+        var packet = BuildPacket(
+            BuildFrame(
+                42,
+                SecurityTradingStatus.OPEN,
+                InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
+                200,
+                2),
+            BuildInstrumentStatusFrame(
+                42,
+                SecurityTradingStatus.OPEN,
+                AdministrativeHaltState.HALTED,
+                AdministrativeTransitionKind.HALT,
+                HaltReason.PENDING_DISCLOSURE,
+                200,
+                2,
+                isRecovery: false));
+
+        MessageDispatcher.Dispatch(in packet, manager);
+
+        Assert.Equal(1, handler.Count);
+        Assert.Equal((byte)HaltReason.PENDING_DISCLOSURE, handler.Update.HaltReasonCode);
+        Assert.Equal((byte)AdministrativeHaltState.HALTED, handler.Update.AdministrativeStateCode);
+        Assert.Equal(handler.Update, manager.InstrumentData[42].AdministrativeStatus);
+    }
+
+    [Fact]
+    public void MarketDataManager_RecoveryTemplate58_CachesDetailedBootstrapState()
+    {
+        var handler = new CapturingHandler();
+        var manager = new MarketDataManager(
+            handler,
+            stateRegistry: new SymbolStateRegistry(NullLogger.Instance));
+
+        manager.OnPacket(
+            in EmptyPacket,
+            BuildInstrumentStatusFrame(
+                42,
+                SecurityTradingStatus.OPEN,
+                AdministrativeHaltState.HALTED,
+                transition: null,
+                HaltReason.VOLATILITY_CIRCUIT_BREAKER,
+                sourceTimestamp: 987,
+                rptSeq: null,
+                isRecovery: true),
+            InstrumentStatus_58Data.MESSAGE_ID);
+
+        Assert.Equal(1, handler.Count);
+        Assert.True(handler.Update.IsRecovery);
+        Assert.Equal(InstrumentStatusDecoder.UnavailableCode, handler.Update.TransitionCode);
+        Assert.Equal((byte)HaltReason.VOLATILITY_CIRCUIT_BREAKER, handler.Update.HaltReasonCode);
+        Assert.Equal(handler.Update, manager.InstrumentData[42].AdministrativeStatus);
+    }
+
     private static byte[] BuildFrame(
         ulong securityId,
         SecurityTradingStatus status,
@@ -92,6 +233,87 @@ public class InstrumentStatusDecoderTests
         BuildBody(securityId, status, eventCode, sourceTimestamp, rptSeq)
             .CopyTo(frame, MessageHeader.MESSAGE_SIZE);
         return frame;
+    }
+
+    private static byte[] BuildInstrumentStatusFrame(
+        ulong securityId,
+        SecurityTradingStatus status,
+        AdministrativeHaltState state,
+        AdministrativeTransitionKind? transition,
+        HaltReason? haltReason,
+        ulong sourceTimestamp,
+        uint? rptSeq,
+        bool isRecovery)
+    {
+        var frame = new byte[MessageHeader.MESSAGE_SIZE + InstrumentStatus_58Data.MESSAGE_SIZE];
+        InstrumentStatus_58Data.WriteHeader(frame);
+        BuildInstrumentStatusBody(
+                securityId,
+                status,
+                state,
+                transition,
+                haltReason,
+                sourceTimestamp,
+                rptSeq,
+                TradingSessionID.REGULAR_TRADING_SESSION,
+                isRecovery)
+            .CopyTo(frame, MessageHeader.MESSAGE_SIZE);
+        return frame;
+    }
+
+    private static byte[] BuildInstrumentStatusBody(
+        ulong securityId,
+        SecurityTradingStatus status,
+        AdministrativeHaltState state,
+        AdministrativeTransitionKind? transition,
+        HaltReason? haltReason,
+        ulong sourceTimestamp,
+        uint? rptSeq,
+        TradingSessionID tradingSessionId,
+        bool isRecovery)
+    {
+        var message = new InstrumentStatus_58Data
+        {
+            SecurityID = securityId,
+            MatchEventIndicator = isRecovery
+                ? MatchEventIndicator.RecoveryMsg
+                : 0,
+            TradingSessionID = tradingSessionId,
+            SecurityTradingStatus = status,
+            AdministrativeHaltState = state,
+        };
+        message.SetAdministrativeTransitionKind(transition);
+        message.SetHaltReason(haltReason);
+        message.SetRptSeq(rptSeq);
+
+        var body = new byte[InstrumentStatus_58Data.MESSAGE_SIZE];
+        Assert.True(message.TryEncode(body, out var written));
+        Assert.Equal(InstrumentStatus_58Data.MESSAGE_SIZE, written);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(16), sourceTimestamp);
+        return body;
+    }
+
+    private static UmdfPacket BuildPacket(params byte[][] sbeFrames)
+    {
+        int length = UmdfPacketHeader.Size
+            + sbeFrames.Sum(frame => FramingHeader.MESSAGE_SIZE + frame.Length);
+        var bytes = new byte[length];
+        int offset = UmdfPacketHeader.Size;
+        foreach (byte[] frame in sbeFrames)
+        {
+            BinaryPrimitives.WriteUInt16LittleEndian(
+                bytes.AsSpan(offset),
+                checked((ushort)(FramingHeader.MESSAGE_SIZE + frame.Length)));
+            frame.CopyTo(bytes, offset + FramingHeader.MESSAGE_SIZE);
+            offset += FramingHeader.MESSAGE_SIZE + frame.Length;
+        }
+
+        return new UmdfPacket
+        {
+            Data = bytes,
+            Channel = ChannelType.IncrementalA,
+            ChannelGroup = 1,
+        };
     }
 
     private static byte[] BuildBody(

--- a/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue75RecoveryTests.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
+++ b/tests/B3.Umdf.Book.Tests/Issue80TradeGapRecoveryTests.cs
@@ -1,6 +1,6 @@
 using B3.Umdf.Book;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Book.Tests/MarketDataManagerInstrumentReplacementTests.cs
+++ b/tests/B3.Umdf.Book.Tests/MarketDataManagerInstrumentReplacementTests.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Umdf.Book.Tests/MarketDataManagerNewsCounterTests.cs
+++ b/tests/B3.Umdf.Book.Tests/MarketDataManagerNewsCounterTests.cs
@@ -1,7 +1,7 @@
 using System.Buffers.Binary;
 using B3.Umdf.Book;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Umdf.Book.Tests/MarketDataManagerSecDefAllocationTests.cs
+++ b/tests/B3.Umdf.Book.Tests/MarketDataManagerSecDefAllocationTests.cs
@@ -1,7 +1,7 @@
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Umdf.Book.Tests/PerSymbolEndToEndTests.cs
+++ b/tests/B3.Umdf.Book.Tests/PerSymbolEndToEndTests.cs
@@ -1,6 +1,6 @@
 using B3.Umdf.Book;
 using B3.Umdf.Feed;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Book.Tests/SpecComplianceTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SpecComplianceTests.cs
@@ -1,5 +1,5 @@
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Book.Tests/SymbolRegistryReuseTests.cs
+++ b/tests/B3.Umdf.Book.Tests/SymbolRegistryReuseTests.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Text;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Book.Tests;

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerColdStartTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerColdStartTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerConfigurableReorderTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerConfigurableReorderTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerReorderInvariantsTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerReorderInvariantsTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceVersionRolloverTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceVersionRolloverTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceWrapTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/ChannelHandlerSequenceWrapTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedExceptionIsolationTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedExceptionIsolationTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerInstrDefRobustnessTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerInstrDefRobustnessTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerInstrDefStuckEscapeTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerInstrDefStuckEscapeTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerLifecycleCallbacksTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerLifecycleCallbacksTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerSnapshotBatchCompleteTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerSnapshotBatchCompleteTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/FeedHandlerStateMachineTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/FeedHandlerStateMachineTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/MessageDispatcherSequenceResetTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MessageDispatcherSequenceResetTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/MpscPacketRingTimeoutTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MpscPacketRingTimeoutTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDispatchResilienceTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDispatchResilienceTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDropVisibilityTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MultiFeedManagerDropVisibilityTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Umdf.Feed.Tests/MultiFeedManagerTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/MultiFeedManagerTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Feed.Tests/SbeFrameWalkerTests.cs
+++ b/tests/B3.Umdf.Feed.Tests/SbeFrameWalkerTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Feed.Tests;

--- a/tests/B3.Umdf.Fuzz.Tests/SbeParserFuzzTests.cs
+++ b/tests/B3.Umdf.Fuzz.Tests/SbeParserFuzzTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Fuzz.Tests;
 

--- a/tests/B3.Umdf.Fuzz.Tests/ValidatingSbeDispatcherFuzzTests.cs
+++ b/tests/B3.Umdf.Fuzz.Tests/ValidatingSbeDispatcherFuzzTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Sbe;
 
 namespace B3.Umdf.Fuzz.Tests;
@@ -223,6 +223,7 @@ public class ValidatingSbeDispatcherFuzzTests
         public void OnEmptyBook_9(in EmptyBook_9DataReader reader, int blockLength, int version) { }
         public void OnChannelReset_11(in ChannelReset_11DataReader reader, int blockLength, int version) { }
         public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) { }
+        public void OnInstrumentStatus_58(in InstrumentStatus_58DataReader reader, int blockLength, int version) { }
         public void OnSecurityGroupPhase_10(in SecurityGroupPhase_10DataReader reader, int blockLength, int version) { }
         public void OnSecurityDefinition_12(in SecurityDefinition_12DataReader reader, int blockLength, int version) { }
         public void OnNews_5(in News_5DataReader reader, int blockLength, int version) { }

--- a/tests/B3.Umdf.Sbe.Tests/ValidatingSbeDispatcherTests.cs
+++ b/tests/B3.Umdf.Sbe.Tests/ValidatingSbeDispatcherTests.cs
@@ -1,5 +1,5 @@
 using System.Buffers.Binary;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Sbe;
 
 namespace B3.Umdf.Sbe.Tests;
@@ -7,7 +7,7 @@ namespace B3.Umdf.Sbe.Tests;
 public class ValidatingSbeDispatcherTests
 {
     private const ushort SchemaId = 2;
-    private const ushort SupportedVersion = 16;
+    private const ushort SupportedVersion = 17;
 
     /// <summary>Builds an 8-byte SBE message header followed by <paramref name="extraPayload"/> bytes.</summary>
     private static byte[] BuildHeader(ushort templateId, ushort schemaId, ushort version, ushort blockLength, int extraPayload = 0)
@@ -38,6 +38,25 @@ public class ValidatingSbeDispatcherTests
         Assert.Null(rejection);
         Assert.Equal(1, handler.DispatchCount);
         Assert.Equal(1, handler.LastTemplateId);
+    }
+
+    [Fact]
+    public void Dispatch_V17InstrumentStatus_DispatchesTemplate58()
+    {
+        var buf = BuildHeader(
+            templateId: InstrumentStatus_58Data.MESSAGE_ID,
+            schemaId: SchemaId,
+            version: SupportedVersion,
+            blockLength: InstrumentStatus_58Data.BLOCK_LENGTH,
+            extraPayload: InstrumentStatus_58Data.MESSAGE_SIZE);
+        var dispatcher = new ValidatingSbeDispatcher();
+        var handler = new CountingHandler();
+
+        bool dispatched = dispatcher.Dispatch(buf, ref handler);
+
+        Assert.True(dispatched);
+        Assert.Equal(1, handler.DispatchCount);
+        Assert.Equal(58, handler.LastTemplateId);
     }
 
     [Fact]
@@ -145,6 +164,7 @@ public class ValidatingSbeDispatcherTests
         public void OnEmptyBook_9(in EmptyBook_9DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 9; }
         public void OnChannelReset_11(in ChannelReset_11DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 11; }
         public void OnSecurityStatus_3(in SecurityStatus_3DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 3; }
+        public void OnInstrumentStatus_58(in InstrumentStatus_58DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 58; }
         public void OnSecurityGroupPhase_10(in SecurityGroupPhase_10DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 10; }
         public void OnSecurityDefinition_12(in SecurityDefinition_12DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 12; }
         public void OnNews_5(in News_5DataReader reader, int blockLength, int version) { DispatchCount++; LastTemplateId = 5; }

--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerAuctionPrintTests.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Reflection;
 using B3.Umdf.Book;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using MessageType = B3.MarketData.Wire.MessageType;
 using B3.Umdf.Server;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
+++ b/tests/B3.Umdf.Server.Tests/InstrumentStatusBootstrapTests.cs
@@ -29,9 +29,11 @@ public class InstrumentStatusBootstrapTests
             PreviousStatus: 17,
             NewStatus: 17,
             TransitionCode: InstrumentStatusDecoder.InstrumentHaltedTransitionCode,
-            HaltReasonCode: null,
+            HaltReasonCode: 4,
             SourceTimestampNanos: 123,
-            RptSeq: 9);
+            RptSeq: 9,
+            AdministrativeStateCode: InstrumentStatusDecoder.AdministrativeHaltedStateCode,
+            TradingSessionId: 1);
 
         var symbols = new SymbolRegistry();
         RegisterSymbol(symbols, Symbol, SecurityId);
@@ -59,7 +61,9 @@ public class InstrumentStatusBootstrapTests
         Assert.NotNull(frame);
         Assert.Equal(
             WireProtocol.InstrumentStatusDeliverySnapshot,
-            frame![^1]);
+            frame![^3]);
+        Assert.Equal(InstrumentStatusDecoder.AdministrativeHaltedStateCode, frame[^2]);
+        Assert.Equal(1, frame[^1]);
 
         session.Dispose();
         await writeTask.WaitAsync(TimeSpan.FromSeconds(2));

--- a/tests/B3.Umdf.Transport.Tests/MulticastChannelMergerTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/MulticastChannelMergerTests.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using System.Threading.Channels;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 
 namespace B3.Umdf.Transport.Tests;
 

--- a/tests/B3.Umdf.Transport.Tests/UmdfPacketHeaderTests.cs
+++ b/tests/B3.Umdf.Transport.Tests/UmdfPacketHeaderTests.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.Transport;
 
 namespace B3.Umdf.Transport.Tests;

--- a/tools/PcapRptSeqAnalyzer/Program.cs
+++ b/tools/PcapRptSeqAnalyzer/Program.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.Mbo.Sbe.V17;
 using B3.Umdf.PcapReplay;
 
 namespace B3.Umdf.Tools.PcapRptSeqAnalyzer;


### PR DESCRIPTION
## Status: blocked — do not merge

This implementation is preserved for review, but it does **not** close #73.
A schema compliance audit found that upstream B3MatchingPlatform#582 manually modified the vendored B3 schema despite repository instructions prohibiting hand edits under `schemas/`. The upstream encoder also mirrors the template body through handwritten `WireOffsets`/raw writes. No further schema architecture changes will be made here until direction is provided.

## Preserved implementation

- mirrors upstream schema 2.3.0 / V17 from merge commit `8212925a45baf52b1ee004419cadfab84063847d`
- decodes generated `InstrumentStatus_58` bindings and maps state, transition, reason, timestamps, RptSeq, session, and recovery semantics
- retains legacy `SecurityStatus_3` compatibility and same-packet rollout deduplication
- preserves detailed cached state for recovery and reconnect bootstrap
- keeps append-only WebSocket compatibility and malformed-frame protections

## Validation completed before blocker

- Debug/Release solution builds: passed, 0 warnings
- Debug/Release full test suites: 834 passed each
- JavaScript golden vectors: 11 passed
- GitHub CI and Docker checks: passed

Issue #73 remains open pending resolution of the upstream schema architecture violation.