### PR TITLE
docs: add protocol contract gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/general-issue.yml
+++ b/.github/ISSUE_TEMPLATE/general-issue.yml
@@ -1,0 +1,30 @@
+name: General issue (non-protocol)
+description: Bugs, docs, operations, UI, performance, or maintenance work with no wire-contract change.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this route for non-protocol work. If the request changes Binary
+        UMDF/SBE decoding, cross-repo wire dependencies, or WebSocket projection
+        of upstream data, use a protocol template instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change or be investigated?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Links, logs, screenshots, repro steps, or other relevant details.
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Expected validation
+      description: What would prove this issue is fixed or complete?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/protocol-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-implementation.yml
@@ -1,0 +1,47 @@
+name: Protocol implementation (contract proven)
+description: Request decoding or WebSocket projection for a proven UMDF/SBE wire contract.
+title: "Protocol: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this route only when the contract is already proven. Issue proposals,
+        draft PRs, and local branches are not evidence; use the research/blocker
+        route if the merged upstream contract or official schema details are absent.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Implementation request
+      description: What should this repository decode, project, or expose?
+    validations:
+      required: true
+  - type: textarea
+    id: upstream-contract
+    attributes:
+      label: Merged upstream contract
+      description: Cite the upstream repository, merged PR URL, and merge commit SHA.
+      placeholder: "pedrosakuma/B3MatchingPlatform#582, merge commit 8212925..."
+    validations:
+      required: true
+  - type: textarea
+    id: official-schema
+    attributes:
+      label: Official schema details
+      description: Cite the official schema family/version, template ID/name, fields/tags/offsets, and enum values.
+      placeholder: "B3 Binary UMDF Market Data vX.Y.Z, template NN Name_NN, field tags ..., enum values ..."
+    validations:
+      required: true
+  - type: textarea
+    id: websocket-projection
+    attributes:
+      label: MarketData WebSocket projection
+      description: If adding WebSocket frames, describe them as this repository's WebSocket protocol messages, not official UMDF templates. Use N/A if none.
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and validation plan
+      description: Describe backwards compatibility, bootstrap/recovery behavior, and targeted validation.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/protocol-research.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-research.yml
@@ -1,0 +1,39 @@
+name: Protocol research / blocker (contract absent)
+description: Track protocol feasibility, missing schema evidence, or blocked downstream requests.
+title: "Protocol research: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this route when the desired behavior is not backed by a merged
+        upstream wire contract plus exact official schema details. Research can
+        collect evidence, define blockers, or link the upstream work that must
+        merge before implementation starts.
+  - type: textarea
+    id: desired-behavior
+    attributes:
+      label: Desired behavior
+      description: What downstream or operator outcome is being investigated?
+    validations:
+      required: true
+  - type: textarea
+    id: missing-contract
+    attributes:
+      label: Missing contract evidence / blocker
+      description: State what is absent, such as a merged upstream PR/commit, official schema version, template ID, fields, or enums.
+    validations:
+      required: true
+  - type: textarea
+    id: sources-checked
+    attributes:
+      label: Sources checked
+      description: Link issue proposals, draft PRs, schema docs, PCAP evidence, or code searches that explain the current state.
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgement
+    attributes:
+      label: Acknowledgement
+      options:
+        - label: I understand that issue proposals, draft PRs, and local branches are not implementation evidence.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Protocol contract gate
+
+Check one:
+
+- [ ] Not a protocol or cross-repo wire-contract change.
+- [ ] Protocol implementation: this PR cites the merged upstream PR/commit plus
+      exact official schema version, template ID/name, fields/tags/offsets, and
+      enums below.
+- [ ] Protocol research/blocker only: this PR does not introduce unsupported
+      UMDF implementation claims.
+
+Contract evidence / N/A:
+
+-
+
+- [ ] Issue proposals, draft PRs, and local branches are not treated as wire
+      contract evidence.
+- [ ] Any MarketData WebSocket-only messages are described as WebSocket protocol
+      messages, not official UMDF templates.

--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ the only modification to the original B3 schema.
 | [docs/WEBSOCKET_API.md](docs/WEBSOCKET_API.md) | **Consumer-facing landing for the WebSocket distribution layer**: stability label, breaking-change policy, "reference price" quickstart for downstream apps (e.g. risk modules) |
 | [docs/CLIENT-SDK.md](docs/CLIENT-SDK.md) | **Typed C# SDK** (`B3.MarketData.WebSocketClient` NuGet): API, DI extension, reconnect+replay, back-pressure policies |
 | [docs/WEBSOCKET-PROTOCOL.md](docs/WEBSOCKET-PROTOCOL.md) | Wire framing, message catalog, hex examples, subscription / reconnect / slow-consumer flows, candle chunking |
