### PR TITLE
ci: fix schema-guard companion repo to be genuinely independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,44 +33,45 @@ jobs:
           echo "$changed"
         fi
 
-        # Best-effort cross-check against the companion SbeB3UmdfConsumer
-        # repo, which vendors the same UMDF market-data schema and is kept
-        # in lock-step per README.md. Network/availability issues here only
-        # warn (they must not make an unrelated outage block every PR); an
-        # actual content mismatch is treated the same as a local edit.
-        # Scoped to files this PR actually touched under schemas/ — PRs
-        # that don't touch schemas/ must not be blocked by pre-existing
-        # drift between the two repos that predates this PR. Iterated
-        # line-by-line (not word-split) so filenames with spaces survive.
-        #
-        # NOTE: because this only runs for files already in $changed, it
-        # can never independently flip flagged from 0 to 1 — flagged is
-        # already 1 whenever the loop has anything to iterate. Its value
-        # is diagnostic: confirming, for a change a maintainer is about to
-        # label schema-upgrade, whether the new content is byte-identical
-        # to the trusted upstream copy (vs. an edit that merely resembles
-        # the official schema). It intentionally does not gate PRs that
-        # leave schemas/ untouched, even if drift exists there already.
-        while IFS= read -r f; do
-          [ -n "$f" ] || continue
-          case "$f" in schemas/*.xml) ;; *) continue ;; esac
-          if [ ! -f "$f" ]; then
-            # Deleted by this PR; already caught by the local diff check
-            # above (flagged=1), nothing to cross-check against upstream.
-            continue
-          fi
-          name="$(basename "$f")"
-          url="https://raw.githubusercontent.com/pedrosakuma/SbeB3UmdfConsumer/main/schemas/$name"
-          if remote_sha="$(curl -fsSL --connect-timeout 5 --max-time 15 "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
-            local_sha="$(sha256sum "$f" | awk '{print $1}')"
-            if [ "$remote_sha" != "$local_sha" ]; then
-              flagged=1
-              echo "$f (sha256 $local_sha) diverges from SbeB3UmdfConsumer's vendored copy (sha256 $remote_sha)."
+          # Best-effort cross-check against the companion B3MatchingPlatform
+          # repo, which vendors the same UMDF market-data schema and is kept
+          # in lock-step per README.md. Network/availability issues here only
+          # warn (they must not make an unrelated outage block every PR); an
+          # actual content mismatch is treated the same as a local edit.
+          # Scoped to files this PR actually touched under schemas/ — PRs
+          # that don't touch schemas/ must not be blocked by pre-existing
+          # drift between the two repos that predates this PR. Iterated
+          # line-by-line (not word-split) so filenames with spaces survive.
+          #
+          # NOTE: because this only runs for files already in $changed, it
+          # can never independently flip flagged from 0 to 1 — flagged is
+          # already 1 whenever the loop has anything to iterate. Its value
+          # is diagnostic: confirming, for a change a maintainer is about
+          # to label schema-upgrade, whether the new content is byte-
+          # identical to the trusted upstream copy (vs. an edit that
+          # merely resembles the official schema). It intentionally does
+          # not gate PRs that leave schemas/ untouched, even if drift
+          # exists there already.
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in schemas/*.xml) ;; *) continue ;; esac
+            if [ ! -f "$f" ]; then
+              # Deleted by this PR; already caught by the local diff check
+              # above (flagged=1), nothing to cross-check against upstream.
+              continue
             fi
-          else
-            echo "::warning::Could not fetch $url to cross-check vendored schema fidelity; skipping cross-repo check for $name."
-          fi
-        done <<< "$changed"
+            name="$(basename "$f")"
+            url="https://raw.githubusercontent.com/pedrosakuma/B3MatchingPlatform/main/schemas/$name"
+            if remote_sha="$(curl -fsSL --connect-timeout 5 --max-time 15 "$url" 2>/dev/null | sha256sum | awk '{print $1}')"; then
+              local_sha="$(sha256sum "$f" | awk '{print $1}')"
+              if [ "$remote_sha" != "$local_sha" ]; then
+                flagged=1
+                echo "$f (sha256 $local_sha) diverges from B3MatchingPlatform's vendored copy (sha256 $remote_sha)."
+              fi
+            else
+              echo "::warning::Could not fetch $url to cross-check vendored schema fidelity; skipping cross-repo check for $name."
+            fi
+          done <<< "$changed"
 
 
         if [ "$flagged" = 0 ]; then


### PR DESCRIPTION
Fixes a bug discovered while extending this pattern to other repos: `SbeB3UmdfConsumer` is a dead/renamed name for this very repository (it was renamed to `B3MarketDataPlatform`), so the cross-repo checksum check was silently comparing this repo against itself via GitHub's rename redirect — zero independent verification value, plus a latent risk if that dead name is ever reclaimed by an unrelated repo.

Switches the companion target to `B3MatchingPlatform`, which genuinely vendors an independent, kept-in-lock-step copy of `b3-market-data-messages-2.2.0.xml`.