### PR TITLE
ci: deterministic guard against hand-edited vendored schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
         # that don't touch schemas/ must not be blocked by pre-existing
         # drift between the two repos that predates this PR. Iterated
         # line-by-line (not word-split) so filenames with spaces survive.
+        #
+        # NOTE: because this only runs for files already in $changed, it
+        # can never independently flip flagged from 0 to 1 — flagged is
+        # already 1 whenever the loop has anything to iterate. Its value
+        # is diagnostic: confirming, for a change a maintainer is about to
+        # label schema-upgrade, whether the new content is byte-identical
+        # to the trusted upstream copy (vs. an edit that merely resembles
+        # the official schema). It intentionally does not gate PRs that
+        # leave schemas/ untouched, even if drift exists there already.
         while IFS= read -r f; do
           [ -n "$f" ] || continue
           case "$f" in schemas/*.xml) ;; *) continue ;; esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,36 @@ on:
     branches: [ main ]
 
 jobs:
+  schema-guard:
+    name: Vendored schema guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Block hand-edits to vendored schemas
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+        changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- schemas/ || true)"
+        if [ -z "$changed" ]; then
+          echo "No changes under schemas/. OK."
+          exit 0
+        fi
+        echo "Changed vendored schema files:"
+        echo "$changed"
+        has_label="$(jq -r '([.pull_request.labels[].name] | index("schema-upgrade")) != null' "$GITHUB_EVENT_PATH")"
+        if [ "$has_label" != "true" ]; then
+          echo "::error::Files under schemas/ are vendored (see README.md) and must not be hand-edited. If this is an intentional, reviewed schema upgrade, add the 'schema-upgrade' label to this PR to acknowledge and unblock this check."
+          exit 1
+        fi
+        echo "PR is labeled 'schema-upgrade' — allowing vendored schema change."
+
   build-and-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,39 @@ jobs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -euo pipefail
+        flagged=0
+
         changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- schemas/)"
-        if [ -z "$changed" ]; then
-          echo "No changes under schemas/. OK."
+        if [ -n "$changed" ]; then
+          flagged=1
+          echo "PR modifies vendored schema file(s):"
+          echo "$changed"
+        fi
+
+        # Best-effort cross-check against the companion SbeB3UmdfConsumer
+        # repo, which vendors the same UMDF market-data schema and is kept
+        # in lock-step per README.md. Network/availability issues here only
+        # warn (they must not make an unrelated outage block every PR); an
+        # actual content mismatch is treated the same as a local edit.
+        for f in schemas/*.xml; do
+          name="$(basename "$f")"
+          url="https://raw.githubusercontent.com/pedrosakuma/SbeB3UmdfConsumer/main/schemas/$name"
+          if remote_sha="$(curl -fsSL "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
+            local_sha="$(sha256sum "$f" | awk '{print $1}')"
+            if [ "$remote_sha" != "$local_sha" ]; then
+              flagged=1
+              echo "$f (sha256 $local_sha) diverges from SbeB3UmdfConsumer's vendored copy (sha256 $remote_sha)."
+            fi
+          else
+            echo "::warning::Could not fetch $url to cross-check vendored schema fidelity; skipping cross-repo check for $name."
+          fi
+        done
+
+        if [ "$flagged" = 0 ]; then
+          echo "No changes under schemas/ and no drift from the companion repo. OK."
           exit 0
         fi
-        echo "Changed vendored schema files:"
-        echo "$changed"
+
         has_label="$(jq -r '([.pull_request.labels[].name] | index("schema-upgrade")) != null' "$GITHUB_EVENT_PATH")"
         if [ "$has_label" != "true" ]; then
           echo "::error::Files under schemas/ are vendored (see README.md) and must not be hand-edited. If this is an intentional, reviewed schema upgrade, add the 'schema-upgrade' label to this PR to acknowledge and unblock this check."
@@ -40,7 +66,6 @@ jobs:
 
   build-and-test:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         for f in schemas/*.xml; do
           name="$(basename "$f")"
           url="https://raw.githubusercontent.com/pedrosakuma/SbeB3UmdfConsumer/main/schemas/$name"
-          if remote_sha="$(curl -fsSL "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
+          if remote_sha="$(curl -fsSL --connect-timeout 5 --max-time 15 "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
             local_sha="$(sha256sum "$f" | awk '{print $1}')"
             if [ "$remote_sha" != "$local_sha" ]; then
               flagged=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,11 @@ jobs:
         # in lock-step per README.md. Network/availability issues here only
         # warn (they must not make an unrelated outage block every PR); an
         # actual content mismatch is treated the same as a local edit.
-        for f in schemas/*.xml; do
+        # Scoped to files this PR actually touched under schemas/ — PRs
+        # that don't touch schemas/ must not be blocked by pre-existing
+        # drift between the two repos that predates this PR.
+        for f in $changed; do
+          case "$f" in schemas/*.xml) ;; *) continue ;; esac
           name="$(basename "$f")"
           url="https://raw.githubusercontent.com/pedrosakuma/SbeB3UmdfConsumer/main/schemas/$name"
           if remote_sha="$(curl -fsSL --connect-timeout 5 --max-time 15 "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
   build-and-test:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,16 @@ jobs:
         # actual content mismatch is treated the same as a local edit.
         # Scoped to files this PR actually touched under schemas/ — PRs
         # that don't touch schemas/ must not be blocked by pre-existing
-        # drift between the two repos that predates this PR.
-        for f in $changed; do
+        # drift between the two repos that predates this PR. Iterated
+        # line-by-line (not word-split) so filenames with spaces survive.
+        while IFS= read -r f; do
+          [ -n "$f" ] || continue
           case "$f" in schemas/*.xml) ;; *) continue ;; esac
+          if [ ! -f "$f" ]; then
+            # Deleted by this PR; already caught by the local diff check
+            # above (flagged=1), nothing to cross-check against upstream.
+            continue
+          fi
           name="$(basename "$f")"
           url="https://raw.githubusercontent.com/pedrosakuma/SbeB3UmdfConsumer/main/schemas/$name"
           if remote_sha="$(curl -fsSL --connect-timeout 5 --max-time 15 "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
@@ -54,7 +61,8 @@ jobs:
           else
             echo "::warning::Could not fetch $url to cross-check vendored schema fidelity; skipping cross-repo check for $name."
           fi
-        done
+        done <<< "$changed"
+
 
         if [ "$flagged" = 0 ]; then
           echo "No changes under schemas/ and no drift from the companion repo. OK."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   schema-guard:
@@ -23,7 +24,7 @@ jobs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         set -euo pipefail
-        changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- schemas/ || true)"
+        changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- schemas/)"
         if [ -z "$changed" ]; then
           echo "No changes under schemas/. OK."
           exit 0


### PR DESCRIPTION
## Summary
- add a `schema-guard` CI job that diffs `schemas/**` between PR base and head
- fails the check unless the PR is labeled `schema-upgrade`
- this is a deterministic, git-diff-based check — it does not depend on any agent or reviewer remembering/following the "schemas are vendored" rule

## Context
An LLM-driven change recently hand-edited a vendored UMDF schema in a companion repo despite the documented rule against it; only a manual audit caught it after merge. This adds an automatic, unavoidable check for the same class of mistake here.

## Follow-up
This repo currently has no branch protection at all, so this check would not be enforced as required. Recommend enabling branch protection on `main` with this job (and the existing build-and-test) as required status checks.