+| [docs/PROTOCOL-CONTRACTS.md](docs/PROTOCOL-CONTRACTS.md) | Contribution gate for UMDF/SBE wire-contract evidence, protocol research blockers, and WebSocket-vs-UMDF terminology |
 | [docs/PERFORMANCE.md](docs/PERFORMANCE.md) | Hot-path design, zero-copy decoding, MPSC ring, broadcaster decoupling, coalescing, benchmarks |
 | [docs/RESILIENCE.md](docs/RESILIENCE.md) | Failure modes, gap recovery, fanout suppression, slow-consumer layered defenses, memory bounds, operational playbook |
 | [docs/NOISY-NEIGHBOUR.md](docs/NOISY-NEIGHBOUR.md) | Behaviour under host-level resource contention, scheduler jitter probe, deployment hardening (cpuset, k8s static CPU manager, NIC IRQ pinning, sysctls) |

--- a/docs/PROTOCOL-CONTRACTS.md
+++ b/docs/PROTOCOL-CONTRACTS.md
@@ -1,0 +1,28 @@
+# Protocol contract gate
+
+This repository decodes official B3 Binary UMDF/SBE packets and also exposes a
+separate MarketData WebSocket protocol for downstream clients. Keep those
+contracts distinct.
+
+## Durable rules
+
+- Cross-repo wire dependencies must cite the merged upstream PR URL and merge
+  commit SHA that produced the contract. Issue proposals, draft PRs, and local
+  branches are useful context, but they are not implementation evidence.
+- Protocol implementation requests must also cite the exact official schema
+  family/version, SBE template ID/name, fields/tags/offsets used, and enum values
+  being decoded or projected.
+- If that contract evidence is absent, file the work as protocol research or a
+  blocker instead of requesting an implementation.
+- The MarketData WebSocket protocol may define its own frames/messages derived
+  from supported data, but those frames must be described as MarketData WebSocket
+  messages, never as official UMDF templates.
+
+## Issue routes
+
+Use **Protocol implementation (contract proven)** only when the merged upstream
+wire contract and official schema details are known. Use **Protocol research /
+blocker (contract absent)** for feasibility work, missing schema evidence, or
+blocked downstream requests. Use **General issue (non-protocol)** for ordinary
+bugs, docs, operations, UI, and performance work that does not change a wire
+contract.

--- a/docs/PROTOCOL-CONTRACTS.md
+++ b/docs/PROTOCOL-CONTRACTS.md
@@ -18,6 +18,16 @@ contracts distinct.
   from supported data, but those frames must be described as MarketData WebSocket
   messages, never as official UMDF templates.
 
+## Relationship to the CI schema guard
+
+The issue forms, PR checklist, and rules above are review-time discipline: they
+are not read or validated by CI. The only deterministically enforced backstop
+in this repo is the **Vendored schema guard** job (`.github/workflows/ci.yml`),
+which fails any PR that touches `schemas/` unless it carries the
+`schema-upgrade` label — this is what actually blocks an unreviewed hand-edit
+of a vendored schema file, independent of what an issue or PR description
+claims.
+
 ## Issue routes
 
 Use **Protocol implementation (contract proven)** only when the merged upstream


### PR DESCRIPTION
## Summary

- add GitHub issue forms that split protocol implementation requests (contract proven) from protocol research/blockers (contract absent)
- disable blank issues while preserving a general non-protocol issue route
- add a PR checklist and durable docs requiring merged upstream PR/commit evidence plus exact official schema version/template ID/fields/enums for cross-repo UMDF wire dependencies
- clarify that MarketData WebSocket frames may be repository-specific messages, but must not be described as official UMDF templates

## Context

Issue #73 requested an `InstrumentStatus` event before this repo had a proven upstream wire contract. PR #85 preserved an implementation but was blocked because the available evidence was not a durable official contract. Upstream B3MatchingPlatform issue #581 captured the missing halt-reason wire contract, and B3MatchingPlatform PR #582 later merged the authoritative `InstrumentStatus_58` schema evidence. This gate is meant to keep future requests in the right lane: implementation only after #582-style evidence exists; research/blocker otherwise.

## Validation

- [x] `git diff --check`
- [x] Python/PyYAML parse of all `.github/**/*.yml` and `.github/**/*.yaml`
- [x] gpt-5.5 code review of the diff; fixed the reported invalid empty issue-form title; re-review found no significant issues

## Protocol contract gate

Check one:

- [x] Not a protocol or cross-repo wire-contract change.
- [ ] Protocol implementation: this PR cites the merged upstream PR/commit plus exact official schema version, template ID/name, fields/tags/offsets, and enums below.
- [ ] Protocol research/blocker only: this PR does not introduce unsupported UMDF implementation claims.

Contract evidence / N/A:

- N/A — repository workflow/template change only.

- [x] Issue proposals, draft PRs, and local branches are not treated as wire contract evidence.
- [x] Any MarketData WebSocket-only messages are described as WebSocket protocol messages, not official UMDF templates.