### PR TITLE
Scaffold FIX Conflated sandbox channel (vendoring + docs)

### DIFF
--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/B3.Umdf.Book/B3.Umdf.Book.csproj" />
     <Project Path="src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj" />
     <Project Path="src/B3.Umdf.Feed/B3.Umdf.Feed.csproj" />
+    <Project Path="src/B3.Umdf.FixConflated/B3.Umdf.FixConflated.csproj" />
     <Project Path="src/B3.Umdf.PcapReplay/B3.Umdf.PcapReplay.csproj" />
     <Project Path="src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj" />
     <Project Path="src/B3.Umdf.Transport/B3.Umdf.Transport.csproj" />

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ SBE XML schema. The schema's `<!DOCTYPE xml>` declaration is removed
 because .NET's `XmlReader` prohibits DTD processing by default. This is
 the only modification to the original B3 schema.
 
+`schemas/fix-conflated/FIX44_UMDFConflated.xml` vendors the FIX 4.4 data
+dictionary published alongside B3's *UMDF PUMA Conflated Market Data
+Specification* (v2.2.0). It is used only by the experimental,
+non-official FIX Conflated sandbox channel described in
+[docs/FIX-CONFLATED-SANDBOX.md](docs/FIX-CONFLATED-SANDBOX.md) — unrelated
+to, and never mixed with, the Binary UMDF/SBE decoding path above.
+
 ## Documentation
 
 | Document | What's inside |
@@ -233,6 +240,7 @@ the only modification to the original B3 schema.
 | [docs/CLIENT-SDK.md](docs/CLIENT-SDK.md) | **Typed C# SDK** (`B3.MarketData.WebSocketClient` NuGet): API, DI extension, reconnect+replay, back-pressure policies |
 | [docs/WEBSOCKET-PROTOCOL.md](docs/WEBSOCKET-PROTOCOL.md) | Wire framing, message catalog, hex examples, subscription / reconnect / slow-consumer flows, candle chunking |
 | [docs/PROTOCOL-CONTRACTS.md](docs/PROTOCOL-CONTRACTS.md) | Contribution gate for UMDF/SBE wire-contract evidence, protocol research blockers, and WebSocket-vs-UMDF terminology |
+| [docs/FIX-CONFLATED-SANDBOX.md](docs/FIX-CONFLATED-SANDBOX.md) | **Experimental, non-official** FIX 4.4 "UMDF Conflated" sandbox output channel: scope, message catalog, and explicit deviations from B3's real product |
 | [docs/PERFORMANCE.md](docs/PERFORMANCE.md) | Hot-path design, zero-copy decoding, MPSC ring, broadcaster decoupling, coalescing, benchmarks |
 | [docs/RESILIENCE.md](docs/RESILIENCE.md) | Failure modes, gap recovery, fanout suppression, slow-consumer layered defenses, memory bounds, operational playbook |
 | [docs/NOISY-NEIGHBOUR.md](docs/NOISY-NEIGHBOUR.md) | Behaviour under host-level resource contention, scheduler jitter probe, deployment hardening (cpuset, k8s static CPU manager, NIC IRQ pinning, sysctls) |

--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -1,0 +1,116 @@
+# FIX "UMDF Conflated" sandbox channel
+
+> **Status: experimental, non-official, non-certified.** This is not the
+> B3 UMDF PUMA Conflated product, is not connected to B3, and is not
+> reviewed or endorsed by B3. It is a local reproduction of the public
+> wire *format* described in B3's *UMDF PUMA Conflated Market Data
+> Specification* (v2.2.0, 2025-10-21), built for exploratory validation
+> of downstream FIX-consuming code against this platform's own market
+> data. See [docs/PROTOCOL-CONTRACTS.md](PROTOCOL-CONTRACTS.md) for why
+> this distinction matters and must never be blurred.
+
+## What this is
+
+An additional, **opt-in** output channel, alongside the existing
+`WireV2` WebSocket protocol (see
+[docs/WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md)), through which this
+platform emits book, trade, instrument-status, news, security-list, and
+market-totals data encoded as **FIX 4.4 Tag=Value** messages, batching
+book deltas over a configurable time window ("conflation"). This
+platform acts as the **FIX session acceptor** ("server" role) — the
+inverse of connecting out to a real B3 UMDF Conflated feed.
+
+## What this is not
+
+- **Not FAST-encoded.** Despite the "UMDF FIX/FAST" branding used for
+  some older/other B3 products, the *Conflated* Market Data
+  Specification explicitly uses "traditional Tag=Value FIX encoding"
+  (§3.1), not FAST. This sandbox follows that: plain SOH-delimited
+  `tag=value` frames.
+- **Not authenticated.** Consistent with the existing `WireV2` WebSocket
+  channel (no API keys / tokens today), the FIX acceptor here performs
+  **no credential validation** on `Logon` (MsgType=A): any
+  `SenderCompID`/`TargetCompID` pair is accepted. The real B3 product
+  requires B3-assigned CompIDs and a certification process (§7.8.15) —
+  this sandbox intentionally skips both.
+- **Not a replay/resend engine.** Real B3 UMDF Conflated does not
+  gap-fill across reconnects: a client reconnecting with a `MsgSeqNum`
+  lower than expected is disconnected immediately, with recovery
+  expected via a fresh `MarketDataSnapshotFullRefresh`, not persisted
+  history. This sandbox mirrors that behavior instead of implementing a
+  general-purpose FIX message store — see "Session behavior" below.
+- **Not built on QuickFIX/n** or any other third-party FIX engine. The
+  session and encoding are purpose-built and intentionally minimal, for
+  three reasons: the outbound zlib compression layer (RFC 1950) doesn't
+  fit typical FIX-engine transport models, this platform never needs to
+  *answer* application-level resends (a pure market-data acceptor has no
+  business messages to redeliver from a persistent store beyond the
+  current session), and the real product's restricted recovery model
+  (forced disconnect + snapshot, not engine-managed gap-fill) would
+  fight a general-purpose engine's assumptions rather than benefit from
+  them.
+- **Not tied to the B3-documented 380ms conflation interval.** The spec
+  cites ~380ms as B3's chosen cadence; this sandbox exposes conflation
+  cadence as a **configurable** parameter with a documented default, not
+  a hard-coded constant reproducing that exact figure.
+
+## Vendored schema
+
+`schemas/fix-conflated/FIX44_UMDFConflated.xml` is the FIX 4.4 data
+dictionary published alongside the *UMDF PUMA Conflated Market Data
+Specification*. Like the SBE schema under `schemas/`, it is vendored
+verbatim and covered by the CI "Vendored schema guard" — any PR touching
+it needs the `schema-upgrade` label.
+
+## Session behavior (summary)
+
+- `Logon` (A) / `Heartbeat` (0) / `TestRequest` (1) / `Logout` (5) are
+  supported per standard FIX 4.4 session semantics, with no credential
+  check.
+- `ResendRequest` (2) is honored only for messages still available in
+  the **current session's** bounded in-memory buffer — there is no
+  cross-session/cross-day persisted message store.
+  `MsgSeqNum` is tracked per connection; a reconnect presenting a
+  sequence number lower than expected is disconnected immediately (no
+  `SequenceReset`-based gap-fill across reconnects), matching B3's
+  documented behavior. Recovery after such a disconnect happens via a
+  fresh `MarketDataSnapshotFullRefresh` on the new session.
+
+## Message scope
+
+| Message | MsgType | Source in this platform |
+|---|---|---|
+| `MarketDataSnapshotFullRefresh` | W | Book state on subscribe / post-reconnect recovery |
+| `MarketDataIncrementalRefresh` | X | Book deltas, batched per configurable conflation window; trades sent unthrottled in the same message family |
+| `SecurityStatus` | f | `OnInstrumentStatusChanged` |
+| `News` | B | Existing `NewsReassembler` pipeline |
+| `SecurityList` / `SecurityListRequest` | y / x | `SymbolRegistry` |
+| `MarketTotals*` | UTOT/UTOTC/UTOTQ/UTOTP | Best-effort, from existing rankings/aggregates |
+
+## Conflation model
+
+Within each conflation window, book deltas (`MDUpdateAction` =
+add/change/delete/delete-thru, indexed by `MDEntryPx`/`OrderID` per B3's
+price/priority model) accumulate and are flushed as a single batched
+`MarketDataIncrementalRefresh` per instrument/side — this is a *batch of
+occurred deltas*, not a last-value-wins collapse. Trades and
+statistical/status data are never conflated.
+
+## Hot-path isolation
+
+The channel plugs into the existing `IBookEventHandler` /
+`IMarketDataEventHandler` fan-out
+(`CompositeBookEventHandler`/`CompositeMarketDataEventHandler`, wired in
+`B3.Umdf.ConsoleApp/Program.cs`) as an additional handler, following the
+same discipline as `GroupConflationHandler`: the synchronous hot-path
+callback only performs a cheap, allocation-free enqueue into its own
+ring buffer; FIX encoding, conflation-window flushing, and socket I/O all
+run on a dedicated background thread, never blocking or allocating on
+the shared per-group hot path.
+
+## Enabling
+
+Disabled by default. Enable with `UMDF_FIX_CONFLATED_ENABLED=true` and
+configure the listening port and conflation window per
+[docs/CONFIGURATION.md](CONFIGURATION.md) (reference added once the
+transport lands).

--- a/schemas/fix-conflated/FIX44_UMDFConflated.xml
+++ b/schemas/fix-conflated/FIX44_UMDFConflated.xml
@@ -1,0 +1,2988 @@
+<!--
+/////////////////////////////////////////////////////////
+//
+//  EXONERAÇÃO DE RESPONSABILIDADE
+//
+/////////////////////////////////////////////////////////
+
+A BM&FBOVESPA fornece as informações contidas neste arquivo com propósito unicamente informativo e as disponibiliza
+apenas para atender às necessidades dos interessados em conhecer a tecnologia de referência e suas conveniências.
+A BM&FBOVESPA não garante acurácia, integridade, perfeição ou ajuste a qualquer propósito específico de tais informações,
+tampouco aceita qualquer encargo, obrigação ou responsabilidade pelo uso das mesmas. As informações disponibilizadas são
+obtidas de fontes entendidas como confiáveis. No entanto, a Bolsa de Mercadorias & Futuros-BM&F não declara que as informações
+disponibilizadas neste código de referência sejam verificadas, atualizadas e precisas. Devido à possibilidade de erro humano ou
+mecânico, bem como a outros fatores, a BM&FBOVESPA não responde por quaisquer erros ou omissões, dado que toda informação é
+provida "tal como está", sem nenhuma garantia de qualquer espécie. Nenhuma informação ou opinião aqui expressada constitui
+solicitação ou proposta de compra ou venda ou ainda oferta de compra ou de venda de qualquer dos contratos futuros e de
+opções negociados na BM&FBOVESPA, tampouco oferta de compra ou de venda de qualquer título, valor mobiliário ou mercadoria
+aqui descrita como produto ou emissão. Como nenhuma informação disponível neste código de referência deve servir de base
+para qualquer decisão de investimento, recomenda-se rigorosamente aos interessados que não confiem nem ajam fundamentados
+nas mesmas. Todavia, caso isso aconteça, será clara e inteiramente por sua conta e risco.
+Nem a BM&FBOVESPA nem seus executivos, diretores, associados, empregados, agentes, procuradores, consultores ou licenciados
+serão responsáveis, perante qualquer pessoa (incluindo, mas não se limitando, um sócio da Bolsa ou um cliente), por qualquer
+perda, dano, custo ou despesa (incluindo, mas não se limitando, lucros cessantes, impedimentos de uso ou danos diretos,
+indiretos, incidentais ou conseqüentes) resultante de quaisquer erros, omissões ou alterações nas informações aqui fornecidas,
+tampouco por quaisquer atrasos, inexatidões, erros, interrupções ou, ainda, quaisquer danos diretos ou conseqüentes
+ocasionados ou mesmo ocorridos em função do uso deste código de referência, nem, ainda, por qualquer prejuízo resultante de
+do seu mau uso, nem mesmo por qualquer descontinuidade do serviço que venha a utilizá-lo.
+As disposições precedentes aplicam-se ainda que venha a surgir qualquer reivindicação ou pretensão de ordem contratual ou
+qualquer ação de reparação por ato ilícito extracontratual, negligência, imprudência, imperícia, responsabilidade objetiva
+ou por qualquer outra maneira.
+
+//////////////////////////////////////////////////////////
+  FIX44 UMDFConflated XML Version: 1.0.0.37-->
+<fix major="4" minor="4">
+	<header>
+		<field name="BeginString" required="Y" />
+		<field name="ApplVerID" required="N" />
+		<field name="BodyLength" required="Y" />
+		<field name="MsgType" required="Y" />
+		<field name="SenderCompID" required="Y" />
+		<field name="TargetCompID" required="Y" />
+		<field name="OnBehalfOfCompID" required="N" />
+		<field name="DeliverToCompID" required="N" />
+		<field name="SecureDataLen" required="N" />
+		<field name="SecureData" required="N" />
+		<field name="MsgSeqNum" required="Y" />
+		<field name="SenderSubID" required="N" />
+		<field name="SenderLocationID" required="N" />
+		<field name="TargetSubID" required="N" />
+		<field name="TargetLocationID" required="N" />
+		<field name="OnBehalfOfSubID" required="N" />
+		<field name="OnBehalfOfLocationID" required="N" />
+		<field name="DeliverToSubID" required="N" />
+		<field name="DeliverToLocationID" required="N" />
+		<field name="PossDupFlag" required="N" />
+		<field name="PossResend" required="N" />
+		<field name="SendingTime" required="Y" />
+		<field name="OrigSendingTime" required="N" />
+		<field name="XmlDataLen" required="N" />
+		<field name="XmlData" required="N" />
+		<field name="MessageEncoding" required="N" />
+		<field name="LastMsgSeqNumProcessed" required="N" />
+		<group name="NoHops" required="N" >
+			<field name="HopCompID" required="N" />
+			<field name="HopSendingTime" required="N" />
+			<field name="HopRefID" required="N" />
+		</group>
+		<field name="BusinessSeqNum" required="N" />
+		<field name="AdministrativeMessage" required="N" />
+		<field name="InternalSeqNo" required="N" />
+		<field name="InternalSeqNoVerID" required="N" />
+		<field name="ProducerID" required="N" />
+	</header>
+	<trailer>
+		<field name="SignatureLength" required="N" />
+		<field name="Signature" required="N" />
+		<field name="CheckSum" required="Y" />
+	</trailer>
+	<messages>
+		<message name="BusinessMessageReject" msgtype="j" msgcat="app">
+			<field name="ApplID" required="N" />
+			<field name="ApplSeqNum" required="N" />
+			<field name="ApplLastSeqNum" required="N" />
+			<field name="ApplResendFlag" required="N" />
+			<field name="RefSeqNum" required="N" />
+			<field name="RefMsgType" required="Y" />
+			<field name="BusinessRejectRefID" required="N" />
+			<field name="BusinessRejectReason" required="Y" />
+			<field name="Text" required="N" />
+			<field name="Memo" required="N" />
+			<field name="EncodedTextLen" required="N" />
+			<field name="EncodedText" required="N" />
+			<field name="SanityValidation" required="N" />
+		</message>
+		<message name="Heartbeat" msgtype="0" msgcat="admin">
+			<field name="TestReqID" required="N" />
+		</message>
+		<message name="LicenseKeyRequest" msgtype="ULRQ" msgcat="app">
+			<field name="LicenseRequestID" required="Y" />
+			<field name="ControllerType" required="Y" />
+			<field name="ControllerID" required="N" />
+			<field name="Password" required="Y" />
+			<field name="Channel" required="N" />
+			<field name="ForceLogin" required="Y" />
+			<field name="InterfaceVersion" required="Y" />
+			<field name="NewPassword" required="N" />
+			<field name="SubUnitID" required="Y" />
+			<group name="NoPartyIDs" required="Y" >
+				<field name="PartyID" required="Y" />
+				<field name="PartyIDSource" required="Y" />
+				<field name="PartyRole" required="Y" />
+				<group name="NoPartySubIDs" required="N" >
+					<field name="PartySubID" required="N" />
+					<field name="PartySubIDType" required="N" />
+				</group>
+			</group>
+		</message>
+		<message name="LicenseKeyResponse" msgtype="ULRP" msgcat="app">
+			<field name="LicenseRequestID" required="Y" />
+			<field name="LicenseRequestStatus" required="Y" />
+			<field name="Text" required="N" />
+			<field name="MarketDate" required="N" />
+			<field name="TraderCode" required="N" />
+			<group name="NoUserRoleIDs" required="N" >
+				<field name="UserRoleID" required="N" />
+			</group>
+			<field name="UserAssignedIdentifier" required="N" />
+			<group name="NoPartyIDs" required="Y" >
+				<field name="PartyID" required="Y" />
+				<field name="PartyIDSource" required="Y" />
+				<field name="PartyRole" required="Y" />
+				<group name="NoPartySubIDs" required="N" >
+					<field name="PartySubID" required="N" />
+					<field name="PartySubIDType" required="N" />
+				</group>
+			</group>
+			<group name="NoTradeIDs" required="N" >
+				<field name="TradeID" required="N" />
+			</group>
+			<group name="NoBroadCastIDs" required="N" >
+				<field name="BroadCastID" required="N" />
+			</group>
+			<group name="NoNewsAgencyIDs" required="N" >
+				<field name="NewsAgencyID" required="N" />
+			</group>
+			<group name="NoSupervisedIDs" required="N" >
+				<field name="SupervisedID" required="N" />
+			</group>
+			<group name="NoTraderCodeByProductIDs" required="N" >
+				<field name="Product" required="N" />
+				<field name="TraderCode" required="N" />
+			</group>
+		</message>
+		<message name="LicenseLogoutReport" msgtype="ULRL" msgcat="app">
+			<field name="LicenseRequestID" required="Y" />
+			<field name="ControllerType" required="Y" />
+			<field name="ControllerID" required="N" />
+			<field name="Text" required="N" />
+			<field name="UserAssignedIdentifier" required="N" />
+			<group name="NoPartyIDs" required="Y" >
+				<field name="PartyID" required="Y" />
+				<field name="PartyIDSource" required="Y" />
+				<field name="PartyRole" required="Y" />
+				<group name="NoPartySubIDs" required="N" >
+					<field name="PartySubID" required="N" />
+					<field name="PartySubIDType" required="N" />
+				</group>
+			</group>
+		</message>
+		<message name="Logon" msgtype="A" msgcat="admin">
+			<field name="EncryptMethod" required="Y" />
+			<field name="HeartBtInt" required="Y" />
+			<field name="RawDataLength" required="N" />
+			<field name="RawData" required="N" />
+			<field name="ResetSeqNumFlag" required="N" />
+			<field name="NextExpectedMsgSeqNum" required="N" />
+			<field name="MaxMessageSize" required="N" />
+			<field name="Text" required="N" />
+			<group name="NoMsgTypes" required="N" >
+				<field name="RefMsgType" required="N" />
+				<field name="MsgDirection" required="N" />
+			</group>
+			<field name="TestMessageIndicator" required="N" />
+			<field name="Username" required="N" />
+			<field name="Password" required="N" />
+			<field name="BTSRequesterIPAddress" required="N" />
+			<field name="BTSRequesterOSIdentifier" required="N" />
+			<field name="ApplicationLogonRspCode" required="N" />
+			<field name="DaysBeforePwdExpiration" required="N" />
+			<field name="NewPassword" required="N" />
+			<field name="CancelOnDisconnectType" required="N" />
+			<field name="CODTimeoutWindow" required="N" />
+		</message>
+		<message name="Logout" msgtype="5" msgcat="admin">
+			<field name="Text" required="N" />
+			<field name="EncodedTextLen" required="N" />
+			<field name="EncodedText" required="N" />
+		</message>
+		<message name="MarketDataIncrementalRefresh" msgtype="X" msgcat="app">
+			<field name="MDReqID" required="N" />
+			<field name="TradeDate" required="N" />
+			<field name="MDBookType" required="N" />
+			<field name="MarketDepth" required="N" />
+			<group name="NoMDEntries" required="Y" >
+				<field name="MDUpdateAction" required="Y" />
+				<field name="DeleteReason" required="N" />
+				<field name="MDEntryType" required="Y" />
+				<field name="MDEntryID" required="N" />
+				<field name="MDEntryRefID" required="N" />
+				<field name="Symbol" required="N" />
+				<field name="SymbolSfx" required="N" />
+				<field name="SecurityID" required="N" />
+				<field name="SecurityIDSource" required="N" />
+				<field name="SecurityExchange" required="N" />
+				<field name="InstrumentID" required="N" />
+				<field name="PutOrCall" required="N" />
+				<group name="NoSecurityAltID" required="N" >
+					<field name="SecurityAltID" required="Y" />
+					<field name="SecurityAltIDSource" required="Y" />
+				</group>
+				<field name="Product" required="N" />
+				<field name="CFICode" required="N" />
+				<field name="SecurityGroup" required="N" />
+				<field name="SecurityType" required="N" />
+				<field name="SecuritySubType" required="N" />
+				<field name="MaturityMonthYear" required="N" />
+				<field name="MaturityDate" required="N" />
+				<field name="CouponPaymentDate" required="N" />
+				<field name="IssueDate" required="N" />
+				<field name="RepoCollateralSecurityType" required="N" />
+				<field name="RepurchaseTerm" required="N" />
+				<field name="RepurchaseRate" required="N" />
+				<field name="Factor" required="N" />
+				<field name="CreditRating" required="N" />
+				<field name="InstrRegistry" required="N" />
+				<field name="CountryOfIssue" required="N" />
+				<field name="StateOrProvinceOfIssue" required="N" />
+				<field name="LocaleOfIssue" required="N" />
+				<field name="RedemptionDate" required="N" />
+				<field name="StrikePrice" required="N" />
+				<field name="StrikeCurrency" required="N" />
+				<field name="ExerciseStyle" required="N" />
+				<field name="OptAttribute" required="N" />
+				<field name="ContractMultiplier" required="N" />
+				<field name="CouponRate" required="N" />
+				<field name="Issuer" required="N" />
+				<field name="EncodedIssuerLen" required="N" />
+				<field name="EncodedIssuer" required="N" />
+				<field name="SecurityDesc" required="N" />
+				<field name="EncodedSecurityDescLen" required="N" />
+				<field name="EncodedSecurityDesc" required="N" />
+				<field name="Pool" required="N" />
+				<field name="ContractSettlMonth" required="N" />
+				<field name="CPProgram" required="N" />
+				<field name="CPRegType" required="N" />
+				<group name="NoEvents" required="N" >
+					<field name="EventType" required="N" />
+					<field name="EventDate" required="N" />
+					<field name="EventPx" required="N" />
+					<field name="EventText" required="N" />
+				</group>
+				<field name="DatedDate" required="N" />
+				<field name="InterestAccrualDate" required="N" />
+				<field name="SettlType" required="N" />
+				<field name="SettlDate" required="N" />
+				<field name="MDStreamID" required="N" />
+				<group name="NoUnderlyings" required="N" >
+					<field name="UnderlyingSecurityID" required="Y" />
+					<field name="UnderlyingSecurityIDSource" required="Y" />
+					<field name="UnderlyingSecurityExchange" required="Y" />
+					<field name="UnderlyingPx" required="Y" />
+					<field name="UnderlyingPxType" required="N" />
+				</group>
+				<group name="NoLegs" required="N" >
+					<field name="LegSymbol" required="N" />
+					<field name="LegSymbolSfx" required="N" />
+					<field name="LegSecurityID" required="N" />
+					<field name="LegSecurityIDSource" required="N" />
+					<group name="NoLegSecurityAltID" required="N" >
+						<field name="LegSecurityAltID" required="N" />
+						<field name="LegSecurityAltIDSource" required="N" />
+					</group>
+					<field name="LegProduct" required="N" />
+					<field name="LegCFICode" required="N" />
+					<field name="LegSecurityType" required="N" />
+					<field name="LegSecuritySubType" required="N" />
+					<field name="LegMaturityMonthYear" required="N" />
+					<field name="LegMaturityDate" required="N" />
+					<field name="LegCouponPaymentDate" required="N" />
+					<field name="LegIssueDate" required="N" />
+					<field name="LegRepoCollateralSecurityType" required="N" />
+					<field name="LegRepurchaseTerm" required="N" />
+					<field name="LegRepurchaseRate" required="N" />
+					<field name="LegFactor" required="N" />
+					<field name="LegCreditRating" required="N" />
+					<field name="LegInstrRegistry" required="N" />
+					<field name="LegCountryOfIssue" required="N" />
+					<field name="LegStateOrProvinceOfIssue" required="N" />
+					<field name="LegLocaleOfIssue" required="N" />
+					<field name="LegRedemptionDate" required="N" />
+					<field name="LegStrikePrice" required="N" />
+					<field name="LegStrikeCurrency" required="N" />
+					<field name="LegOptAttribute" required="N" />
+					<field name="LegContractMultiplier" required="N" />
+					<field name="LegCouponRate" required="N" />
+					<field name="LegSecurityExchange" required="N" />
+					<field name="LegIssuer" required="N" />
+					<field name="EncodedLegIssuerLen" required="N" />
+					<field name="EncodedLegIssuer" required="N" />
+					<field name="LegSecurityDesc" required="N" />
+					<field name="EncodedLegSecurityDescLen" required="N" />
+					<field name="EncodedLegSecurityDesc" required="N" />
+					<field name="LegRatioQty" required="N" />
+					<field name="LegSide" required="N" />
+					<field name="LegCurrency" required="N" />
+					<field name="LegPool" required="N" />
+					<field name="LegDatedDate" required="N" />
+					<field name="LegContractSettlMonth" required="N" />
+					<field name="LegInterestAccrualDate" required="N" />
+				</group>
+				<field name="FinancialStatus" required="N" />
+				<field name="CorporateAction" required="N" />
+				<field name="MDEntryPx" required="N" />
+				<field name="MDEntryInterestRate" required="N" />
+				<field name="LastTradeDate" required="N" />
+				<field name="PriceAdjustmentMethod" required="N" />
+				<field name="PriceBandType" required="N" />
+				<field name="PriceLimitType" required="N" />
+				<field name="LowLimitPrice" required="N" />
+				<field name="HighLimitPrice" required="N" />
+				<field name="TradingReferencePrice" required="N" />
+				<field name="PriceBandMidpointPriceType" required="N" />
+				<field name="AvgDailyTradedQty" required="N" />
+				<field name="StopPx" required="N" />
+				<field name="Currency" required="N" />
+				<field name="MDEntrySize" required="N" />
+				<field name="MDEntryDate" required="Y" />
+				<field name="MDEntryTime" required="Y" />
+				<field name="MDInsertDate" required="N" />
+				<field name="MDInsertTime" required="N" />
+				<field name="MDEntryPrevSize" required="N" />
+				<field name="TickDirection" required="N" />
+				<field name="MDMkt" required="N" />
+				<field name="TradingSessionID" required="N" />
+				<field name="TradingSessionSubID" required="N" />
+				<field name="QuoteCondition" required="N" />
+				<field name="TradeCondition" required="N" />
+				<field name="MDEntryOriginator" required="N" />
+				<field name="LocationID" required="N" />
+				<field name="DeskID" required="N" />
+				<field name="OpenCloseSettlFlag" required="N" />
+				<field name="TimeInForce" required="N" />
+				<field name="ExpireDate" required="N" />
+				<field name="EarlyTermination" required="N" />
+				<field name="BTBCertIndicator" required="N" />
+				<field name="BTBContractInfo" required="N" />
+				<field name="BTBGraceDate" required="N" />
+				<field name="MaxTradeVol" required="N" />
+				<field name="ExpireTime" required="N" />
+				<field name="MinQty" required="N" />
+				<field name="ExecInst" required="N" />
+				<field name="SellerDays" required="N" />
+				<field name="SettlPriceType" required="N" />
+				<field name="OrderID" required="N" />
+				<field name="QuoteEntryID" required="N" />
+				<field name="MDEntryBuyer" required="N" />
+				<field name="MDEntrySeller" required="N" />
+				<field name="NumberOfOrders" required="N" />
+				<field name="MDEntryPositionNo" required="N" />
+				<field name="PriceType" required="N" />
+				<field name="Scope" required="N" />
+				<field name="PriceDelta" required="N" />
+				<field name="FirstPx" required="N" />
+				<field name="LastPx" required="N" />
+				<field name="NetChgPrevDay" required="N" />
+				<field name="TradeID" required="N" />
+				<field name="TradeVolume" required="N" />
+				<field name="Text" required="N" />
+				<field name="EncodedTextLen" required="N" />
+				<field name="EncodedText" required="N" />
+				<field name="UniqueTradeID" required="N" />
+				<field name="SecurityTradingStatus" required="N" />
+				<field name="Duration" required="N" />
+				<group name="NoReferentialPrices" required="N" >
+					<field name="ReferentialPxType" required="Y" />
+					<field name="ReferentialState" required="N" />
+					<field name="ReferentialPx" required="N" />
+					<field name="ContextId" required="N" />
+					<field name="TransactTime" required="N" />
+				</group>
+				<field name="TradSesOpenTime" required="N" />
+				<field name="RLCMsgID" required="N" />
+				<field name="MicrosecondOrderTimestamp" required="N" />
+				<field name="IndexSeq" required="N" />
+			</group>
+			<field name="ApplQueueDepth" required="N" />
+			<field name="ApplQueueResolution" required="N" />
+		</message>
+		<message name="MarketDataRequest" msgtype="V" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="SubscriptionRequestType" required="Y" />
+			<field name="MDBookType" required="N" />
+			<field name="MarketDepth" required="N" />
+			<group name="NoRelatedSym" required="N" >
+				<field name="SecurityID" required="Y" />
+				<field name="SecurityIDSource" required="Y" />
+				<field name="SecurityExchange" required="Y" />
+			</group>
+			<field name="SecurityType" required="N" />
+			<field name="CFICode" required="N" />
+			<field name="Product" required="N" />
+			<group name="NoSecurityGroups" required="N" >
+				<field name="SecurityGroup" required="N" />
+			</group>
+		</message>
+		<message name="MarketDataRequestReject" msgtype="Y" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="MDReqRejReason" required="Y" />
+			<field name="Text" required="N" />
+		</message>
+		<message name="MarketDataSnapshotFullRefresh" msgtype="W" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="MDReportID" required="N" />
+			<field name="TradeDate" required="N" />
+			<field name="TotNumReports" required="N" />
+			<field name="LastFragment" required="N" />
+			<field name="Symbol" required="N" />
+			<field name="SymbolSfx" required="N" />
+			<field name="SecurityID" required="N" />
+			<field name="SecurityIDSource" required="N" />
+			<field name="SecurityExchange" required="N" />
+			<field name="InstrumentID" required="N" />
+			<field name="PutOrCall" required="N" />
+			<group name="NoSecurityAltID" required="N" >
+				<field name="SecurityAltID" required="Y" />
+				<field name="SecurityAltIDSource" required="Y" />
+			</group>
+			<field name="Product" required="N" />
+			<field name="CFICode" required="N" />
+			<field name="SecurityGroup" required="N" />
+			<field name="SecurityType" required="N" />
+			<field name="SecuritySubType" required="N" />
+			<field name="MaturityMonthYear" required="N" />
+			<field name="MaturityDate" required="N" />
+			<field name="CouponPaymentDate" required="N" />
+			<field name="IssueDate" required="N" />
+			<field name="RepoCollateralSecurityType" required="N" />
+			<field name="RepurchaseTerm" required="N" />
+			<field name="RepurchaseRate" required="N" />
+			<field name="Factor" required="N" />
+			<field name="CreditRating" required="N" />
+			<field name="InstrRegistry" required="N" />
+			<field name="CountryOfIssue" required="N" />
+			<field name="StateOrProvinceOfIssue" required="N" />
+			<field name="LocaleOfIssue" required="N" />
+			<field name="RedemptionDate" required="N" />
+			<field name="StrikePrice" required="N" />
+			<field name="StrikeCurrency" required="N" />
+			<field name="ExerciseStyle" required="N" />
+			<field name="OptAttribute" required="N" />
+			<field name="ContractMultiplier" required="N" />
+			<field name="CouponRate" required="N" />
+			<field name="Issuer" required="N" />
+			<field name="EncodedIssuerLen" required="N" />
+			<field name="EncodedIssuer" required="N" />
+			<field name="SecurityDesc" required="N" />
+			<field name="EncodedSecurityDescLen" required="N" />
+			<field name="EncodedSecurityDesc" required="N" />
+			<field name="Pool" required="N" />
+			<field name="ContractSettlMonth" required="N" />
+			<field name="CPProgram" required="N" />
+			<field name="CPRegType" required="N" />
+			<group name="NoEvents" required="N" >
+				<field name="EventType" required="N" />
+				<field name="EventDate" required="N" />
+				<field name="EventPx" required="N" />
+				<field name="EventText" required="N" />
+			</group>
+			<field name="DatedDate" required="N" />
+			<field name="InterestAccrualDate" required="N" />
+			<field name="SettlType" required="N" />
+			<field name="SettlDate" required="N" />
+			<group name="NoUnderlyings" required="N" >
+				<field name="UnderlyingSymbol" required="N" />
+				<field name="UnderlyingSymbolSfx" required="N" />
+				<field name="UnderlyingSecurityID" required="N" />
+				<field name="UnderlyingSecurityIDSource" required="N" />
+				<group name="NoUnderlyingSecurityAltID" required="N" >
+					<field name="UnderlyingSecurityAltID" required="N" />
+					<field name="UnderlyingSecurityAltIDSource" required="N" />
+				</group>
+				<field name="UnderlyingProduct" required="N" />
+				<field name="UnderlyingCFICode" required="N" />
+				<field name="UnderlyingSecurityType" required="N" />
+				<field name="UnderlyingSecuritySubType" required="N" />
+				<field name="UnderlyingMaturityMonthYear" required="N" />
+				<field name="UnderlyingMaturityDate" required="N" />
+				<field name="UnderlyingCouponPaymentDate" required="N" />
+				<field name="UnderlyingIssueDate" required="N" />
+				<field name="UnderlyingRepoCollateralSecurityType" required="N" />
+				<field name="UnderlyingRepurchaseTerm" required="N" />
+				<field name="UnderlyingRepurchaseRate" required="N" />
+				<field name="UnderlyingFactor" required="N" />
+				<field name="UnderlyingCreditRating" required="N" />
+				<field name="UnderlyingInstrRegistry" required="N" />
+				<field name="UnderlyingCountryOfIssue" required="N" />
+				<field name="UnderlyingStateOrProvinceOfIssue" required="N" />
+				<field name="UnderlyingLocaleOfIssue" required="N" />
+				<field name="UnderlyingRedemptionDate" required="N" />
+				<field name="UnderlyingStrikePrice" required="N" />
+				<field name="UnderlyingStrikeCurrency" required="N" />
+				<field name="UnderlyingOptAttribute" required="N" />
+				<field name="UnderlyingContractMultiplier" required="N" />
+				<field name="UnderlyingCouponRate" required="N" />
+				<field name="UnderlyingSecurityExchange" required="N" />
+				<field name="UnderlyingIssuer" required="N" />
+				<field name="EncodedUnderlyingIssuerLen" required="N" />
+				<field name="EncodedUnderlyingIssuer" required="N" />
+				<field name="UnderlyingSecurityDesc" required="N" />
+				<field name="EncodedUnderlyingSecurityDescLen" required="N" />
+				<field name="EncodedUnderlyingSecurityDesc" required="N" />
+				<field name="UnderlyingCPProgram" required="N" />
+				<field name="UnderlyingCPRegType" required="N" />
+				<field name="UnderlyingCurrency" required="N" />
+				<field name="UnderlyingQty" required="N" />
+				<field name="UnderlyingPx" required="N" />
+				<field name="UnderlyingPxType" required="N" />
+				<field name="UnderlyingDirtyPrice" required="N" />
+				<field name="UnderlyingEndPrice" required="N" />
+				<field name="UnderlyingStartValue" required="N" />
+				<field name="UnderlyingCurrentValue" required="N" />
+				<field name="UnderlyingEndValue" required="N" />
+				<group name="NoUnderlyingStips" required="N" >
+					<field name="UnderlyingStipType" required="N" />
+					<field name="UnderlyingStipValue" required="N" />
+				</group>
+			</group>
+			<group name="NoLegs" required="N" >
+				<field name="LegSymbol" required="N" />
+				<field name="LegSymbolSfx" required="N" />
+				<field name="LegSecurityID" required="N" />
+				<field name="LegSecurityIDSource" required="N" />
+				<group name="NoLegSecurityAltID" required="N" >
+					<field name="LegSecurityAltID" required="N" />
+					<field name="LegSecurityAltIDSource" required="N" />
+				</group>
+				<field name="LegProduct" required="N" />
+				<field name="LegCFICode" required="N" />
+				<field name="LegSecurityType" required="N" />
+				<field name="LegSecuritySubType" required="N" />
+				<field name="LegMaturityMonthYear" required="N" />
+				<field name="LegMaturityDate" required="N" />
+				<field name="LegCouponPaymentDate" required="N" />
+				<field name="LegIssueDate" required="N" />
+				<field name="LegRepoCollateralSecurityType" required="N" />
+				<field name="LegRepurchaseTerm" required="N" />
+				<field name="LegRepurchaseRate" required="N" />
+				<field name="LegFactor" required="N" />
+				<field name="LegCreditRating" required="N" />
+				<field name="LegInstrRegistry" required="N" />
+				<field name="LegCountryOfIssue" required="N" />
+				<field name="LegStateOrProvinceOfIssue" required="N" />
+				<field name="LegLocaleOfIssue" required="N" />
+				<field name="LegRedemptionDate" required="N" />
+				<field name="LegStrikePrice" required="N" />
+				<field name="LegStrikeCurrency" required="N" />
+				<field name="LegOptAttribute" required="N" />
+				<field name="LegContractMultiplier" required="N" />
+				<field name="LegCouponRate" required="N" />
+				<field name="LegSecurityExchange" required="N" />
+				<field name="LegIssuer" required="N" />
+				<field name="EncodedLegIssuerLen" required="N" />
+				<field name="EncodedLegIssuer" required="N" />
+				<field name="LegSecurityDesc" required="N" />
+				<field name="EncodedLegSecurityDescLen" required="N" />
+				<field name="EncodedLegSecurityDesc" required="N" />
+				<field name="LegRatioQty" required="N" />
+				<field name="LegSide" required="N" />
+				<field name="LegCurrency" required="N" />
+				<field name="LegPool" required="N" />
+				<field name="LegDatedDate" required="N" />
+				<field name="LegContractSettlMonth" required="N" />
+				<field name="LegInterestAccrualDate" required="N" />
+			</group>
+			<field name="FinancialStatus" required="N" />
+			<field name="CorporateAction" required="N" />
+			<group name="NoMDEntries" required="Y" >
+				<field name="MDEntryType" required="Y" />
+				<field name="MDBookType" required="N" />
+				<field name="MDStreamID" required="N" />
+				<field name="MarketDepth" required="N" />
+				<field name="StopPx" required="N" />
+				<field name="MDEntryPx" required="N" />
+				<field name="PriceType" required="N" />
+				<field name="MDEntryInterestRate" required="N" />
+				<field name="IndexSeq" required="N" />
+				<field name="Currency" required="N" />
+				<field name="MDEntrySize" required="N" />
+				<field name="MDEntryDate" required="Y" />
+				<field name="MDEntryTime" required="Y" />
+				<field name="MDInsertDate" required="N" />
+				<field name="MDInsertTime" required="N" />
+				<field name="TickDirection" required="N" />
+				<field name="MDMkt" required="N" />
+				<field name="TradingSessionID" required="N" />
+				<field name="SecurityTradingEvent" required="N" />
+				<field name="TradingSessionSubID" required="N" />
+				<field name="QuoteCondition" required="N" />
+				<field name="TradeCondition" required="N" />
+				<field name="MDEntryOriginator" required="N" />
+				<field name="LocationID" required="N" />
+				<field name="DeskID" required="N" />
+				<field name="OpenCloseSettlFlag" required="N" />
+				<field name="TimeInForce" required="N" />
+				<field name="ExpireDate" required="N" />
+				<field name="EarlyTermination" required="N" />
+				<field name="BTBCertIndicator" required="N" />
+				<field name="BTBContractInfo" required="N" />
+				<field name="BTBGraceDate" required="N" />
+				<field name="MaxTradeVol" required="N" />
+				<field name="ExpireTime" required="N" />
+				<field name="MinQty" required="N" />
+				<field name="ExecInst" required="N" />
+				<field name="SellerDays" required="N" />
+				<field name="SettlPriceType" required="N" />
+				<field name="LastTradeDate" required="N" />
+				<field name="PriceAdjustmentMethod" required="N" />
+				<field name="PriceBandType" required="N" />
+				<field name="PriceLimitType" required="N" />
+				<field name="LowLimitPrice" required="N" />
+				<field name="HighLimitPrice" required="N" />
+				<field name="TradingReferencePrice" required="N" />
+				<field name="PriceBandMidpointPriceType" required="N" />
+				<field name="AvgDailyTradedQty" required="N" />
+				<field name="OrderID" required="N" />
+				<field name="QuoteEntryID" required="N" />
+				<field name="MDEntryBuyer" required="N" />
+				<field name="MDEntrySeller" required="N" />
+				<field name="NumberOfOrders" required="N" />
+				<field name="MDEntryPositionNo" required="N" />
+				<field name="Scope" required="N" />
+				<field name="PriceDelta" required="N" />
+				<field name="FirstPx" required="N" />
+				<field name="LastPx" required="N" />
+				<field name="Text" required="N" />
+				<field name="EncodedTextLen" required="N" />
+				<field name="EncodedText" required="N" />
+				<field name="UniqueTradeID" required="N" />
+				<field name="TradeID" required="N" />
+				<field name="TradeVolume" required="N" />
+				<field name="SecurityTradingStatus" required="N" />
+				<field name="NetChgPrevDay" required="N" />
+				<field name="Duration" required="N" />
+				<group name="NoReferentialPrices" required="N" >
+					<field name="ReferentialPxType" required="Y" />
+					<field name="ReferentialState" required="N" />
+					<field name="ReferentialPx" required="N" />
+					<field name="ContextId" required="N" />
+					<field name="TransactTime" required="N" />
+				</group>
+				<field name="TradSesOpenTime" required="N" />
+				<field name="RLCMsgID" required="N" />
+				<field name="MicrosecondOrderTimestamp" required="N" />
+				<field name="NoSharesIssued" required="N" />
+				<group name="NoUnderlyings" required="N" >
+					<field name="UnderlyingSecurityID" required="Y" />
+					<field name="UnderlyingSecurityIDSource" required="Y" />
+					<field name="UnderlyingSecurityExchange" required="Y" />
+					<field name="UnderlyingPx" required="Y" />
+					<field name="UnderlyingPxType" required="N" />
+				</group>
+			</group>
+			<field name="ApplQueueDepth" required="N" />
+			<field name="ApplQueueResolution" required="N" />
+		</message>
+		<message name="MarketTotalsBroadcast" msgtype="UTOT" msgcat="app">
+			<group name="NoMDEntries" required="Y" >
+				<field name="MDEntryType" required="Y" />
+				<field name="Symbol" required="Y" />
+				<field name="MDEntryDate" required="Y" />
+				<field name="MDEntryTime" required="Y" />
+				<field name="GrossTradeAmt" required="Y" />
+				<field name="TotalVolumeTraded" required="Y" />
+				<field name="TotalNumOfTrades" required="Y" />
+			</group>
+		</message>
+		<message name="MarketTotalsComposition" msgtype="UTOTC" msgcat="app">
+			<field name="TotNoRelatedSym" required="Y" />
+			<field name="LastFragment" required="Y" />
+			<field name="IndexID" required="N" />
+			<group name="NoRelatedSym" required="Y" >
+				<field name="Symbol" required="Y" />
+				<field name="SecurityDesc" required="Y" />
+				<group name="NoSecurityGroups" required="N" >
+					<field name="SecurityGroup" required="Y" />
+				</group>
+			</group>
+		</message>
+		<message name="MarketTotalsRequest" msgtype="UTOTQ" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="SubscriptionRequestType" required="Y" />
+		</message>
+		<message name="MarketTotalsResponse" msgtype="UTOTP" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="MDReqRejReason" required="N" />
+			<field name="Text" required="N" />
+		</message>
+		<message name="NetworkStatusResponse" msgtype="BD" msgcat="admin">
+			<field name="NetworkStatusResponseType" required="Y" />
+			<field name="NetworkRequestID" required="N" />
+			<field name="NetworkResponseID" required="Y" />
+			<field name="LastNetworkResponseID" required="N" />
+			<group name="NoCompIDs" required="Y" >
+				<field name="RefCompID" required="Y" />
+				<field name="RefSubID" required="N" />
+				<field name="LocationID" required="N" />
+				<field name="DeskID" required="N" />
+				<field name="StatusValue" required="N" />
+				<field name="StatusText" required="N" />
+			</group>
+		</message>
+		<message name="News" msgtype="B" msgcat="app">
+			<field name="OrigTime" required="Y" />
+			<field name="Urgency" required="N" />
+			<field name="Headline" required="Y" />
+			<field name="EncodedHeadlineLen" required="N" />
+			<field name="EncodedHeadline" required="N" />
+			<field name="NewsSource" required="Y" />
+			<field name="NewsID" required="N" />
+			<field name="LanguageCode" required="N" />
+			<field name="Language" required="N" />
+			<group name="NoRoutingIDs" required="N" >
+				<field name="RoutingType" required="N" />
+				<field name="RoutingID" required="N" />
+			</group>
+			<group name="NoRelatedSym" required="N" >
+				<field name="Symbol" required="N" />
+				<field name="SymbolSfx" required="N" />
+				<field name="SecurityID" required="N" />
+				<field name="SecurityIDSource" required="N" />
+				<field name="SecurityExchange" required="N" />
+				<field name="InstrumentID" required="N" />
+				<field name="PutOrCall" required="N" />
+				<group name="NoSecurityAltID" required="N" >
+					<field name="SecurityAltID" required="Y" />
+					<field name="SecurityAltIDSource" required="Y" />
+				</group>
+				<field name="Product" required="N" />
+				<field name="CFICode" required="N" />
+				<field name="SecurityGroup" required="N" />
+				<field name="SecurityType" required="N" />
+				<field name="SecuritySubType" required="N" />
+				<field name="MaturityMonthYear" required="N" />
+				<field name="MaturityDate" required="N" />
+				<field name="CouponPaymentDate" required="N" />
+				<field name="IssueDate" required="N" />
+				<field name="RepoCollateralSecurityType" required="N" />
+				<field name="RepurchaseTerm" required="N" />
+				<field name="RepurchaseRate" required="N" />
+				<field name="Factor" required="N" />
+				<field name="CreditRating" required="N" />
+				<field name="InstrRegistry" required="N" />
+				<field name="CountryOfIssue" required="N" />
+				<field name="StateOrProvinceOfIssue" required="N" />
+				<field name="LocaleOfIssue" required="N" />
+				<field name="RedemptionDate" required="N" />
+				<field name="StrikePrice" required="N" />
+				<field name="StrikeCurrency" required="N" />
+				<field name="ExerciseStyle" required="N" />
+				<field name="OptAttribute" required="N" />
+				<field name="ContractMultiplier" required="N" />
+				<field name="CouponRate" required="N" />
+				<field name="Issuer" required="N" />
+				<field name="EncodedIssuerLen" required="N" />
+				<field name="EncodedIssuer" required="N" />
+				<field name="SecurityDesc" required="N" />
+				<field name="EncodedSecurityDescLen" required="N" />
+				<field name="EncodedSecurityDesc" required="N" />
+				<field name="Pool" required="N" />
+				<field name="ContractSettlMonth" required="N" />
+				<field name="CPProgram" required="N" />
+				<field name="CPRegType" required="N" />
+				<group name="NoEvents" required="N" >
+					<field name="EventType" required="N" />
+					<field name="EventDate" required="N" />
+					<field name="EventPx" required="N" />
+					<field name="EventText" required="N" />
+				</group>
+				<field name="DatedDate" required="N" />
+				<field name="InterestAccrualDate" required="N" />
+				<field name="SettlType" required="N" />
+				<field name="SettlDate" required="N" />
+			</group>
+			<group name="NoLegs" required="N" >
+				<field name="LegSymbol" required="N" />
+				<field name="LegSymbolSfx" required="N" />
+				<field name="LegSecurityID" required="N" />
+				<field name="LegSecurityIDSource" required="N" />
+				<group name="NoLegSecurityAltID" required="N" >
+					<field name="LegSecurityAltID" required="N" />
+					<field name="LegSecurityAltIDSource" required="N" />
+				</group>
+				<field name="LegProduct" required="N" />
+				<field name="LegCFICode" required="N" />
+				<field name="LegSecurityType" required="N" />
+				<field name="LegSecuritySubType" required="N" />
+				<field name="LegMaturityMonthYear" required="N" />
+				<field name="LegMaturityDate" required="N" />
+				<field name="LegCouponPaymentDate" required="N" />
+				<field name="LegIssueDate" required="N" />
+				<field name="LegRepoCollateralSecurityType" required="N" />
+				<field name="LegRepurchaseTerm" required="N" />
+				<field name="LegRepurchaseRate" required="N" />
+				<field name="LegFactor" required="N" />
+				<field name="LegCreditRating" required="N" />
+				<field name="LegInstrRegistry" required="N" />
+				<field name="LegCountryOfIssue" required="N" />
+				<field name="LegStateOrProvinceOfIssue" required="N" />
+				<field name="LegLocaleOfIssue" required="N" />
+				<field name="LegRedemptionDate" required="N" />
+				<field name="LegStrikePrice" required="N" />
+				<field name="LegStrikeCurrency" required="N" />
+				<field name="LegOptAttribute" required="N" />
+				<field name="LegContractMultiplier" required="N" />
+				<field name="LegCouponRate" required="N" />
+				<field name="LegSecurityExchange" required="N" />
+				<field name="LegIssuer" required="N" />
+				<field name="EncodedLegIssuerLen" required="N" />
+				<field name="EncodedLegIssuer" required="N" />
+				<field name="LegSecurityDesc" required="N" />
+				<field name="EncodedLegSecurityDescLen" required="N" />
+				<field name="EncodedLegSecurityDesc" required="N" />
+				<field name="LegRatioQty" required="N" />
+				<field name="LegSide" required="N" />
+				<field name="LegCurrency" required="N" />
+				<field name="LegPool" required="N" />
+				<field name="LegDatedDate" required="N" />
+				<field name="LegContractSettlMonth" required="N" />
+				<field name="LegInterestAccrualDate" required="N" />
+			</group>
+			<group name="NoUnderlyings" required="N" >
+				<field name="UnderlyingSymbol" required="N" />
+				<field name="UnderlyingSymbolSfx" required="N" />
+				<field name="UnderlyingSecurityID" required="N" />
+				<field name="UnderlyingSecurityIDSource" required="N" />
+				<group name="NoUnderlyingSecurityAltID" required="N" >
+					<field name="UnderlyingSecurityAltID" required="N" />
+					<field name="UnderlyingSecurityAltIDSource" required="N" />
+				</group>
+				<field name="UnderlyingProduct" required="N" />
+				<field name="UnderlyingCFICode" required="N" />
+				<field name="UnderlyingSecurityType" required="N" />
+				<field name="UnderlyingSecuritySubType" required="N" />
+				<field name="UnderlyingMaturityMonthYear" required="N" />
+				<field name="UnderlyingMaturityDate" required="N" />
+				<field name="UnderlyingCouponPaymentDate" required="N" />
+				<field name="UnderlyingIssueDate" required="N" />
+				<field name="UnderlyingRepoCollateralSecurityType" required="N" />
+				<field name="UnderlyingRepurchaseTerm" required="N" />
+				<field name="UnderlyingRepurchaseRate" required="N" />
+				<field name="UnderlyingFactor" required="N" />
+				<field name="UnderlyingCreditRating" required="N" />
+				<field name="UnderlyingInstrRegistry" required="N" />
+				<field name="UnderlyingCountryOfIssue" required="N" />
+				<field name="UnderlyingStateOrProvinceOfIssue" required="N" />
+				<field name="UnderlyingLocaleOfIssue" required="N" />
+				<field name="UnderlyingRedemptionDate" required="N" />
+				<field name="UnderlyingStrikePrice" required="N" />
+				<field name="UnderlyingStrikeCurrency" required="N" />
+				<field name="UnderlyingOptAttribute" required="N" />
+				<field name="UnderlyingContractMultiplier" required="N" />
+				<field name="UnderlyingCouponRate" required="N" />
+				<field name="UnderlyingSecurityExchange" required="N" />
+				<field name="UnderlyingIssuer" required="N" />
+				<field name="EncodedUnderlyingIssuerLen" required="N" />
+				<field name="EncodedUnderlyingIssuer" required="N" />
+				<field name="UnderlyingSecurityDesc" required="N" />
+				<field name="EncodedUnderlyingSecurityDescLen" required="N" />
+				<field name="EncodedUnderlyingSecurityDesc" required="N" />
+				<field name="UnderlyingCPProgram" required="N" />
+				<field name="UnderlyingCPRegType" required="N" />
+				<field name="UnderlyingCurrency" required="N" />
+				<field name="UnderlyingQty" required="N" />
+				<field name="UnderlyingPx" required="N" />
+				<field name="UnderlyingPxType" required="N" />
+				<field name="UnderlyingDirtyPrice" required="N" />
+				<field name="UnderlyingEndPrice" required="N" />
+				<field name="UnderlyingStartValue" required="N" />
+				<field name="UnderlyingCurrentValue" required="N" />
+				<field name="UnderlyingEndValue" required="N" />
+				<group name="NoUnderlyingStips" required="N" >
+					<field name="UnderlyingStipType" required="N" />
+					<field name="UnderlyingStipValue" required="N" />
+				</group>
+			</group>
+			<group name="NoLinesOfText" required="Y" >
+				<field name="Text" required="Y" />
+				<field name="EncodedTextLen" required="N" />
+				<field name="EncodedText" required="N" />
+			</group>
+			<field name="URLLink" required="N" />
+			<field name="RawDataLength" required="N" />
+			<field name="RawData" required="N" />
+		</message>
+		<message name="Reject" msgtype="3" msgcat="admin">
+			<field name="RefSeqNum" required="Y" />
+			<field name="RefTagID" required="N" />
+			<field name="RefMsgType" required="N" />
+			<field name="SessionRejectReason" required="N" />
+			<field name="Text" required="N" />
+			<field name="EncodedTextLen" required="N" />
+			<field name="EncodedText" required="N" />
+		</message>
+		<message name="ResendRequest" msgtype="2" msgcat="admin">
+			<field name="BeginSeqNo" required="Y" />
+			<field name="EndSeqNo" required="Y" />
+		</message>
+		<message name="SecurityList" msgtype="y" msgcat="app">
+			<field name="SecurityReqID" required="N" />
+			<field name="SecurityResponseID" required="N" />
+			<field name="SecurityRequestResult" required="N" />
+			<field name="TotNoRelatedSym" required="N" />
+			<field name="LastFragment" required="N" />
+			<group name="NoRelatedSym" required="N" >
+				<field name="Symbol" required="N" />
+				<field name="SymbolSfx" required="N" />
+				<field name="SecurityID" required="N" />
+				<field name="SecurityIDSource" required="N" />
+				<field name="SecurityExchange" required="N" />
+				<group name="NoApplIDs" required="N" >
+					<field name="ApplID" required="N" />
+					<group name="NoMDFeedTypes" required="N" >
+						<field name="MDFeedType" required="N" />
+						<field name="MarketDepth" required="N" />
+					</group>
+				</group>
+				<group name="NoMDFeedTypes" required="Y" >
+					<field name="MDFeedType" required="Y" />
+					<field name="MarketDepth" required="Y" />
+					<field name="MDBookType" required="Y" />
+				</group>
+				<field name="InstrumentID" required="N" />
+				<field name="PutOrCall" required="N" />
+				<group name="NoSecurityAltID" required="N" >
+					<field name="SecurityAltID" required="Y" />
+					<field name="SecurityAltIDSource" required="Y" />
+				</group>
+				<field name="Product" required="N" />
+				<field name="CFICode" required="N" />
+				<field name="SecurityGroup" required="N" />
+				<field name="SecurityType" required="N" />
+				<field name="SecuritySubType" required="N" />
+				<field name="MaturityMonthYear" required="N" />
+				<field name="MaturityDate" required="N" />
+				<field name="CouponPaymentDate" required="N" />
+				<field name="IssueDate" required="N" />
+				<field name="RepoCollateralSecurityType" required="N" />
+				<field name="RepurchaseTerm" required="N" />
+				<field name="RepurchaseRate" required="N" />
+				<field name="Factor" required="N" />
+				<field name="CreditRating" required="N" />
+				<field name="InstrRegistry" required="N" />
+				<field name="CountryOfIssue" required="N" />
+				<field name="StateOrProvinceOfIssue" required="N" />
+				<field name="LocaleOfIssue" required="N" />
+				<field name="RedemptionDate" required="N" />
+				<field name="StrikePrice" required="N" />
+				<field name="StrikeCurrency" required="N" />
+				<field name="ExerciseStyle" required="N" />
+				<field name="OptAttribute" required="N" />
+				<field name="ContractMultiplier" required="N" />
+				<field name="CouponRate" required="N" />
+				<field name="Issuer" required="N" />
+				<field name="EncodedIssuerLen" required="N" />
+				<field name="EncodedIssuer" required="N" />
+				<field name="SecurityDesc" required="N" />
+				<field name="EncodedSecurityDescLen" required="N" />
+				<field name="EncodedSecurityDesc" required="N" />
+				<field name="Pool" required="N" />
+				<field name="ContractSettlMonth" required="N" />
+				<field name="CPProgram" required="N" />
+				<field name="CPRegType" required="N" />
+				<group name="NoEvents" required="N" >
+					<field name="EventType" required="N" />
+					<field name="EventDate" required="N" />
+					<field name="EventPx" required="N" />
+					<field name="EventText" required="N" />
+				</group>
+				<field name="DatedDate" required="N" />
+				<field name="InterestAccrualDate" required="N" />
+				<field name="SettlType" required="N" />
+				<field name="SettlDate" required="N" />
+				<field name="PriceDivisor" required="N" />
+				<field name="SecurityUpdateAction" required="Y" />
+				<field name="MinPriceIncrement" required="N" />
+				<field name="TickSizeDenominator" required="N" />
+				<field name="MinOrderQty" required="N" />
+				<field name="MaxOrderQty" required="N" />
+				<field name="MultiLegModel" required="N" />
+				<field name="MultiLegPriceMethod" required="N" />
+				<field name="IndexPct" required="N" />
+				<field name="DeliveryForm" required="N" />
+				<field name="PctAtRisk" required="N" />
+				<group name="NoInstrAttrib" required="N" >
+					<field name="InstrAttribType" required="N" />
+					<field name="InstrAttribValue" required="N" />
+				</group>
+				<field name="AgreementDesc" required="N" />
+				<field name="AgreementID" required="N" />
+				<field name="AgreementDate" required="N" />
+				<field name="AgreementCurrency" required="N" />
+				<field name="TerminationType" required="N" />
+				<field name="StartDate" required="N" />
+				<field name="EndDate" required="N" />
+				<field name="DeliveryType" required="N" />
+				<field name="MarginRatio" required="N" />
+				<group name="NoUnderlyings" required="N" >
+					<field name="UnderlyingSymbol" required="N" />
+					<field name="UnderlyingSymbolSfx" required="N" />
+					<field name="UnderlyingSecurityID" required="N" />
+					<field name="UnderlyingSecurityIDSource" required="N" />
+					<group name="NoUnderlyingSecurityAltID" required="N" >
+						<field name="UnderlyingSecurityAltID" required="N" />
+						<field name="UnderlyingSecurityAltIDSource" required="N" />
+					</group>
+					<field name="UnderlyingProduct" required="N" />
+					<field name="UnderlyingCFICode" required="N" />
+					<field name="UnderlyingSecurityType" required="N" />
+					<field name="UnderlyingSecuritySubType" required="N" />
+					<field name="UnderlyingMaturityMonthYear" required="N" />
+					<field name="UnderlyingMaturityDate" required="N" />
+					<field name="UnderlyingCouponPaymentDate" required="N" />
+					<field name="UnderlyingIssueDate" required="N" />
+					<field name="UnderlyingRepoCollateralSecurityType" required="N" />
+					<field name="UnderlyingRepurchaseTerm" required="N" />
+					<field name="UnderlyingRepurchaseRate" required="N" />
+					<field name="UnderlyingFactor" required="N" />
+					<field name="UnderlyingCreditRating" required="N" />
+					<field name="UnderlyingInstrRegistry" required="N" />
+					<field name="UnderlyingCountryOfIssue" required="N" />
+					<field name="UnderlyingStateOrProvinceOfIssue" required="N" />
+					<field name="UnderlyingLocaleOfIssue" required="N" />
+					<field name="UnderlyingRedemptionDate" required="N" />
+					<field name="UnderlyingStrikePrice" required="N" />
+					<field name="UnderlyingStrikeCurrency" required="N" />
+					<field name="UnderlyingOptAttribute" required="N" />
+					<field name="UnderlyingContractMultiplier" required="N" />
+					<field name="UnderlyingCouponRate" required="N" />
+					<field name="UnderlyingSecurityExchange" required="N" />
+					<field name="UnderlyingIssuer" required="N" />
+					<field name="EncodedUnderlyingIssuerLen" required="N" />
+					<field name="EncodedUnderlyingIssuer" required="N" />
+					<field name="UnderlyingSecurityDesc" required="N" />
+					<field name="EncodedUnderlyingSecurityDescLen" required="N" />
+					<field name="EncodedUnderlyingSecurityDesc" required="N" />
+					<field name="UnderlyingCPProgram" required="N" />
+					<field name="UnderlyingCPRegType" required="N" />
+					<field name="UnderlyingCurrency" required="N" />
+					<field name="UnderlyingQty" required="N" />
+					<field name="UnderlyingPx" required="N" />
+					<field name="UnderlyingPxType" required="N" />
+					<field name="UnderlyingDirtyPrice" required="N" />
+					<field name="UnderlyingEndPrice" required="N" />
+					<field name="UnderlyingStartValue" required="N" />
+					<field name="UnderlyingCurrentValue" required="N" />
+					<field name="UnderlyingEndValue" required="N" />
+					<field name="IndexPct" required="N" />
+					<field name="IndexTheoreticalQty" required="N" />
+					<group name="NoUnderlyingStips" required="N" >
+						<field name="UnderlyingStipType" required="N" />
+						<field name="UnderlyingStipValue" required="N" />
+					</group>
+				</group>
+				<field name="Currency" required="N" />
+				<field name="SettlCurrency" required="N" />
+				<field name="SecurityStrategyType" required="N" />
+				<field name="Asset" required="N" />
+				<field name="NoSharesIssued" required="N" />
+				<field name="SecurityValidityTimestamp" required="N" />
+				<field name="MarketSegmentID" required="N" />
+				<field name="GovernanceIndicator" required="N" />
+				<field name="CorporateActionEventID" required="N" />
+				<field name="SecurityMatchType" required="N" />
+				<group name="NoStipulations" required="N" >
+					<field name="StipulationType" required="N" />
+					<field name="StipulationValue" required="N" />
+				</group>
+				<group name="NoLegs" required="N" >
+					<field name="LegSymbol" required="N" />
+					<field name="LegSymbolSfx" required="N" />
+					<field name="LegSecurityID" required="N" />
+					<field name="LegSecurityIDSource" required="N" />
+					<group name="NoLegSecurityAltID" required="N" >
+						<field name="LegSecurityAltID" required="N" />
+						<field name="LegSecurityAltIDSource" required="N" />
+					</group>
+					<field name="LegProduct" required="N" />
+					<field name="LegCFICode" required="N" />
+					<field name="LegSecurityType" required="N" />
+					<field name="LegSecuritySubType" required="N" />
+					<field name="LegMaturityMonthYear" required="N" />
+					<field name="LegMaturityDate" required="N" />
+					<field name="LegCouponPaymentDate" required="N" />
+					<field name="LegIssueDate" required="N" />
+					<field name="LegRepoCollateralSecurityType" required="N" />
+					<field name="LegRepurchaseTerm" required="N" />
+					<field name="LegRepurchaseRate" required="N" />
+					<field name="LegFactor" required="N" />
+					<field name="LegCreditRating" required="N" />
+					<field name="LegInstrRegistry" required="N" />
+					<field name="LegCountryOfIssue" required="N" />
+					<field name="LegStateOrProvinceOfIssue" required="N" />
+					<field name="LegLocaleOfIssue" required="N" />
+					<field name="LegRedemptionDate" required="N" />
+					<field name="LegStrikePrice" required="N" />
+					<field name="LegStrikeCurrency" required="N" />
+					<field name="LegOptAttribute" required="N" />
+					<field name="LegContractMultiplier" required="N" />
+					<field name="LegCouponRate" required="N" />
+					<field name="LegSecurityExchange" required="N" />
+					<field name="LegIssuer" required="N" />
+					<field name="EncodedLegIssuerLen" required="N" />
+					<field name="EncodedLegIssuer" required="N" />
+					<field name="LegSecurityDesc" required="N" />
+					<field name="EncodedLegSecurityDescLen" required="N" />
+					<field name="EncodedLegSecurityDesc" required="N" />
+					<field name="LegRatioQty" required="N" />
+					<field name="LegSide" required="N" />
+					<field name="LegCurrency" required="N" />
+					<field name="LegPool" required="N" />
+					<field name="LegDatedDate" required="N" />
+					<field name="LegContractSettlMonth" required="N" />
+					<field name="LegInterestAccrualDate" required="N" />
+					<field name="LegSwapType" required="N" />
+					<field name="LegSettlType" required="N" />
+					<group name="NoLegStipulations" required="N" >
+						<field name="LegStipulationType" required="N" />
+						<field name="LegStipulationValue" required="N" />
+					</group>
+					<field name="LegBenchmarkCurveCurrency" required="N" />
+					<field name="LegBenchmarkCurveName" required="N" />
+					<field name="LegBenchmarkCurvePoint" required="N" />
+					<field name="LegBenchmarkPrice" required="N" />
+					<field name="LegBenchmarkPriceType" required="N" />
+				</group>
+				<field name="Spread" required="N" />
+				<field name="BenchmarkCurveCurrency" required="N" />
+				<field name="BenchmarkCurveName" required="N" />
+				<field name="BenchmarkCurvePoint" required="N" />
+				<field name="BenchmarkPrice" required="N" />
+				<field name="BenchmarkPriceType" required="N" />
+				<field name="BenchmarkSecurityID" required="N" />
+				<field name="BenchmarkSecurityIDSource" required="N" />
+				<field name="YieldType" required="N" />
+				<field name="Yield" required="N" />
+				<field name="YieldCalcDate" required="N" />
+				<field name="YieldRedemptionDate" required="N" />
+				<field name="YieldRedemptionPrice" required="N" />
+				<field name="YieldRedemptionPriceType" required="N" />
+				<field name="Text" required="N" />
+				<field name="EncodedTextLen" required="N" />
+				<field name="EncodedText" required="N" />
+				<group name="NoTickRules" required="N" >
+					<field name="StartTickPriceRange" required="N" />
+					<field name="EndTickPriceRange" required="N" />
+					<field name="TickIncrement" required="N" />
+					<field name="TickRuleType" required="N" />
+				</group>
+				<group name="NoLotTypeRules" required="N" >
+					<field name="LotType" required="Y" />
+					<field name="MinLotSize" required="Y" />
+				</group>
+				<field name="PriceLimitType" required="N" />
+				<field name="LowLimitPrice" required="N" />
+				<field name="HighLimitPrice" required="N" />
+				<field name="TradingReferencePrice" required="N" />
+				<field name="ExpirationCycle" required="N" />
+				<field name="MinTradeVol" required="N" />
+				<field name="MaxTradeVol" required="N" />
+				<field name="MaxPriceVariation" required="N" />
+				<field name="ImpliedMarketIndicator" required="N" />
+				<field name="TradingCurrency" required="N" />
+				<field name="RoundLot" required="N" />
+				<field name="MultilegModel" required="N" />
+				<field name="MultilegPriceMethod" required="N" />
+				<field name="PriceType" required="N" />
+				<group name="NoTradingSessionRules" required="N" >
+					<field name="TradingSessionID" required="N" />
+					<field name="TradingSessionSubID" required="N" />
+					<group name="NoOrdTypeRules" required="N" >
+						<field name="OrdType" required="N" />
+					</group>
+					<group name="NoTimeInForceRules" required="N" >
+						<field name="TimeInForce" required="N" />
+					</group>
+					<group name="NoExecInstRules" required="N" >
+						<field name="ExecInstValue" required="N" />
+					</group>
+					<group name="NoMatchRules" required="N" >
+						<field name="MatchAlgorithm" required="N" />
+						<field name="MatchType" required="N" />
+					</group>
+				</group>
+				<group name="NoNestedInstrAttrib" required="N" >
+					<field name="NestedInstrAttribType" required="N" />
+					<field name="NestedInstrAttribValue" required="N" />
+				</group>
+				<group name="NoStrikeRules" required="N" >
+					<field name="StrikeRuleID" required="N" />
+					<field name="StartStrikePxRange" required="N" />
+					<field name="EndStrikePxRange" required="N" />
+					<field name="StrikeIncrement" required="N" />
+					<field name="StrikeExerciseStyle" required="N" />
+					<group name="NoMaturityRules" required="N" >
+						<field name="MaturityRuleID" required="N" />
+						<field name="MaturityMonthYearFormat" required="N" />
+						<field name="MaturityMonthYearIncrementUnits" required="N" />
+						<field name="StartMaturityMonthYear" required="N" />
+						<field name="EndMaturityMonthYear" required="N" />
+						<field name="MaturityMonthYearIncrement" required="N" />
+					</group>
+				</group>
+				<field name="RelSymTransactTime" required="N" />
+				<field name="MinCrossQty" required="N" />
+				<field name="OptPayoutType" required="N" />
+			</group>
+			<field name="SecurityReportID" required="N" />
+			<field name="ClearingBusinessDate" required="N" />
+			<field name="MarketID" required="N" />
+			<field name="SecurityListID" required="N" />
+			<field name="SecurityListRefID" required="N" />
+			<field name="SecurityListDesc" required="N" />
+			<field name="EncodedSecurityListDescLen" required="N" />
+			<field name="EncodedSecurityListDesc" required="N" />
+			<field name="SecurityListType" required="N" />
+			<field name="SecurityListTypeSource" required="N" />
+			<field name="TransactTime" required="N" />
+		</message>
+		<message name="SecurityListRequest" msgtype="x" msgcat="app">
+			<field name="SecurityReqID" required="Y" />
+			<field name="SubscriptionRequestType" required="Y" />
+			<field name="SecurityType" required="N" />
+			<field name="Product" required="N" />
+			<field name="CFICode" required="N" />
+			<field name="SecurityListRequestType" required="N" />
+			<field name="SecurityUpdatesSince" required="N" />
+		</message>
+		<message name="SecurityStatus" msgtype="f" msgcat="app">
+			<field name="SecurityStatusReqID" required="N" />
+			<field name="Symbol" required="N" />
+			<field name="SymbolSfx" required="N" />
+			<field name="SecurityID" required="N" />
+			<field name="SecurityIDSource" required="N" />
+			<field name="SecurityExchange" required="N" />
+			<field name="InstrumentID" required="N" />
+			<field name="PutOrCall" required="N" />
+			<group name="NoSecurityAltID" required="N" >
+				<field name="SecurityAltID" required="Y" />
+				<field name="SecurityAltIDSource" required="Y" />
+			</group>
+			<field name="Product" required="N" />
+			<field name="CFICode" required="N" />
+			<field name="SecurityGroup" required="N" />
+			<field name="SecurityType" required="N" />
+			<field name="SecuritySubType" required="N" />
+			<field name="MaturityMonthYear" required="N" />
+			<field name="MaturityDate" required="N" />
+			<field name="CouponPaymentDate" required="N" />
+			<field name="IssueDate" required="N" />
+			<field name="RepoCollateralSecurityType" required="N" />
+			<field name="RepurchaseTerm" required="N" />
+			<field name="RepurchaseRate" required="N" />
+			<field name="Factor" required="N" />
+			<field name="CreditRating" required="N" />
+			<field name="InstrRegistry" required="N" />
+			<field name="CountryOfIssue" required="N" />
+			<field name="StateOrProvinceOfIssue" required="N" />
+			<field name="LocaleOfIssue" required="N" />
+			<field name="RedemptionDate" required="N" />
+			<field name="StrikePrice" required="N" />
+			<field name="StrikeCurrency" required="N" />
+			<field name="ExerciseStyle" required="N" />
+			<field name="OptAttribute" required="N" />
+			<field name="ContractMultiplier" required="N" />
+			<field name="CouponRate" required="N" />
+			<field name="Issuer" required="N" />
+			<field name="EncodedIssuerLen" required="N" />
+			<field name="EncodedIssuer" required="N" />
+			<field name="SecurityDesc" required="N" />
+			<field name="EncodedSecurityDescLen" required="N" />
+			<field name="EncodedSecurityDesc" required="N" />
+			<field name="Pool" required="N" />
+			<field name="ContractSettlMonth" required="N" />
+			<field name="CPProgram" required="N" />
+			<field name="CPRegType" required="N" />
+			<group name="NoEvents" required="N" >
+				<field name="EventType" required="N" />
+				<field name="EventDate" required="N" />
+				<field name="EventPx" required="N" />
+				<field name="EventText" required="N" />
+			</group>
+			<field name="DatedDate" required="N" />
+			<field name="InterestAccrualDate" required="N" />
+			<field name="SettlType" required="N" />
+			<field name="SettlDate" required="N" />
+			<field name="DeliveryForm" required="N" />
+			<field name="PctAtRisk" required="N" />
+			<group name="NoInstrAttrib" required="N" >
+				<field name="InstrAttribType" required="N" />
+				<field name="InstrAttribValue" required="N" />
+			</group>
+			<group name="NoUnderlyings" required="N" >
+				<field name="UnderlyingSymbol" required="N" />
+				<field name="UnderlyingSymbolSfx" required="N" />
+				<field name="UnderlyingSecurityID" required="N" />
+				<field name="UnderlyingSecurityIDSource" required="N" />
+				<group name="NoUnderlyingSecurityAltID" required="N" >
+					<field name="UnderlyingSecurityAltID" required="N" />
+					<field name="UnderlyingSecurityAltIDSource" required="N" />
+				</group>
+				<field name="UnderlyingProduct" required="N" />
+				<field name="UnderlyingCFICode" required="N" />
+				<field name="UnderlyingSecurityType" required="N" />
+				<field name="UnderlyingSecuritySubType" required="N" />
+				<field name="UnderlyingMaturityMonthYear" required="N" />
+				<field name="UnderlyingMaturityDate" required="N" />
+				<field name="UnderlyingCouponPaymentDate" required="N" />
+				<field name="UnderlyingIssueDate" required="N" />
+				<field name="UnderlyingRepoCollateralSecurityType" required="N" />
+				<field name="UnderlyingRepurchaseTerm" required="N" />
+				<field name="UnderlyingRepurchaseRate" required="N" />
+				<field name="UnderlyingFactor" required="N" />
+				<field name="UnderlyingCreditRating" required="N" />
+				<field name="UnderlyingInstrRegistry" required="N" />
+				<field name="UnderlyingCountryOfIssue" required="N" />
+				<field name="UnderlyingStateOrProvinceOfIssue" required="N" />
+				<field name="UnderlyingLocaleOfIssue" required="N" />
+				<field name="UnderlyingRedemptionDate" required="N" />
+				<field name="UnderlyingStrikePrice" required="N" />
+				<field name="UnderlyingStrikeCurrency" required="N" />
+				<field name="UnderlyingOptAttribute" required="N" />
+				<field name="UnderlyingContractMultiplier" required="N" />
+				<field name="UnderlyingCouponRate" required="N" />
+				<field name="UnderlyingSecurityExchange" required="N" />
+				<field name="UnderlyingIssuer" required="N" />
+				<field name="EncodedUnderlyingIssuerLen" required="N" />
+				<field name="EncodedUnderlyingIssuer" required="N" />
+				<field name="UnderlyingSecurityDesc" required="N" />
+				<field name="EncodedUnderlyingSecurityDescLen" required="N" />
+				<field name="EncodedUnderlyingSecurityDesc" required="N" />
+				<field name="UnderlyingCPProgram" required="N" />
+				<field name="UnderlyingCPRegType" required="N" />
+				<field name="UnderlyingCurrency" required="N" />
+				<field name="UnderlyingQty" required="N" />
+				<field name="UnderlyingPx" required="N" />
+				<field name="UnderlyingPxType" required="N" />
+				<field name="UnderlyingDirtyPrice" required="N" />
+				<field name="UnderlyingEndPrice" required="N" />
+				<field name="UnderlyingStartValue" required="N" />
+				<field name="UnderlyingCurrentValue" required="N" />
+				<field name="UnderlyingEndValue" required="N" />
+				<group name="NoUnderlyingStips" required="N" >
+					<field name="UnderlyingStipType" required="N" />
+					<field name="UnderlyingStipValue" required="N" />
+				</group>
+			</group>
+			<group name="NoLegs" required="N" >
+				<field name="LegSymbol" required="N" />
+				<field name="LegSymbolSfx" required="N" />
+				<field name="LegSecurityID" required="N" />
+				<field name="LegSecurityIDSource" required="N" />
+				<group name="NoLegSecurityAltID" required="N" >
+					<field name="LegSecurityAltID" required="N" />
+					<field name="LegSecurityAltIDSource" required="N" />
+				</group>
+				<field name="LegProduct" required="N" />
+				<field name="LegCFICode" required="N" />
+				<field name="LegSecurityType" required="N" />
+				<field name="LegSecuritySubType" required="N" />
+				<field name="LegMaturityMonthYear" required="N" />
+				<field name="LegMaturityDate" required="N" />
+				<field name="LegCouponPaymentDate" required="N" />
+				<field name="LegIssueDate" required="N" />
+				<field name="LegRepoCollateralSecurityType" required="N" />
+				<field name="LegRepurchaseTerm" required="N" />
+				<field name="LegRepurchaseRate" required="N" />
+				<field name="LegFactor" required="N" />
+				<field name="LegCreditRating" required="N" />
+				<field name="LegInstrRegistry" required="N" />
+				<field name="LegCountryOfIssue" required="N" />
+				<field name="LegStateOrProvinceOfIssue" required="N" />
+				<field name="LegLocaleOfIssue" required="N" />
+				<field name="LegRedemptionDate" required="N" />
+				<field name="LegStrikePrice" required="N" />
+				<field name="LegStrikeCurrency" required="N" />
+				<field name="LegOptAttribute" required="N" />
+				<field name="LegContractMultiplier" required="N" />
+				<field name="LegCouponRate" required="N" />
+				<field name="LegSecurityExchange" required="N" />
+				<field name="LegIssuer" required="N" />
+				<field name="EncodedLegIssuerLen" required="N" />
+				<field name="EncodedLegIssuer" required="N" />
+				<field name="LegSecurityDesc" required="N" />
+				<field name="EncodedLegSecurityDescLen" required="N" />
+				<field name="EncodedLegSecurityDesc" required="N" />
+				<field name="LegRatioQty" required="N" />
+				<field name="LegSide" required="N" />
+				<field name="LegCurrency" required="N" />
+				<field name="LegPool" required="N" />
+				<field name="LegDatedDate" required="N" />
+				<field name="LegContractSettlMonth" required="N" />
+				<field name="LegInterestAccrualDate" required="N" />
+			</group>
+			<field name="Currency" required="N" />
+			<field name="TradingSessionID" required="N" />
+			<field name="TradingSessionSubID" required="N" />
+			<field name="UnsolicitedIndicator" required="N" />
+			<field name="TradSesOpenTime" required="N" />
+			<field name="SecurityTradingStatus" required="N" />
+			<field name="MDStreamID" required="N" />
+			<field name="TradeDate" required="Y" />
+			<field name="BEITradingStatus" required="N" />
+			<field name="FinancialStatus" required="N" />
+			<field name="CorporateAction" required="N" />
+			<field name="HaltReason" required="N" />
+			<field name="InViewOfCommon" required="N" />
+			<field name="DueToRelated" required="N" />
+			<field name="BuyVolume" required="N" />
+			<field name="SellVolume" required="N" />
+			<field name="HighPx" required="N" />
+			<field name="LowPx" required="N" />
+			<field name="LastPx" required="N" />
+			<field name="TransactTime" required="Y" />
+			<field name="Adjustment" required="N" />
+			<field name="Text" required="N" />
+			<field name="EncodedTextLen" required="N" />
+			<field name="EncodedText" required="N" />
+			<field name="SecurityTradingEvent" required="N" />
+		</message>
+		<message name="SequenceReset" msgtype="4" msgcat="admin">
+			<field name="GapFillFlag" required="N" />
+			<field name="NewSeqNo" required="Y" />
+			<field name="PossMissingApplMsg" required="N" />
+		</message>
+		<message name="TestRequest" msgtype="1" msgcat="admin">
+			<field name="TestReqID" required="Y" />
+		</message>
+		<message name="TradeHistoryRequest" msgtype="UTHQ" msgcat="app">
+			<field name="MDReqID" required="Y" />
+			<field name="SubscriptionRequestType" required="Y" />
+			<group name="NoMDEntryTypes" required="N" >
+				<field name="MDEntryType" required="Y" />
+			</group>
+			<group name="NoRelatedSym" required="N" >
+				<field name="SecurityID" required="Y" />
+				<field name="SecurityIDSource" required="Y" />
+				<field name="SecurityExchange" required="Y" />
+				<field name="StartSequence" required="Y" />
+				<field name="EndSequence" required="Y" />
+			</group>
+			<field name="SecurityUpdatesSince" required="N" />
+		</message>
+		<message name="TradeHistoryResponse" msgtype="UTHP" msgcat="app">
+			<field name="MDReqRejReason" required="N" />
+			<field name="MDReqID" required="Y" />
+			<field name="LastFragment" required="N" />
+			<field name="Symbol" required="N" />
+			<field name="SymbolSfx" required="N" />
+			<field name="SecurityID" required="N" />
+			<field name="SecurityIDSource" required="N" />
+			<field name="SecurityExchange" required="N" />
+			<field name="InstrumentID" required="N" />
+			<field name="PutOrCall" required="N" />
+			<group name="NoSecurityAltID" required="N" >
+				<field name="SecurityAltID" required="Y" />
+				<field name="SecurityAltIDSource" required="Y" />
+			</group>
+			<field name="Product" required="N" />
+			<field name="CFICode" required="N" />
+			<field name="SecurityGroup" required="N" />
+			<field name="SecurityType" required="N" />
+			<field name="SecuritySubType" required="N" />
+			<field name="MaturityMonthYear" required="N" />
+			<field name="MaturityDate" required="N" />
+			<field name="CouponPaymentDate" required="N" />
+			<field name="IssueDate" required="N" />
+			<field name="RepoCollateralSecurityType" required="N" />
+			<field name="RepurchaseTerm" required="N" />
+			<field name="RepurchaseRate" required="N" />
+			<field name="Factor" required="N" />
+			<field name="CreditRating" required="N" />
+			<field name="InstrRegistry" required="N" />
+			<field name="CountryOfIssue" required="N" />
+			<field name="StateOrProvinceOfIssue" required="N" />
+			<field name="LocaleOfIssue" required="N" />
+			<field name="RedemptionDate" required="N" />
+			<field name="StrikePrice" required="N" />
+			<field name="StrikeCurrency" required="N" />
+			<field name="ExerciseStyle" required="N" />
+			<field name="OptAttribute" required="N" />
+			<field name="ContractMultiplier" required="N" />
+			<field name="CouponRate" required="N" />
+			<field name="Issuer" required="N" />
+			<field name="EncodedIssuerLen" required="N" />
+			<field name="EncodedIssuer" required="N" />
+			<field name="SecurityDesc" required="N" />
+			<field name="EncodedSecurityDescLen" required="N" />
+			<field name="EncodedSecurityDesc" required="N" />
+			<field name="Pool" required="N" />
+			<field name="ContractSettlMonth" required="N" />
+			<field name="CPProgram" required="N" />
+			<field name="CPRegType" required="N" />
+			<group name="NoEvents" required="N" >
+				<field name="EventType" required="N" />
+				<field name="EventDate" required="N" />
+				<field name="EventPx" required="N" />
+				<field name="EventText" required="N" />
+			</group>
+			<field name="DatedDate" required="N" />
+			<field name="InterestAccrualDate" required="N" />
+			<field name="SettlType" required="N" />
+			<field name="SettlDate" required="N" />
+			<group name="NoMDEntries" required="N" >
+				<field name="MDEntryType" required="Y" />
+				<field name="MDUpdateAction" required="N" />
+				<field name="MDStreamID" required="N" />
+				<field name="MDEntryPx" required="N" />
+				<field name="MDEntrySize" required="N" />
+				<field name="PriceType" required="N" />
+				<field name="MDEntryInterestRate" required="N" />
+				<field name="IndexSeq" required="N" />
+				<field name="Currency" required="N" />
+				<field name="MDEntryDate" required="Y" />
+				<field name="MDEntryTime" required="Y" />
+				<field name="MDInsertDate" required="N" />
+				<field name="MDInsertTime" required="N" />
+				<field name="BTBContractInfo" required="N" />
+				<field name="BTBGraceDate" required="N" />
+				<field name="TradeDate" required="N" />
+				<field name="OpenCloseSettlFlag" required="N" />
+				<field name="TickDirection" required="N" />
+				<field name="TradeCondition" required="N" />
+				<field name="TradingSessionID" required="N" />
+				<field name="MDEntryBuyer" required="N" />
+				<field name="MDEntrySeller" required="N" />
+				<field name="NetChgPrevDay" required="N" />
+				<field name="TradeID" required="N" />
+				<field name="TradeVolume" required="N" />
+				<field name="SellerDays" required="N" />
+				<field name="SettlPriceType" required="N" />
+				<field name="LastTradeDate" required="N" />
+				<field name="PriceAdjustmentMethod" required="N" />
+				<field name="PriceBandType" required="N" />
+				<field name="PriceLimitType" required="N" />
+				<field name="LowLimitPrice" required="N" />
+				<field name="HighLimitPrice" required="N" />
+				<field name="TradingReferencePrice" required="N" />
+				<field name="PriceBandMidpointPriceType" required="N" />
+				<field name="AvgDailyTradedQty" required="N" />
+				<field name="MaxTradeVol" required="N" />
+			</group>
+		</message>
+	</messages>
+	<fields>
+		<field number="7" name="BeginSeqNo" type="SEQNUM" />
+		<field number="8" name="BeginString" type="STRING" />
+		<field number="9" name="BodyLength" type="LENGTH" />
+		<field number="10" name="CheckSum" type="STRING" />
+		<field number="15" name="Currency" type="CURRENCY" />
+		<field number="16" name="EndSeqNo" type="SEQNUM" />
+		<field number="18" name="ExecInst" type="MULTIPLEVALUESTRING" >
+			<value enum="1" description="NOT_HELD" />
+			<value enum="2" description="WORK" />
+			<value enum="3" description="GO_ALONG" />
+			<value enum="4" description="OVER_THE_DAY" />
+			<value enum="5" description="HELD" />
+			<value enum="6" description="PARTICIPATE_DONT_INITIATE" />
+			<value enum="7" description="STRICT_SCALE" />
+			<value enum="8" description="TRY_TO_SCALE" />
+			<value enum="9" description="STAY_ON_BIDSIDE" />
+			<value enum="0" description="STAY_ON_OFFERSIDE" />
+			<value enum="A" description="NO_CROSS" />
+			<value enum="B" description="OK_TO_CROSS" />
+			<value enum="C" description="CALL_FIRST" />
+			<value enum="D" description="PERCENT_OF_VOLUME" />
+			<value enum="E" description="DO_NOT_INCREASE" />
+			<value enum="F" description="DO_NOT_REDUCE" />
+			<value enum="G" description="ALL_OR_NONE" />
+			<value enum="H" description="REINSTATE_ON_SYSTEM_FAILURE" />
+			<value enum="I" description="INSTITUTIONS_ONLY" />
+			<value enum="J" description="REINSTATE_ON_TRADING_HALT" />
+			<value enum="K" description="CANCEL_ON_TRADING_HALT" />
+			<value enum="L" description="LAST_PEG" />
+			<value enum="M" description="MID_PRICE" />
+			<value enum="N" description="NON_NEGOTIABLE" />
+			<value enum="O" description="OPENING_PEG" />
+			<value enum="P" description="MARKET_PEG" />
+			<value enum="Q" description="CANCEL_ON_SYSTEM_FAILURE" />
+			<value enum="R" description="PRIMARY_PEG" />
+			<value enum="S" description="SUSPEND" />
+			<value enum="T" description="FIXED_PEG_TO_LOCAL_BEST_BID_OR_OFFER_AT_TIME_OF_ORDER" />
+			<value enum="U" description="CUSTOMER_DISPLAY_INSTRUCTION" />
+			<value enum="V" description="NETTING" />
+			<value enum="W" description="PEG_TO_VWAP" />
+			<value enum="X" description="TRADE_ALONG" />
+			<value enum="Y" description="TRY_TO_STOP" />
+			<value enum="Z" description="CANCEL_IF_NOT_BEST" />
+			<value enum="a" description="TRAILING_STOP_PEG" />
+			<value enum="b" description="STRICT_LIMIT" />
+			<value enum="c" description="IGNORE_PRICE_VALIDITY_CHECKS" />
+			<value enum="d" description="PEG_TO_LIMIT_PRICE" />
+			<value enum="e" description="WORK_TO_TARGET_STRATEGY" />
+		</field>
+		<field number="22" name="SecurityIDSource" type="STRING" >
+			<value enum="1" description="CUSIP" />
+			<value enum="2" description="SEDOL" />
+			<value enum="3" description="QUIK" />
+			<value enum="4" description="ISIN_NUMBER" />
+			<value enum="5" description="RIC_CODE" />
+			<value enum="6" description="ISO_CURRENCY_CODE" />
+			<value enum="7" description="ISO_COUNTRY_CODE" />
+			<value enum="8" description="EXCHANGE_SYMBOL" />
+			<value enum="9" description="CONSOLIDATED_TAPE_ASSOCIATION" />
+			<value enum="A" description="BLOOMBERG_SYMBOL" />
+			<value enum="B" description="WERTPAPIER" />
+			<value enum="C" description="DUTCH" />
+			<value enum="D" description="VALOREN" />
+			<value enum="E" description="SICOVAM" />
+			<value enum="F" description="BELGIAN" />
+			<value enum="G" description="COMMON" />
+			<value enum="H" description="CLEARING_HOUSE_CLEARING_ORGANIZATION" />
+			<value enum="I" description="ISDA_FPML_PRODUCT_SPECIFICATION" />
+			<value enum="J" description="OPTIONS_PRICE_REPORTING_AUTHORITY" />
+		</field>
+		<field number="31" name="LastPx" type="PRICE" />
+		<field number="33" name="NoLinesOfText" type="NUMINGROUP" />
+		<field number="34" name="MsgSeqNum" type="SEQNUM" />
+		<field number="35" name="MsgType" type="STRING" >
+			<value enum="0" description="HEARTBEAT" />
+			<value enum="1" description="TEST_REQUEST" />
+			<value enum="2" description="RESEND_REQUEST" />
+			<value enum="3" description="REJECT" />
+			<value enum="4" description="SEQUENCE_RESET" />
+			<value enum="5" description="LOGOUT" />
+			<value enum="A" description="LOGON" />
+			<value enum="B" description="NEWS" />
+			<value enum="V" description="MARKET_DATA_REQUEST" />
+			<value enum="W" description="MARKET_DATA_SNAPSHOT_FULL_REFRESH" />
+			<value enum="X" description="MARKET_DATA_INCREMENTAL_REFRESH" />
+			<value enum="Y" description="MARKET_DATA_REQUEST_REJECT" />
+			<value enum="f" description="SECURITY_STATUS" />
+			<value enum="j" description="BUSINESS_MESSAGE_REJECT" />
+			<value enum="x" description="SECURITY_LIST_REQUEST" />
+			<value enum="y" description="SECURITY_LIST" />
+			<value enum="BD" description="NETWORK_STATUS_RESPONSE" />
+			<value enum="ULRQ" description="BTS_LICENSE_REQUEST" />
+			<value enum="ULRP" description="BTS_LICENSE_RESPONSE" />
+			<value enum="ULRL" description="BTS_LICENSE_LOGOUT_REPORT" />
+			<value enum="UTHQ" description="TRADE_HISTORY_REQUEST" />
+			<value enum="UTHP" description="TRADE_HISTORY_RESPONSE" />
+			<value enum="UTOT" description="MARKET_DATA_SUMMARIZER_REFRESH" />
+			<value enum="UTOTC" description="MARKET_DATA_SUMMARIZER_COMPOSITION_REFRESH" />
+			<value enum="UTOTQ" description="MARKET_DATA_SUMMARIZER_REQUEST" />
+			<value enum="UTOTP" description="MARKET_DATA_SUMMARIZER_RESPONSE" />
+		</field>
+		<field number="36" name="NewSeqNo" type="SEQNUM" />
+		<field number="37" name="OrderID" type="STRING" />
+		<field number="40" name="OrdType" type="CHAR" >
+			<value enum="2" description="LIMIT" />
+			<value enum="4" description="STOP_LIMIT" />
+			<value enum="K" description="MARKET_WITH_LEFTOVER_AS_LIMIT" />
+			<value enum="W" description="OFFER_RLP" />
+		</field>
+		<field number="42" name="OrigTime" type="UTCTIMESTAMP" />
+		<field number="43" name="PossDupFlag" type="BOOLEAN" />
+		<field number="45" name="RefSeqNum" type="SEQNUM" />
+		<field number="48" name="SecurityID" type="STRING" />
+		<field number="49" name="SenderCompID" type="STRING" />
+		<field number="50" name="SenderSubID" type="STRING" />
+		<field number="52" name="SendingTime" type="UTCTIMESTAMP" />
+		<field number="55" name="Symbol" type="STRING" />
+		<field number="56" name="TargetCompID" type="STRING" />
+		<field number="57" name="TargetSubID" type="STRING" />
+		<field number="58" name="Text" type="STRING" />
+		<field number="59" name="TimeInForce" type="CHAR" >
+			<value enum="0" description="DAY" />
+			<value enum="3" description="IMMEDIATE_OR_CANCEL" />
+			<value enum="4" description="FILL_OR_KILL" />
+		</field>
+		<field number="60" name="TransactTime" type="UTCTIMESTAMP" />
+		<field number="61" name="Urgency" type="CHAR" >
+			<value enum="0" description="NORMAL" />
+			<value enum="1" description="FLASH" />
+			<value enum="2" description="BACKGROUND" />
+		</field>
+		<field number="63" name="SettlType" type="STRING" />
+		<field number="64" name="SettlDate" type="LOCALMKTDATE" />
+		<field number="65" name="SymbolSfx" type="STRING" >
+			<value enum="WI" description="WHEN_ISSUED" />
+			<value enum="CD" description="A_EUCP_WITH_LUMP_SUM_INTEREST" />
+		</field>
+		<field number="75" name="TradeDate" type="LOCALMKTDATE" />
+		<field number="89" name="Signature" type="DATA" />
+		<field number="90" name="SecureDataLen" type="LENGTH" />
+		<field number="91" name="SecureData" type="DATA" />
+		<field number="93" name="SignatureLength" type="LENGTH" />
+		<field number="95" name="RawDataLength" type="LENGTH" />
+		<field number="96" name="RawData" type="DATA" />
+		<field number="97" name="PossResend" type="BOOLEAN" />
+		<field number="98" name="EncryptMethod" type="INT" >
+			<value enum="0" description="NONE_OTHER" />
+			<value enum="1" description="PKCS" />
+			<value enum="2" description="DES" />
+			<value enum="3" description="PKCS_DES" />
+			<value enum="4" description="PGP_DES" />
+			<value enum="5" description="PGP_DES_MD5" />
+			<value enum="6" description="PEM_DES_MD5" />
+		</field>
+		<field number="99" name="StopPx" type="PRICE" />
+		<field number="106" name="Issuer" type="STRING" />
+		<field number="107" name="SecurityDesc" type="STRING" />
+		<field number="108" name="HeartBtInt" type="INT" />
+		<field number="110" name="MinQty" type="QTY" />
+		<field number="112" name="TestReqID" type="STRING" />
+		<field number="115" name="OnBehalfOfCompID" type="STRING" />
+		<field number="116" name="OnBehalfOfSubID" type="STRING" />
+		<field number="120" name="SettlCurrency" type="CURRENCY" />
+		<field number="122" name="OrigSendingTime" type="UTCTIMESTAMP" />
+		<field number="123" name="GapFillFlag" type="BOOLEAN" />
+		<field number="126" name="ExpireTime" type="UTCTIMESTAMP" />
+		<field number="128" name="DeliverToCompID" type="STRING" />
+		<field number="129" name="DeliverToSubID" type="STRING" />
+		<field number="141" name="ResetSeqNumFlag" type="BOOLEAN" />
+		<field number="142" name="SenderLocationID" type="STRING" />
+		<field number="143" name="TargetLocationID" type="STRING" />
+		<field number="144" name="OnBehalfOfLocationID" type="STRING" />
+		<field number="145" name="DeliverToLocationID" type="STRING" />
+		<field number="146" name="NoRelatedSym" type="NUMINGROUP" />
+		<field number="148" name="Headline" type="STRING" />
+		<field number="149" name="URLLink" type="STRING" />
+		<field number="167" name="SecurityType" type="STRING" >
+			<value enum="EUSUPRA" description="EURO_SUPRANATIONAL_COUPONS" />
+			<value enum="FAC" description="FEDERAL_AGENCY_COUPON" />
+			<value enum="FADN" description="FEDERAL_AGENCY_DISCOUNT_NOTE" />
+			<value enum="PEF" description="PRIVATE_EXPORT_FUNDING" />
+			<value enum="SUPRA" description="USD_SUPRANATIONAL_COUPONS" />
+			<value enum="FUT" description="FUTURE" />
+			<value enum="OPT" description="OPTION" />
+			<value enum="CORP" description="CORPORATE_BOND" />
+			<value enum="CPP" description="CORPORATE_PRIVATE_PLACEMENT" />
+			<value enum="CB" description="CONVERTIBLE_BOND" />
+			<value enum="DUAL" description="DUAL_CURRENCY" />
+			<value enum="EUCORP" description="EURO_CORPORATE_BOND" />
+			<value enum="XLINKD" description="INDEXED_LINKED" />
+			<value enum="STRUCT" description="STRUCTURED_NOTES" />
+			<value enum="YANK" description="YANKEE_CORPORATE_BOND" />
+			<value enum="FOR" description="FOREIGN_EXCHANGE_CONTRACT" />
+			<value enum="CS" description="COMMON_STOCK" />
+			<value enum="PS" description="PREFERRED_STOCK" />
+			<value enum="BRADY" description="BRADY_BOND" />
+			<value enum="EUSOV" description="EURO_SOVEREIGNS" />
+			<value enum="TBOND" description="US_TREASURY_BOND" />
+			<value enum="TINT" description="INTEREST_STRIP_FROM_ANY_BOND_OR_NOTE" />
+			<value enum="TIPS" description="TREASURY_INFLATION_PROTECTED_SECURITIES" />
+			<value enum="TCAL" description="PRINCIPAL_STRIP_OF_A_CALLABLE_BOND_OR_NOTE" />
+			<value enum="TPRN" description="PRINCIPAL_STRIP_FROM_A_NON_CALLABLE_BOND_OR_NOTE" />
+			<value enum="TNOTE" description="US_TREASURY_NOTE" />
+			<value enum="TBILL" description="US_TREASURY_BILL" />
+			<value enum="REPO" description="REPURCHASE" />
+			<value enum="FORWARD" description="FORWARD" />
+			<value enum="BUYSELL" description="BUY_SELLBACK" />
+			<value enum="SECLOAN" description="SECURITIES_LOAN" />
+			<value enum="SECPLEDGE" description="SECURITIES_PLEDGE" />
+			<value enum="TERM" description="TERM_LOAN" />
+			<value enum="RVLV" description="REVOLVER_LOAN" />
+			<value enum="RVLVTRM" description="REVOLVER_TERM_LOAN" />
+			<value enum="BRIDGE" description="BRIDGE_LOAN" />
+			<value enum="LOFC" description="LETTER_OF_CREDIT" />
+			<value enum="SWING" description="SWING_LINE_FACILITY" />
+			<value enum="DINP" description="DEBTOR_IN_POSSESSION" />
+			<value enum="DEFLTED" description="DEFAULTED" />
+			<value enum="WITHDRN" description="WITHDRAWN" />
+			<value enum="REPLACD" description="REPLACED" />
+			<value enum="MATURED" description="MATURED" />
+			<value enum="AMENDED" description="AMENDED_AND_RESTATED" />
+			<value enum="RETIRED" description="RETIRED" />
+			<value enum="BA" description="BANKERS_ACCEPTANCE" />
+			<value enum="BN" description="BANK_NOTES" />
+			<value enum="BOX" description="BILL_OF_EXCHANGES" />
+			<value enum="CD" description="CERTIFICATE_OF_DEPOSIT" />
+			<value enum="CL" description="CALL_LOANS" />
+			<value enum="CP" description="COMMERCIAL_PAPER" />
+			<value enum="DN" description="DEPOSIT_NOTES" />
+			<value enum="EUCD" description="EURO_CERTIFICATE_OF_DEPOSIT" />
+			<value enum="EUCP" description="EURO_COMMERCIAL_PAPER" />
+			<value enum="LQN" description="LIQUIDITY_NOTE" />
+			<value enum="MTN" description="MEDIUM_TERM_NOTES" />
+			<value enum="ONITE" description="OVERNIGHT" />
+			<value enum="PN" description="PROMISSORY_NOTE" />
+			<value enum="PZFJ" description="PLAZOS_FIJOS" />
+			<value enum="STN" description="SHORT_TERM_LOAN_NOTE" />
+			<value enum="TD" description="TIME_DEPOSIT" />
+			<value enum="XCN" description="EXTENDED_COMM_NOTE" />
+			<value enum="YCD" description="YANKEE_CERTIFICATE_OF_DEPOSIT" />
+			<value enum="ABS" description="ASSET_BACKED_SECURITIES" />
+			<value enum="CMBS" description="CORP_MORTGAGE_BACKED_SECURITIES" />
+			<value enum="CMO" description="COLLATERALIZED_MORTGAGE_OBLIGATION" />
+			<value enum="IET" description="IOETTE_MORTGAGE" />
+			<value enum="MBS" description="MORTGAGE_BACKED_SECURITIES" />
+			<value enum="MIO" description="MORTGAGE_INTEREST_ONLY" />
+			<value enum="MPO" description="MORTGAGE_PRINCIPAL_ONLY" />
+			<value enum="MPP" description="MORTGAGE_PRIVATE_PLACEMENT" />
+			<value enum="MPT" description="MISCELLANEOUS_PASS_THROUGH" />
+			<value enum="PFAND" description="PFANDBRIEFE" />
+			<value enum="TBA" description="TO_BE_ANNOUNCED" />
+			<value enum="AN" description="OTHER_ANTICIPATION_NOTES" />
+			<value enum="COFO" description="CERTIFICATE_OF_OBLIGATION" />
+			<value enum="COFP" description="CERTIFICATE_OF_PARTICIPATION" />
+			<value enum="GO" description="GENERAL_OBLIGATION_BONDS" />
+			<value enum="MT" description="MANDATORY_TENDER" />
+			<value enum="RAN" description="REVENUE_ANTICIPATION_NOTE" />
+			<value enum="REV" description="REVENUE_BONDS" />
+			<value enum="SPCLA" description="SPECIAL_ASSESSMENT" />
+			<value enum="SPCLO" description="SPECIAL_OBLIGATION" />
+			<value enum="SPCLT" description="SPECIAL_TAX" />
+			<value enum="TAN" description="TAX_ANTICIPATION_NOTE" />
+			<value enum="TAXA" description="TAX_ALLOCATION" />
+			<value enum="TECP" description="TAX_EXEMPT_COMMERCIAL_PAPER" />
+			<value enum="TRAN" description="TAX_AND_REVENUE_ANTICIPATION_NOTE" />
+			<value enum="VRDN" description="VARIABLE_RATE_DEMAND_NOTE" />
+			<value enum="WAR" description="WARRANT" />
+			<value enum="MF" description="MUTUAL_FUND" />
+			<value enum="MLEG" description="MULTI_LEG_INSTRUMENT" />
+			<value enum="NONE" description="NO_SECURITY_TYPE" />
+			<value enum="?" description="WILDCARD" />
+			<value enum="SPOT" description="SPOT_FUTURE" />
+			<value enum="SOPT" description="SPOT_OPTIONS" />
+			<value enum="FOPT" description="FUTURE_OPTIONS" />
+			<value enum="DTERM" description="FORWARD_TERM" />
+			<value enum="UNKNOWN" description="UNKNOWN" />
+			<value enum="CASH" description="CASH" />
+			<value enum="INDEX" description="INDEX" />
+			<value enum="ETF" description="ETF" />
+			<value enum="OPTEXER" description="OPTION_EXERCISE" />
+			<value enum="INDEXOPT" description="OPTION_ON_INDEX" />
+		</field>
+		<field number="200" name="MaturityMonthYear" type="MONTHYEAR" />
+		<field number="201" name="PutOrCall" type="INT" >
+			<value enum="0" description="PUT" />
+			<value enum="1" description="CALL" />
+		</field>
+		<field number="202" name="StrikePrice" type="PRICE" />
+		<field number="206" name="OptAttribute" type="CHAR" />
+		<field number="207" name="SecurityExchange" type="EXCHANGE" />
+		<field number="212" name="XmlDataLen" type="LENGTH" />
+		<field number="213" name="XmlData" type="DATA" />
+		<field number="215" name="NoRoutingIDs" type="NUMINGROUP" />
+		<field number="216" name="RoutingType" type="INT" >
+			<value enum="1" description="TARGET_FIRM" />
+			<value enum="2" description="TARGET_LIST" />
+			<value enum="3" description="BLOCK_FIRM" />
+			<value enum="4" description="BLOCK_LIST" />
+		</field>
+		<field number="217" name="RoutingID" type="STRING" />
+		<field number="218" name="Spread" type="PRICEOFFSET" />
+		<field number="220" name="BenchmarkCurveCurrency" type="CURRENCY" />
+		<field number="221" name="BenchmarkCurveName" type="STRING" >
+			<value enum="MuniAAA" description="MUNIAAA" />
+			<value enum="FutureSWAP" description="FUTURESWAP" />
+			<value enum="LIBID" description="LIBID" />
+			<value enum="LIBOR" description="LIBOR" />
+			<value enum="OTHER" description="OTHER" />
+			<value enum="SWAP" description="SWAP" />
+			<value enum="Treasury" description="TREASURY" />
+			<value enum="Euribor" description="EURIBOR" />
+			<value enum="Pfandbriefe" description="PFANDBRIEFE" />
+			<value enum="EONIA" description="EONIA" />
+			<value enum="SONIA" description="SONIA" />
+			<value enum="EUREPO" description="EUREPO" />
+		</field>
+		<field number="222" name="BenchmarkCurvePoint" type="STRING" />
+		<field number="223" name="CouponRate" type="PERCENTAGE" />
+		<field number="224" name="CouponPaymentDate" type="LOCALMKTDATE" />
+		<field number="225" name="IssueDate" type="LOCALMKTDATE" />
+		<field number="226" name="RepurchaseTerm" type="INT" />
+		<field number="227" name="RepurchaseRate" type="PERCENTAGE" />
+		<field number="228" name="Factor" type="FLOAT" />
+		<field number="231" name="ContractMultiplier" type="FLOAT" />
+		<field number="232" name="NoStipulations" type="NUMINGROUP" />
+		<field number="233" name="StipulationType" type="STRING" >
+			<value enum="AMT" description="AMT" />
+			<value enum="AUTOREINV" description="AUTO_REINVESTMENT_AT_OR_BETTER" />
+			<value enum="BANKQUAL" description="BANK_QUALIFIED" />
+			<value enum="BGNCON" description="BARGAIN_CONDITIONS" />
+			<value enum="COUPON" description="COUPON_RANGE" />
+			<value enum="CURRENCY" description="ISO_CURRENCY_CODE" />
+			<value enum="CUSTOMDATE" description="CUSTOM_START_END_DATE" />
+			<value enum="GEOG" description="GEOGRAPHICS_AND_PERCENT_RANGE" />
+			<value enum="HAIRCUT" description="VALUATION_DISCOUNT" />
+			<value enum="INSURED" description="INSURED" />
+			<value enum="ISSUE" description="YEAR_OR_YEAR_MONTH_OF_ISSUE" />
+			<value enum="ISSUER" description="ISSUERS_TICKER" />
+			<value enum="ISSUESIZE" description="ISSUE_SIZE_RANGE" />
+			<value enum="LOOKBACK" description="LOOKBACK_DAYS" />
+			<value enum="LOT" description="EXPLICIT_LOT_IDENTIFIER" />
+			<value enum="LOTVAR" description="LOT_VARIANCE" />
+			<value enum="MAT" description="MATURITY_YEAR_AND_MONTH" />
+			<value enum="MATURITY" description="MATURITY_RANGE" />
+			<value enum="MAXSUBS" description="MAXIMUM_SUBSTITUTIONS" />
+			<value enum="MINQTY" description="MINIMUM_QUANTITY" />
+			<value enum="MININCR" description="MINIMUM_INCREMENT" />
+			<value enum="MINDNOM" description="MINIMUM_DENOMINATION" />
+			<value enum="PAYFREQ" description="PAYMENT_FREQUENCY_CALENDAR" />
+			<value enum="PIECES" description="NUMBER_OF_PIECES" />
+			<value enum="PMAX" description="POOLS_MAXIMUM" />
+			<value enum="PPM" description="POOLS_PER_MILLION" />
+			<value enum="PPL" description="POOLS_PER_LOT" />
+			<value enum="PPT" description="POOLS_PER_TRADE" />
+			<value enum="PRICE" description="PRICE_RANGE" />
+			<value enum="PRICEFREQ" description="PRICING_FREQUENCY" />
+			<value enum="PROD" description="PRODUCTION_YEAR" />
+			<value enum="PROTECT" description="CALL_PROTECTION" />
+			<value enum="PURPOSE" description="PURPOSE" />
+			<value enum="PXSOURCE" description="BENCHMARK_PRICE_SOURCE" />
+			<value enum="RATING" description="RATING_SOURCE_AND_RANGE" />
+			<value enum="RESTRICTED" description="RESTRICTED" />
+			<value enum="SECTOR" description="MARKET_SECTOR" />
+			<value enum="SECTYPE" description="SECURITYTYPE_INCLUDED_OR_EXCLUDED" />
+			<value enum="STRUCT" description="STRUCTURE" />
+			<value enum="SUBSFREQ" description="SUBSTITUTIONS_FREQUENCY" />
+			<value enum="SUBSLEFT" description="SUBSTITUTIONS_LEFT" />
+			<value enum="TEXT" description="FREEFORM_TEXT" />
+			<value enum="TRDVAR" description="TRADE_VARIANCE" />
+			<value enum="WAC" description="WEIGHTED_AVERAGE_COUPON" />
+			<value enum="WAL" description="WEIGHTED_AVERAGE_LIFE_COUPON" />
+			<value enum="WALA" description="WEIGHTED_AVERAGE_LOAN_AGE" />
+			<value enum="WAM" description="WEIGHTED_AVERAGE_MATURITY" />
+			<value enum="WHOLE" description="WHOLE_POOL" />
+			<value enum="YIELD" description="YIELD_RANGE" />
+			<value enum="SMM" description="SINGLE_MONTHLY_MORTALITY" />
+			<value enum="CPR" description="CONSTANT_PREPAYMENT_RATE" />
+			<value enum="CPY" description="CONSTANT_PREPAYMENT_YIELD" />
+			<value enum="CPP" description="CONSTANT_PREPAYMENT_PENALTY" />
+			<value enum="ABS" description="ABSOLUTE_PREPAYMENT_SPEED" />
+			<value enum="MPR" description="MONTHLY_PREPAYMENT_RATE" />
+			<value enum="PSA" description="PERCENT_OF_BMA_PREPAYMENT_CURVE" />
+			<value enum="PPC" description="PERCENT_OF_PROSPECTUS_PREPAYMENT_CURVE" />
+			<value enum="MHP" description="PERCENT_OF_MANUFACTURED_HOUSING_PREPAYMENT_CURVE" />
+			<value enum="HEP" description="FINAL_CPR_OF_HOME_EQUITY_PREPAYMENT_CURVE" />
+		</field>
+		<field number="234" name="StipulationValue" type="STRING" >
+			<value enum="CD" description="SPECIAL_CUM_DIVIDEND" />
+			<value enum="XD" description="SPECIAL_EX_DIVIDEND" />
+			<value enum="CC" description="SPECIAL_CUM_COUPON" />
+			<value enum="XC" description="SPECIAL_EX_COUPON" />
+			<value enum="CB" description="SPECIAL_CUM_BONUS" />
+			<value enum="XB" description="SPECIAL_EX_BONUS" />
+			<value enum="CR" description="SPECIAL_CUM_RIGHTS" />
+			<value enum="XR" description="SPECIAL_EX_RIGHTS" />
+			<value enum="CP" description="SPECIAL_CUM_CAPITAL_REPAYMENTS" />
+			<value enum="XP" description="SPECIAL_EX_CAPITAL_REPAYMENTS" />
+			<value enum="CS" description="CASH_SETTLEMENT" />
+			<value enum="SP" description="SPECIAL_PRICE" />
+			<value enum="TR" description="REPORT_FOR_EUROPEAN_EQUITY_MARKET_SECURITIES" />
+			<value enum="GD" description="GUARANTEED_DELIVERY" />
+		</field>
+		<field number="235" name="YieldType" type="STRING" >
+			<value enum="AFTERTAX" description="AFTER_TAX_YIELD" />
+			<value enum="ANNUAL" description="ANNUAL_YIELD" />
+			<value enum="ATISSUE" description="YIELD_AT_ISSUE" />
+			<value enum="AVGMATURITY" description="YIELD_TO_AVERAGE_MATURITY" />
+			<value enum="BOOK" description="BOOK_YIELD" />
+			<value enum="CALL" description="YIELD_TO_NEXT_CALL" />
+			<value enum="CHANGE" description="YIELD_CHANGE_SINCE_CLOSE" />
+			<value enum="CLOSE" description="CLOSING_YIELD" />
+			<value enum="COMPOUND" description="COMPOUND_YIELD" />
+			<value enum="CURRENT" description="CURRENT_YIELD" />
+			<value enum="GROSS" description="TRUE_GROSS_YIELD" />
+			<value enum="GOVTEQUIV" description="GOVERNMENT_EQUIVALENT_YIELD" />
+			<value enum="INFLATION" description="YIELD_WITH_INFLATION_ASSUMPTION" />
+			<value enum="INVERSEFLOATER" description="INVERSE_FLOATER_BOND_YIELD" />
+			<value enum="LASTCLOSE" description="MOST_RECENT_CLOSING_YIELD" />
+			<value enum="LASTMONTH" description="CLOSING_YIELD_MOST_RECENT_MONTH" />
+			<value enum="LASTQUARTER" description="CLOSING_YIELD_MOST_RECENT_QUARTER" />
+			<value enum="LASTYEAR" description="CLOSING_YIELD_MOST_RECENT_YEAR" />
+			<value enum="LONGAVGLIFE" description="YIELD_TO_LONGEST_AVERAGE_LIFE" />
+			<value enum="MARK" description="MARK_TO_MARKET_YIELD" />
+			<value enum="MATURITY" description="YIELD_TO_MATURITY" />
+			<value enum="NEXTREFUND" description="YIELD_TO_NEXT_REFUND" />
+			<value enum="OPENAVG" description="OPEN_AVERAGE_YIELD" />
+			<value enum="PUT" description="YIELD_TO_NEXT_PUT" />
+			<value enum="PREVCLOSE" description="PREVIOUS_CLOSE_YIELD" />
+			<value enum="PROCEEDS" description="PROCEEDS_YIELD" />
+			<value enum="SEMIANNUAL" description="SEMI_ANNUAL_YIELD" />
+			<value enum="SHORTAVGLIFE" description="YIELD_TO_SHORTEST_AVERAGE_LIFE" />
+			<value enum="SIMPLE" description="SIMPLE_YIELD" />
+			<value enum="TAXEQUIV" description="TAX_EQUIVALENT_YIELD" />
+			<value enum="TENDER" description="YIELD_TO_TENDER_DATE" />
+			<value enum="TRUE" description="TRUE_YIELD" />
+			<value enum="VALUE1_32" description="YIELD_VALUE_OF_1_32" />
+			<value enum="WORST" description="YIELD_TO_WORST" />
+		</field>
+		<field number="236" name="Yield" type="PERCENTAGE" />
+		<field number="239" name="RepoCollateralSecurityType" type="INT" />
+		<field number="240" name="RedemptionDate" type="LOCALMKTDATE" />
+		<field number="241" name="UnderlyingCouponPaymentDate" type="LOCALMKTDATE" />
+		<field number="242" name="UnderlyingIssueDate" type="LOCALMKTDATE" />
+		<field number="243" name="UnderlyingRepoCollateralSecurityType" type="INT" />
+		<field number="244" name="UnderlyingRepurchaseTerm" type="INT" />
+		<field number="245" name="UnderlyingRepurchaseRate" type="PERCENTAGE" />
+		<field number="246" name="UnderlyingFactor" type="FLOAT" />
+		<field number="247" name="UnderlyingRedemptionDate" type="LOCALMKTDATE" />
+		<field number="248" name="LegCouponPaymentDate" type="LOCALMKTDATE" />
+		<field number="249" name="LegIssueDate" type="LOCALMKTDATE" />
+		<field number="250" name="LegRepoCollateralSecurityType" type="INT" />
+		<field number="251" name="LegRepurchaseTerm" type="INT" />
+		<field number="252" name="LegRepurchaseRate" type="PERCENTAGE" />
+		<field number="253" name="LegFactor" type="FLOAT" />
+		<field number="254" name="LegRedemptionDate" type="LOCALMKTDATE" />
+		<field number="255" name="CreditRating" type="STRING" />
+		<field number="256" name="UnderlyingCreditRating" type="STRING" />
+		<field number="257" name="LegCreditRating" type="STRING" />
+		<field number="262" name="MDReqID" type="STRING" />
+		<field number="263" name="SubscriptionRequestType" type="CHAR" >
+			<value enum="0" description="SNAPSHOT" />
+			<value enum="1" description="SNAPSHOT_PLUS_UPDATES" />
+			<value enum="2" description="DISABLE_PREVIOUS_SNAPSHOT_PLUS_UPDATE_REQUEST" />
+		</field>
+		<field number="264" name="MarketDepth" type="INT" />
+		<field number="265" name="MDUpdateType" type="INT" >
+			<value enum="0" description="FULL_REFRESH" />
+			<value enum="1" description="INCREMENTAL_REFRESH" />
+		</field>
+		<field number="267" name="NoMDEntryTypes" type="NUMINGROUP" />
+		<field number="268" name="NoMDEntries" type="NUMINGROUP" />
+		<field number="269" name="MDEntryType" type="CHAR" >
+			<value enum="0" description="BID" />
+			<value enum="1" description="OFFER" />
+			<value enum="2" description="TRADE" />
+			<value enum="3" description="INDEX_VALUE" />
+			<value enum="4" description="OPENING_PRICE" />
+			<value enum="5" description="CLOSING_PRICE" />
+			<value enum="6" description="SETTLEMENT_PRICE" />
+			<value enum="7" description="TRADING_SESSION_HIGH_PRICE" />
+			<value enum="8" description="TRADING_SESSION_LOW_PRICE" />
+			<value enum="9" description="TRADING_SESSION_VWAP_PRICE" />
+			<value enum="A" description="Imbalance" />
+			<value enum="B" description="TRADE_VOLUME" />
+			<value enum="C" description="OPEN_INTEREST" />
+			<value enum="D" description="COMPOSITE_UNDERLYING_PRICE" />
+			<value enum="J" description="REBUILD_BOOK" />
+			<value enum="X" description="TOP_OF_BOOK_OFFER" />
+			<value enum="Z" description="TOP_OF_BOOK_BID" />
+			<value enum="a" description="REFERENTIAL_PRICES" />
+			<value enum="b" description="TRADING_PHASE" />
+			<value enum="c" description="TRADING_STATUS" />
+			<value enum="e" description="AGGREGATE_BID" />
+			<value enum="f" description="AGGREGATE_OFFER" />
+			<value enum="g" description="PRICE_BAND" />
+			<value enum="h" description="QUALITY_BAND" />
+			<value enum="t" description="MARKET_TOTAL_BROADCAST" />
+			<value enum="v" description="VOLATILITY_PRICE" />
+		</field>
+		<field number="270" name="MDEntryPx" type="PRICE" />
+		<field number="271" name="MDEntrySize" type="QTY" />
+		<field number="272" name="MDEntryDate" type="UTCDATEONLY" />
+		<field number="273" name="MDEntryTime" type="UTCTIMEONLY" />
+		<field number="274" name="TickDirection" type="CHAR" >
+			<value enum="0" description="PLUS_TICK" />
+			<value enum="1" description="ZERO_PLUS_TICK" />
+			<value enum="2" description="MINUS_TICK" />
+			<value enum="3" description="ZERO_MINUS_TICK" />
+		</field>
+		<field number="275" name="MDMkt" type="EXCHANGE" />
+		<field number="276" name="QuoteCondition" type="MULTIPLEVALUESTRING" >
+			<value enum="A" description="OPEN_ACTIVE" />
+			<value enum="B" description="CLOSED_INACTIVE" />
+			<value enum="C" description="EXCHANGE_BEST" />
+			<value enum="D" description="CONSOLIDATED_BEST" />
+			<value enum="E" description="LOCKED" />
+			<value enum="F" description="CROSSED" />
+			<value enum="G" description="DEPTH" />
+			<value enum="H" description="FAST_TRADING" />
+			<value enum="I" description="NON_FIRM" />
+			<value enum="R" description="ORDER_RETRANSMISSION" />
+			<value enum="K" description="IMPLIED_PRICE" />
+			<value enum="LM" description="BTB_LIMITED_ORDER" />
+			<value enum="AN" description="BTB_ALL_OR_NOTHING_ORDER" />
+		</field>
+		<field number="277" name="TradeCondition" type="MULTIPLEVALUESTRING" >
+			<value enum="A" description="CASH_MARKET" />
+			<value enum="B" description="AVERAGE_PRICE_TRADE" />
+			<value enum="C" description="CASH_TRADE" />
+			<value enum="D" description="NEXT_DAY_MARKET" />
+			<value enum="E" description="OPENING_REOPENING_TRADE_DETAIL" />
+			<value enum="F" description="INTRADAY_TRADE_DETAIL" />
+			<value enum="G" description="RULE127" />
+			<value enum="H" description="RULE155" />
+			<value enum="I" description="SOLD_LAST" />
+			<value enum="J" description="NEXT_DAY_TRADE" />
+			<value enum="K" description="OPENED" />
+			<value enum="L" description="SELLER" />
+			<value enum="M" description="SOLD" />
+			<value enum="N" description="STOPPED_STOCK" />
+			<value enum="P" description="IMBALANCE_MORE_BUYERS" />
+			<value enum="Q" description="IMBALANCE_MORE_SELLERS" />
+			<value enum="R" description="OPENING_PRICE" />
+			<value enum="U" description="EXCHANGE_LAST" />
+			<value enum="X" description="CROSSED" />
+			<value enum="1" description="LEG_TRADE" />
+			<value enum="2" description="MARKETPLACE_ENTERED_TRADE" />
+			<value enum="3" description="MULTI_ASSET_TRADE" />
+			<value enum="IM" description="IMPLIED" />
+			<value enum="RF" description="REQUEST_FOR_QUOTE" />
+			<value enum="RL" description="RLP_TRADE" />
+			<value enum="MP" description="PEGGED_MIDPOINT_TRADE" />
+			<value enum="PT" description="BLOCK_BOOK_TRADE" />
+			<value enum="TC" description="TRADE_AT_CLOSE" />
+			<value enum="TA" description="TRADE_AT_AVERAGE" />
+			<value enum="SW" description="SWEEP" />
+		</field>
+		<field number="278" name="MDEntryID" type="STRING" />
+		<field number="279" name="MDUpdateAction" type="CHAR" >
+			<value enum="0" description="NEW" />
+			<value enum="1" description="CHANGE" />
+			<value enum="2" description="DELETE" />
+			<value enum="3" description="DELETE_THRU" />
+			<value enum="4" description="DELETE_FROM" />
+			<value enum="5" description="OVERLAY" />
+		</field>
+		<field number="280" name="MDEntryRefID" type="STRING" />
+		<field number="281" name="MDReqRejReason" type="CHAR" >
+			<value enum="0" description="UNKNOWN_SYMBOL" />
+			<value enum="1" description="DUPLICATE_MDREQID" />
+			<value enum="2" description="INSUFFICIENT_BANDWIDTH" />
+			<value enum="3" description="INSUFFICIENT_PERMISSIONS" />
+			<value enum="4" description="UNSUPPORTED_SUBSCRIPTIONREQUESTTYPE" />
+			<value enum="5" description="UNSUPPORTED_MARKETDEPTH" />
+			<value enum="6" description="UNSUPPORTED_MDUPDATETYPE" />
+			<value enum="7" description="UNSUPPORTED_AGGREGATEDBOOK" />
+			<value enum="8" description="UNSUPPORTED_MDENTRYTYPE" />
+			<value enum="9" description="UNSUPPORTED_TRADINGSESSIONID" />
+			<value enum="A" description="UNSUPPORTED_SCOPE" />
+			<value enum="B" description="UNSUPPORTED_OPENCLOSESETTLEFLAG" />
+			<value enum="C" description="UNSUPPORTED_MDIMPLICITDELETE" />
+			<value enum="M" description="MAXIMUM_NUMBER_OF_SUBSCRIPTIONS_EXCEEDED" />
+			<value enum="T" description="PROCESSING_OF_PRIOR_REQUEST_IN_PROGRESS" />
+			<value enum="Y" description="MDREQID_NOT_FOUND" />
+			<value enum="Z" description="INVALID_REQUEST" />
+			<value enum="X" description="REQUEST_NOT_PROCESSED" />
+		</field>
+		<field number="282" name="MDEntryOriginator" type="STRING" />
+		<field number="283" name="LocationID" type="STRING" />
+		<field number="284" name="DeskID" type="STRING" />
+		<field number="285" name="DeleteReason" type="CHAR" >
+			<value enum="0" description="CANCELATION_TRADE_BUST" />
+			<value enum="1" description="ERROR" />
+		</field>
+		<field number="286" name="OpenCloseSettlFlag" type="MULTIPLEVALUESTRING" >
+			<value enum="0" description="DAILY_OPEN_CLOSE_SETTLEMENT_ENTRY" />
+			<value enum="1" description="SESSION_OPEN_CLOSE_SETTLEMENT_ENTRY" />
+			<value enum="2" description="DELIVERY_SETTLEMENT_ENTRY" />
+			<value enum="3" description="EXPECTED_ENTRY" />
+			<value enum="4" description="ENTRY_FROM_PREVIOUS_BUSINESS_DAY" />
+			<value enum="5" description="THEORETICAL_PRICE_VALUE" />
+		</field>
+		<field number="287" name="SellerDays" type="INT" />
+		<field number="288" name="MDEntryBuyer" type="STRING" />
+		<field number="289" name="MDEntrySeller" type="STRING" />
+		<field number="290" name="MDEntryPositionNo" type="INT" />
+		<field number="291" name="FinancialStatus" type="MULTIPLEVALUESTRING" >
+			<value enum="1" description="BANKRUPT" />
+			<value enum="2" description="PENDING_DELISTING" />
+		</field>
+		<field number="292" name="CorporateAction" type="MULTIPLEVALUESTRING" >
+			<value enum="A" description="EX_DIVIDEND" />
+			<value enum="B" description="EX_DISTRIBUTION" />
+			<value enum="C" description="EX_RIGHTS" />
+			<value enum="D" description="NEW" />
+			<value enum="E" description="EX_INTEREST" />
+		</field>
+		<field number="299" name="QuoteEntryID" type="STRING" />
+		<field number="305" name="UnderlyingSecurityIDSource" type="STRING" />
+		<field number="306" name="UnderlyingIssuer" type="STRING" />
+		<field number="307" name="UnderlyingSecurityDesc" type="STRING" />
+		<field number="308" name="UnderlyingSecurityExchange" type="EXCHANGE" />
+		<field number="309" name="UnderlyingSecurityID" type="STRING" />
+		<field number="310" name="UnderlyingSecurityType" type="STRING" />
+		<field number="311" name="UnderlyingSymbol" type="STRING" />
+		<field number="312" name="UnderlyingSymbolSfx" type="STRING" />
+		<field number="313" name="UnderlyingMaturityMonthYear" type="MONTHYEAR" />
+		<field number="316" name="UnderlyingStrikePrice" type="PRICE" />
+		<field number="317" name="UnderlyingOptAttribute" type="CHAR" />
+		<field number="318" name="UnderlyingCurrency" type="CURRENCY" />
+		<field number="320" name="SecurityReqID" type="STRING" />
+		<field number="322" name="SecurityResponseID" type="STRING" />
+		<field number="324" name="SecurityStatusReqID" type="STRING" />
+		<field number="325" name="UnsolicitedIndicator" type="BOOLEAN" />
+		<field number="326" name="SecurityTradingStatus" type="INT" >
+			<value enum="1" description="OPENING_DELAY" />
+			<value enum="2" description="TRADING_HALT" />
+			<value enum="3" description="RESUME" />
+			<value enum="4" description="NO_OPEN_NO_RESUME" />
+			<value enum="5" description="PRICE_INDICATION" />
+			<value enum="6" description="TRADING_RANGE_INDICATION" />
+			<value enum="7" description="MARKET_IMBALANCE_BUY" />
+			<value enum="8" description="MARKET_IMBALANCE_SELL" />
+			<value enum="9" description="MARKET_ON_CLOSE_IMBALANCE_BUY" />
+			<value enum="10" description="MARKET_ON_CLOSE_IMBALANCE_SELL" />
+			<value enum="12" description="NO_MARKET_IMBALANCE" />
+			<value enum="13" description="NO_MARKET_ON_CLOSE_IMBALANCE" />
+			<value enum="14" description="ITS_PRE_OPENING" />
+			<value enum="15" description="NEW_PRICE_INDICATION" />
+			<value enum="16" description="TRADE_DISSEMINATION_TIME" />
+			<value enum="17" description="READY_TO_TRADE" />
+			<value enum="18" description="NOT_AVAILABLE_FOR_TRADING" />
+			<value enum="19" description="NOT_TRADED_ON_THIS_MARKET" />
+			<value enum="20" description="UNKNOWN_OR_INVALID" />
+			<value enum="21" description="PRE_OPEN" />
+			<value enum="22" description="OPENING_ROTATION" />
+			<value enum="23" description="FAST_MARKET" />
+			<value enum="100" description="NOT_STARTED" />
+			<value enum="101" description="TRADING" />
+			<value enum="102" description="AUCTION" />
+			<value enum="103" description="FORBIDDEN" />
+			<value enum="104" description="AUTHORIZED" />
+			<value enum="105" description="SUSPENDED" />
+			<value enum="106" description="PRE_AUCTION" />
+			<value enum="107" description="POST_AUCTION" />
+			<value enum="108" description="REVOKED" />
+			<value enum="109" description="CANCELED" />
+			<value enum="110" description="MATCHING" />
+			<value enum="111" description="NO_BIDDER" />
+			<value enum="112" description="MINIMUN_BID_NOT_REACHED" />
+			<value enum="113" description="ADJUDICADO" />
+			<value enum="114" description="ACCEPTED" />
+			<value enum="115" description="IMPUGNADO" />
+			<value enum="116" description="FORBIDDEN_AUCTION" />
+			<value enum="117" description="SUBJECT_TO_INTERFERENCE" />
+			<value enum="118" description="FROZEN" />
+			<value enum="119" description="EXTENDED_AUCTION" />
+			<value enum="120" description="EXPIRED" />
+			<value enum="121" description="RANDOM_CLOSING" />
+			<value enum="122" description="HALTED" />
+			<value enum="123" description="FORBIDDEN_SUSPENDED" />
+			<value enum="124" description="FORBIDDEN_TRADING" />
+			<value enum="125" description="FORBIDDEN_FROZEN" />
+		</field>
+		<field number="327" name="HaltReason" type="CHAR" >
+			<value enum="I" description="ORDER_IMBALANCE" />
+			<value enum="X" description="EQUIPMENT_CHANGEOVER" />
+			<value enum="P" description="NEWS_PENDING" />
+			<value enum="D" description="NEWS_DISSEMINATION" />
+			<value enum="E" description="ORDER_INFLUX" />
+			<value enum="M" description="ADDITIONAL_INFORMATION" />
+		</field>
+		<field number="328" name="InViewOfCommon" type="BOOLEAN" />
+		<field number="329" name="DueToRelated" type="BOOLEAN" />
+		<field number="330" name="BuyVolume" type="QTY" />
+		<field number="331" name="SellVolume" type="QTY" />
+		<field number="332" name="HighPx" type="PRICE" />
+		<field number="333" name="LowPx" type="PRICE" />
+		<field number="334" name="Adjustment" type="INT" >
+			<value enum="1" description="CANCEL" />
+			<value enum="2" description="ERROR" />
+			<value enum="3" description="CORRECTION" />
+		</field>
+		<field number="336" name="TradingSessionID" type="STRING" />
+		<field number="342" name="TradSesOpenTime" type="UTCTIMESTAMP" />
+		<field number="346" name="NumberOfOrders" type="INT" />
+		<field number="347" name="MessageEncoding" type="STRING" >
+			<value enum="ISO-2022-JP" description="ISO_2022_JP" />
+			<value enum="EUC-JP" description="EUC_JP" />
+			<value enum="SHIFT_JIS" description="SHIFT_JIS" />
+			<value enum="UTF-8" description="UTF_8" />
+		</field>
+		<field number="348" name="EncodedIssuerLen" type="LENGTH" />
+		<field number="349" name="EncodedIssuer" type="DATA" />
+		<field number="350" name="EncodedSecurityDescLen" type="LENGTH" />
+		<field number="351" name="EncodedSecurityDesc" type="DATA" />
+		<field number="354" name="EncodedTextLen" type="LENGTH" />
+		<field number="355" name="EncodedText" type="DATA" />
+		<field number="358" name="EncodedHeadlineLen" type="LENGTH" />
+		<field number="359" name="EncodedHeadline" type="DATA" />
+		<field number="362" name="EncodedUnderlyingIssuerLen" type="LENGTH" />
+		<field number="363" name="EncodedUnderlyingIssuer" type="DATA" />
+		<field number="364" name="EncodedUnderlyingSecurityDescLen" type="LENGTH" />
+		<field number="365" name="EncodedUnderlyingSecurityDesc" type="DATA" />
+		<field number="369" name="LastMsgSeqNumProcessed" type="SEQNUM" />
+		<field number="371" name="RefTagID" type="INT" />
+		<field number="372" name="RefMsgType" type="STRING" />
+		<field number="373" name="SessionRejectReason" type="INT" >
+			<value enum="0" description="INVALID_TAG_NUMBER" />
+			<value enum="1" description="REQUIRED_TAG_MISSING" />
+			<value enum="2" description="TAG_NOT_DEFINED_FOR_THIS_MESSAGE_TYPE" />
+			<value enum="3" description="UNDEFINED_TAG" />
+			<value enum="4" description="TAG_SPECIFIED_WITHOUT_A_VALUE" />
+			<value enum="5" description="VALUE_IS_INCORRECT" />
+			<value enum="6" description="INCORRECT_DATA_FORMAT_FOR_VALUE" />
+			<value enum="7" description="DECRYPTION_PROBLEM" />
+			<value enum="8" description="SIGNATURE_PROBLEM" />
+			<value enum="9" description="COMPID_PROBLEM" />
+			<value enum="10" description="SENDINGTIME_ACCURACY_PROBLEM" />
+			<value enum="11" description="INVALID_MSGTYPE" />
+			<value enum="12" description="XML_VALIDATION_ERROR" />
+			<value enum="13" description="TAG_APPEARS_MORE_THAN_ONCE" />
+			<value enum="14" description="TAG_SPECIFIED_OUT_OF_REQUIRED_ORDER" />
+			<value enum="15" description="REPEATING_GROUP_FIELDS_OUT_OF_ORDER" />
+			<value enum="16" description="INCORRECT_NUMINGROUP_COUNT_FOR_REPEATING_GROUP" />
+			<value enum="17" description="NON_DATA_VALUE_INCLUDES_FIELD_DELIMITER" />
+			<value enum="99" description="OTHER" />
+		</field>
+		<field number="379" name="BusinessRejectRefID" type="STRING" />
+		<field number="380" name="BusinessRejectReason" type="INT" >
+			<value enum="0" description="OTHER" />
+			<value enum="1" description="UNKOWN_ID" />
+			<value enum="2" description="UNKNOWN_SECURITY" />
+			<value enum="3" description="UNSUPPORTED_MESSAGE_TYPE" />
+			<value enum="4" description="APPLICATION_NOT_AVAILABLE" />
+			<value enum="5" description="CONDITIONALLY_REQUIRED_FIELD_MISSING" />
+			<value enum="6" description="NOT_AUTHORIZED" />
+			<value enum="7" description="DELIVERTO_FIRM_NOT_AVAILABLE_AT_THIS_TIME" />
+			<value enum="99" description="THROTTLE_LIMIT_EXCEEDED" />
+		</field>
+		<field number="381" name="GrossTradeAmt" type="AMT" />
+		<field number="383" name="MaxMessageSize" type="LENGTH" />
+		<field number="384" name="NoMsgTypes" type="NUMINGROUP" />
+		<field number="385" name="MsgDirection" type="CHAR" >
+			<value enum="S" description="SEND" />
+			<value enum="R" description="RECEIVE" />
+		</field>
+		<field number="387" name="TotalVolumeTraded" type="QTY" />
+		<field number="393" name="TotNoRelatedSym" type="INT" />
+		<field number="423" name="PriceType" type="INT" >
+			<value enum="1" description="PERCENTAGE" />
+			<value enum="2" description="PER_UNIT" />
+			<value enum="3" description="FIXED_AMOUNT" />
+			<value enum="4" description="DISCOUNT" />
+			<value enum="5" description="PREMIUM" />
+			<value enum="6" description="SPREAD" />
+			<value enum="7" description="TED_PRICE" />
+			<value enum="8" description="TED_YIELD" />
+			<value enum="9" description="YIELD" />
+			<value enum="12" description="FULL_TICK" />
+			<value enum="13" description="HALFS" />
+			<value enum="14" description="FOURTHS" />
+			<value enum="15" description="EIGHTHS" />
+			<value enum="16" description="SIXTEENTHS" />
+			<value enum="17" description="THIRTY_SECONDS" />
+			<value enum="18" description="SIXTY_FOURTHS" />
+			<value enum="20" description="HALF_THIRTY_SECONDS" />
+			<value enum="21" description="QUARTER_THIRTY_SECONDS" />
+			<value enum="22" description="HALF_SIXTY_FOURTHS" />
+		</field>
+		<field number="432" name="ExpireDate" type="LOCALMKTDATE" />
+		<field number="435" name="UnderlyingCouponRate" type="PERCENTAGE" />
+		<field number="436" name="UnderlyingContractMultiplier" type="FLOAT" />
+		<field number="447" name="PartyIDSource" type="CHAR" >
+			<value enum="B" description="BIC" />
+			<value enum="C" description="GENERALLY_ACCEPTED_MARKET_PARTICIPANT_IDENTIFIER" />
+			<value enum="D" description="PROPRIETARY_CUSTOM_CODE" />
+			<value enum="E" description="ISO_COUNTRY_CODE" />
+			<value enum="F" description="SETTLEMENT_ENTITY_LOCATION" />
+			<value enum="G" description="MIC" />
+			<value enum="H" description="CSD_PARTICIPANT_MEMBER_CODE" />
+			<value enum="1" description="KOREAN_INVESTOR_ID" />
+			<value enum="2" description="TAIWANESE_QUALIFIED_FOREIGN_INVESTOR_ID_QFII_FID" />
+			<value enum="3" description="TAIWANESE_TRADING_ACCOUNT" />
+			<value enum="4" description="MALAYSIAN_CENTRAL_DEPOSITORY_NUMBER" />
+			<value enum="5" description="CHINESE_B_SHARE" />
+			<value enum="6" description="UK_NATIONAL_INSURANCE_OR_PENSION_NUMBER" />
+			<value enum="7" description="US_SOCIAL_SECURITY_NUMBER" />
+			<value enum="8" description="US_EMPLOYER_IDENTIFICATION_NUMBER" />
+			<value enum="9" description="AUSTRALIAN_BUSINESS_NUMBER" />
+			<value enum="A" description="AUSTRALIAN_TAX_FILE_NUMBER" />
+			<value enum="I" description="DIRECTED_BROKER" />
+		</field>
+		<field number="448" name="PartyID" type="STRING" />
+		<field number="451" name="NetChgPrevDay" type="PRICEOFFSET" />
+		<field number="452" name="PartyRole" type="INT" >
+			<value enum="1" description="EXECUTING_FIRM" />
+			<value enum="2" description="BROKER_OF_CREDIT" />
+			<value enum="3" description="CLIENT_ID" />
+			<value enum="4" description="CLEARING_FIRM" />
+			<value enum="5" description="INVESTOR_ID" />
+			<value enum="6" description="INTRODUCING_FIRM" />
+			<value enum="7" description="ENTERING_FIRM" />
+			<value enum="8" description="LOCATE_LENDING_FIRM" />
+			<value enum="9" description="FUND_MANAGER_CLIENT_ID" />
+			<value enum="10" description="SETTLEMENT_LOCATION" />
+			<value enum="11" description="ORDER_ORIGINATION_TRADER" />
+			<value enum="12" description="EXECUTING_TRADER" />
+			<value enum="13" description="ORDER_ORIGINATION_FIRM" />
+			<value enum="14" description="GIVEUP_CLEARING_FIRM" />
+			<value enum="15" description="CORRESPONDANT_CLEARING_FIRM" />
+			<value enum="16" description="EXECUTING_SYSTEM" />
+			<value enum="17" description="CONTRA_FIRM" />
+			<value enum="18" description="CONTRA_CLEARING_FIRM" />
+			<value enum="19" description="SPONSORING_FIRM" />
+			<value enum="20" description="UNDERLYING_CONTRA_FIRM" />
+			<value enum="21" description="CLEARING_ORGANIZATION" />
+			<value enum="22" description="EXCHANGE" />
+			<value enum="24" description="CUSTOMER_ACCOUNT" />
+			<value enum="25" description="CORRESPONDENT_CLEARING_ORGANIZATION" />
+			<value enum="26" description="CORRESPONDENT_BROKER" />
+			<value enum="27" description="BUYER_SELLER" />
+			<value enum="28" description="CUSTODIAN" />
+			<value enum="29" description="INTERMEDIARY" />
+			<value enum="30" description="AGENT" />
+			<value enum="31" description="SUB_CUSTODIAN" />
+			<value enum="32" description="BENEFICIARY" />
+			<value enum="33" description="INTERESTED_PARTY" />
+			<value enum="34" description="REGULATORY_BODY" />
+			<value enum="36" description="ENTERING_TRADER" />
+			<value enum="37" description="CONTRA_TRADER" />
+			<value enum="38" description="POSITION_ACCOUNT" />
+			<value enum="40" description="TRANSFER_TO_FIRM" />
+			<value enum="44" description="ORDER_ENTRY_OPERATOR_ID" />
+			<value enum="45" description="SECONDARY_ACCOUNT_NUMBER" />
+			<value enum="54" description="SENDER_LOCATION" />
+			<value enum="55" description="SESSION_ID" />
+			<value enum="76" description="DESK_ID" />
+		</field>
+		<field number="453" name="NoPartyIDs" type="NUMINGROUP" />
+		<field number="454" name="NoSecurityAltID" type="NUMINGROUP" />
+		<field number="455" name="SecurityAltID" type="STRING" />
+		<field number="456" name="SecurityAltIDSource" type="STRING" />
+		<field number="457" name="NoUnderlyingSecurityAltID" type="NUMINGROUP" />
+		<field number="458" name="UnderlyingSecurityAltID" type="STRING" />
+		<field number="459" name="UnderlyingSecurityAltIDSource" type="STRING" />
+		<field number="460" name="Product" type="INT" >
+			<value enum="1" description="AGENCY" />
+			<value enum="2" description="COMMODITY" />
+			<value enum="3" description="CORPORATE" />
+			<value enum="4" description="CURRENCY" />
+			<value enum="5" description="EQUITY" />
+			<value enum="6" description="GOVERNMENT" />
+			<value enum="7" description="INDEX" />
+			<value enum="8" description="LOAN" />
+			<value enum="9" description="MONEYMARKET" />
+			<value enum="10" description="MORTGAGE" />
+			<value enum="11" description="MUNICIPAL" />
+			<value enum="12" description="OTHER" />
+			<value enum="13" description="FINANCING" />
+			<value enum="14" description="CARBON_CREDIT" />
+			<value enum="15" description="INDICATOR" />
+			<value enum="16" description="MULTILEG" />
+			<value enum="95" description="MAIS" />
+			<value enum="96" description="MERCADO_BALCAO" />
+		</field>
+		<field number="461" name="CFICode" type="STRING" />
+		<field number="462" name="UnderlyingProduct" type="INT" />
+		<field number="463" name="UnderlyingCFICode" type="STRING" />
+		<field number="464" name="TestMessageIndicator" type="BOOLEAN" />
+		<field number="470" name="CountryOfIssue" type="COUNTRY" />
+		<field number="471" name="StateOrProvinceOfIssue" type="STRING" />
+		<field number="472" name="LocaleOfIssue" type="STRING" />
+		<field number="523" name="PartySubID" type="STRING" />
+		<field number="525" name="NestedPartyIDSource" type="CHAR" />
+		<field number="541" name="MaturityDate" type="LOCALMKTDATE" />
+		<field number="542" name="UnderlyingMaturityDate" type="LOCALMKTDATE" />
+		<field number="543" name="InstrRegistry" type="STRING" />
+		<field number="546" name="Scope" type="MULTIPLEVALUESTRING" >
+			<value enum="1" description="LOCAL" />
+			<value enum="2" description="NATIONAL" />
+			<value enum="3" description="GLOBAL" />
+		</field>
+		<field number="553" name="Username" type="STRING" />
+		<field number="554" name="Password" type="STRING" />
+		<field number="555" name="NoLegs" type="NUMINGROUP" />
+		<field number="556" name="LegCurrency" type="CURRENCY" />
+		<field number="559" name="SecurityListRequestType" type="INT" >
+			<value enum="0" description="SYMBOL" />
+			<value enum="1" description="SECURITYTYPE_AND_OR_CFICODE" />
+			<value enum="2" description="PRODUCT" />
+			<value enum="3" description="TRADINGSESSIONID" />
+			<value enum="4" description="ALL_SECURITIES" />
+			<value enum="5" description="ASSET" />
+		</field>
+		<field number="560" name="SecurityRequestResult" type="CHAR" >
+			<value enum="0" description="VALID_REQUEST" />
+			<value enum="1" description="INVALID_OR_UNSUPPORTED_REQUEST" />
+			<value enum="2" description="NO_INSTRUMENTS_FOUND_THAT_MATCH_SELECTION_CRITERIA" />
+			<value enum="3" description="NOT_AUTHORIZED_TO_RETRIEVE_INSTRUMENT_DATA" />
+			<value enum="4" description="INSTRUMENT_DATA_TEMPORARILY_UNAVAILABLE" />
+			<value enum="5" description="REQUEST_FOR_INSTRUMENT_DATA_NOT_SUPPORTED" />
+			<value enum="6" description="DUPLICATE_SECURITYREQID" />
+			<value enum="7" description="REQUEST_QUEUED" />
+			<value enum="M" description="MAXIMUM_NUMBER_OF_SUBSCRIPTIONS_EXCEEDED" />
+		</field>
+		<field number="561" name="RoundLot" type="QTY" />
+		<field number="562" name="MinTradeVol" type="QTY" />
+		<field number="574" name="MatchType" type="STRING" />
+		<field number="587" name="LegSettlType" type="CHAR" />
+		<field number="592" name="UnderlyingCountryOfIssue" type="COUNTRY" />
+		<field number="593" name="UnderlyingStateOrProvinceOfIssue" type="STRING" />
+		<field number="594" name="UnderlyingLocaleOfIssue" type="STRING" />
+		<field number="595" name="UnderlyingInstrRegistry" type="STRING" />
+		<field number="596" name="LegCountryOfIssue" type="COUNTRY" />
+		<field number="597" name="LegStateOrProvinceOfIssue" type="STRING" />
+		<field number="598" name="LegLocaleOfIssue" type="STRING" />
+		<field number="599" name="LegInstrRegistry" type="STRING" />
+		<field number="600" name="LegSymbol" type="STRING" />
+		<field number="601" name="LegSymbolSfx" type="STRING" />
+		<field number="602" name="LegSecurityID" type="STRING" />
+		<field number="603" name="LegSecurityIDSource" type="STRING" />
+		<field number="604" name="NoLegSecurityAltID" type="STRING" />
+		<field number="605" name="LegSecurityAltID" type="STRING" />
+		<field number="606" name="LegSecurityAltIDSource" type="STRING" />
+		<field number="607" name="LegProduct" type="INT" />
+		<field number="608" name="LegCFICode" type="STRING" />
+		<field number="609" name="LegSecurityType" type="STRING" />
+		<field number="610" name="LegMaturityMonthYear" type="MONTHYEAR" />
+		<field number="611" name="LegMaturityDate" type="LOCALMKTDATE" />
+		<field number="612" name="LegStrikePrice" type="PRICE" />
+		<field number="613" name="LegOptAttribute" type="CHAR" />
+		<field number="614" name="LegContractMultiplier" type="FLOAT" />
+		<field number="615" name="LegCouponRate" type="PERCENTAGE" />
+		<field number="616" name="LegSecurityExchange" type="EXCHANGE" />
+		<field number="617" name="LegIssuer" type="STRING" />
+		<field number="618" name="EncodedLegIssuerLen" type="LENGTH" />
+		<field number="619" name="EncodedLegIssuer" type="DATA" />
+		<field number="620" name="LegSecurityDesc" type="STRING" />
+		<field number="621" name="EncodedLegSecurityDescLen" type="LENGTH" />
+		<field number="622" name="EncodedLegSecurityDesc" type="DATA" />
+		<field number="623" name="LegRatioQty" type="FLOAT" />
+		<field number="624" name="LegSide" type="CHAR" >
+			<value enum="1" description="BUY" />
+			<value enum="2" description="SELL" />
+		</field>
+		<field number="625" name="TradingSessionSubID" type="STRING" />
+		<field number="627" name="NoHops" type="NUMINGROUP" />
+		<field number="628" name="HopCompID" type="STRING" />
+		<field number="629" name="HopSendingTime" type="UTCTIMESTAMP" />
+		<field number="630" name="HopRefID" type="SEQNUM" />
+		<field number="662" name="BenchmarkPrice" type="PRICE" />
+		<field number="663" name="BenchmarkPriceType" type="INT" />
+		<field number="667" name="ContractSettlMonth" type="MONTHYEAR" />
+		<field number="668" name="DeliveryForm" type="INT" >
+			<value enum="1" description="BOOKENTRY" />
+			<value enum="2" description="BEARER" />
+		</field>
+		<field number="676" name="LegBenchmarkCurveCurrency" type="CURRENCY" />
+		<field number="677" name="LegBenchmarkCurveName" type="STRING" />
+		<field number="678" name="LegBenchmarkCurvePoint" type="STRING" />
+		<field number="679" name="LegBenchmarkPrice" type="PRICE" />
+		<field number="680" name="LegBenchmarkPriceType" type="INT" />
+		<field number="683" name="NoLegStipulations" type="NUMINGROUP" />
+		<field number="688" name="LegStipulationType" type="STRING" />
+		<field number="689" name="LegStipulationValue" type="STRING" />
+		<field number="690" name="LegSwapType" type="INT" >
+			<value enum="1" description="PAR_FOR_PAR" />
+			<value enum="2" description="MODIFIED_DURATION" />
+			<value enum="4" description="RISK" />
+			<value enum="5" description="PROCEEDS" />
+		</field>
+		<field number="691" name="Pool" type="STRING" />
+		<field number="696" name="YieldRedemptionDate" type="LOCALMKTDATE" />
+		<field number="697" name="YieldRedemptionPrice" type="PRICE" />
+		<field number="698" name="YieldRedemptionPriceType" type="INT" />
+		<field number="699" name="BenchmarkSecurityID" type="STRING" />
+		<field number="701" name="YieldCalcDate" type="LOCALMKTDATE" />
+		<field number="711" name="NoUnderlyings" type="NUMINGROUP" />
+		<field number="715" name="ClearingBusinessDate" type="LOCALMKTDATE" />
+		<field number="731" name="SettlPriceType" type="INT" >
+			<value enum="1" description="FINAL" />
+			<value enum="2" description="THEORETICAL" />
+			<value enum="3" description="UPDATED" />
+		</field>
+		<field number="739" name="LegDatedDate" type="LOCALMKTDATE" />
+		<field number="740" name="LegPool" type="STRING" />
+		<field number="761" name="BenchmarkSecurityIDSource" type="STRING" />
+		<field number="762" name="SecuritySubType" type="STRING" />
+		<field number="763" name="UnderlyingSecuritySubType" type="STRING" />
+		<field number="764" name="LegSecuritySubType" type="STRING" />
+		<field number="788" name="TerminationType" type="INT" >
+			<value enum="1" description="OVERNIGHT" />
+			<value enum="2" description="TERM" />
+			<value enum="3" description="FLEXIBLE" />
+			<value enum="4" description="OPEN" />
+		</field>
+		<field number="789" name="NextExpectedMsgSeqNum" type="SEQNUM" />
+		<field number="802" name="NoPartySubIDs" type="NUMINGROUP" />
+		<field number="803" name="PartySubIDType" type="INT" />
+		<field number="810" name="UnderlyingPx" type="PRICE" />
+		<field number="811" name="PriceDelta" type="FLOAT" />
+		<field number="813" name="ApplQueueDepth" type="INT" />
+		<field number="814" name="ApplQueueResolution" type="INT" >
+			<value enum="0" description="NO_ACTION_TAKEN" />
+			<value enum="1" description="QUEUE_FLUSHED" />
+			<value enum="2" description="OVERLAY_LAST" />
+			<value enum="3" description="END_SESSION" />
+		</field>
+		<field number="827" name="ExpirationCycle" type="INT" >
+			<value enum="0" description="EXPIRE_ON_TRADING_SESSION_CLOSE" />
+			<value enum="1" description="EXPIRE_ON_TRADING_SESSION_OPEN" />
+		</field>
+		<field number="864" name="NoEvents" type="NUMINGROUP" />
+		<field number="865" name="EventType" type="INT" >
+			<value enum="1" description="PUT" />
+			<value enum="2" description="CALL" />
+			<value enum="3" description="TENDER" />
+			<value enum="4" description="SINKING_FUND_CALL" />
+		</field>
+		<field number="866" name="EventDate" type="LOCALMKTDATE" />
+		<field number="867" name="EventPx" type="PRICE" />
+		<field number="868" name="EventText" type="STRING" />
+		<field number="869" name="PctAtRisk" type="PERCENTAGE" />
+		<field number="870" name="NoInstrAttrib" type="NUMINGROUP" />
+		<field number="871" name="InstrAttribType" type="INT" >
+			<value enum="1" description="FLAT" />
+			<value enum="2" description="ZERO_COUPON" />
+			<value enum="3" description="INTEREST_BEARING" />
+			<value enum="4" description="NO_PERIODIC_PAYMENTS" />
+			<value enum="5" description="VARIABLE_RATE" />
+			<value enum="6" description="LESS_FEE_FOR_PUT" />
+			<value enum="7" description="STEPPED_COUPON" />
+			<value enum="8" description="COUPON_PERIOD" />
+			<value enum="9" description="WHEN_AND_IF_ISSUED" />
+			<value enum="24" description="TRADE_TYPE_ELIGIBILITY_DETAILS" />
+			<value enum="34" description="ELIGIBILITY_FOR_GTD_GTC" />
+		</field>
+		<field number="872" name="InstrAttribValue" type="STRING" />
+		<field number="873" name="DatedDate" type="LOCALMKTDATE" />
+		<field number="874" name="InterestAccrualDate" type="LOCALMKTDATE" />
+		<field number="875" name="CPProgram" type="INT" />
+		<field number="876" name="CPRegType" type="STRING" />
+		<field number="877" name="UnderlyingCPProgram" type="STRING" />
+		<field number="878" name="UnderlyingCPRegType" type="STRING" />
+		<field number="879" name="UnderlyingQty" type="QTY" />
+		<field number="882" name="UnderlyingDirtyPrice" type="PRICE" />
+		<field number="883" name="UnderlyingEndPrice" type="PRICE" />
+		<field number="884" name="UnderlyingStartValue" type="AMT" />
+		<field number="885" name="UnderlyingCurrentValue" type="AMT" />
+		<field number="886" name="UnderlyingEndValue" type="AMT" />
+		<field number="887" name="NoUnderlyingStips" type="NUMINGROUP" />
+		<field number="888" name="UnderlyingStipType" type="STRING" />
+		<field number="889" name="UnderlyingStipValue" type="STRING" />
+		<field number="893" name="LastFragment" type="BOOLEAN" />
+		<field number="898" name="MarginRatio" type="PERCENTAGE" />
+		<field number="911" name="TotNumReports" type="INT" />
+		<field number="913" name="AgreementDesc" type="STRING" />
+		<field number="914" name="AgreementID" type="STRING" />
+		<field number="915" name="AgreementDate" type="LOCALMKTDATE" />
+		<field number="916" name="StartDate" type="LOCALMKTDATE" />
+		<field number="917" name="EndDate" type="LOCALMKTDATE" />
+		<field number="918" name="AgreementCurrency" type="CURRENCY" />
+		<field number="919" name="DeliveryType" type="INT" >
+			<value enum="0" description="VERSUS_PAYMENT" />
+			<value enum="1" description="FREE" />
+			<value enum="2" description="TRI_PARTY" />
+			<value enum="3" description="HOLD_IN_CUSTODY" />
+		</field>
+		<field number="925" name="NewPassword" type="STRING" />
+		<field number="928" name="StatusValue" type="INT" >
+			<value enum="1" description="CONNECTED" />
+			<value enum="2" description="NOT_CONNECTED_DOWN_EXPECTED_UP" />
+			<value enum="3" description="NOT_CONNECTED_DOWN_EXPECTED_DOWN" />
+			<value enum="4" description="IN_PROCESS" />
+		</field>
+		<field number="929" name="StatusText" type="STRING" />
+		<field number="930" name="RefCompID" type="STRING" />
+		<field number="931" name="RefSubID" type="STRING" />
+		<field number="932" name="NetworkResponseID" type="STRING" />
+		<field number="933" name="NetworkRequestID" type="STRING" />
+		<field number="934" name="LastNetworkResponseID" type="STRING" />
+		<field number="936" name="NoCompIDs" type="NUMINGROUP" />
+		<field number="937" name="NetworkStatusResponseType" type="INT" >
+			<value enum="1" description="FULL" />
+			<value enum="2" description="INCREMENTAL_UPDATE" />
+		</field>
+		<field number="941" name="UnderlyingStrikeCurrency" type="CURRENCY" />
+		<field number="942" name="LegStrikeCurrency" type="CURRENCY" />
+		<field number="947" name="StrikeCurrency" type="CURRENCY" />
+		<field number="955" name="LegContractSettlMonth" type="MONTHYEAR" />
+		<field number="956" name="LegInterestAccrualDate" type="LOCALMKTDATE" />
+		<field number="963" name="MDReportID" type="INT" />
+		<field number="964" name="SecurityReportID" type="INT" />
+		<field number="969" name="MinPriceIncrement" type="FLOAT" />
+		<field number="980" name="SecurityUpdateAction" type="CHAR" >
+			<value enum="A" description="ADD" />
+			<value enum="D" description="DELETE" />
+			<value enum="M" description="MODIFY" />
+		</field>
+		<field number="1003" name="TradeID" type="STRING" />
+		<field number="1020" name="TradeVolume" type="QTY" />
+		<field number="1021" name="MDBookType" type="INT" >
+			<value enum="1" description="TOP_OF_BOOK" />
+			<value enum="2" description="PRICE_DEPTH" />
+			<value enum="3" description="ORDER_DEPTH" />
+		</field>
+		<field number="1022" name="MDFeedType" type="STRING" />
+		<field number="1025" name="FirstPx" type="PRICE" />
+		<field number="1093" name="LotType" type="INT" >
+			<value enum="1" description="ODD_LOT" />
+			<value enum="2" description="ROUND_LOT" />
+			<value enum="3" description="BLOCK_LOT" />
+		</field>
+		<field number="1128" name="ApplVerID" type="STRING" />
+		<field number="1140" name="MaxTradeVol" type="QTY" />
+		<field number="1141" name="NoMDFeedTypes" type="NUMINGROUP" />
+		<field number="1142" name="MatchAlgorithm" type="STRING" />
+		<field number="1143" name="MaxPriceVariation" type="FLOAT" />
+		<field number="1144" name="ImpliedMarketIndicator" type="INT" >
+			<value enum="0" description="NOT_IMPLIED" />
+			<value enum="1" description="IMPLIED" />
+		</field>
+		<field number="1148" name="LowLimitPrice" type="PRICE" />
+		<field number="1149" name="HighLimitPrice" type="PRICE" />
+		<field number="1150" name="TradingReferencePrice" type="PRICE" />
+		<field number="1151" name="SecurityGroup" type="STRING" />
+		<field number="1174" name="SecurityTradingEvent" type="INT" />
+		<field number="1180" name="ApplID" type="STRING" />
+		<field number="1181" name="ApplSeqNum" type="SEQNUM" />
+		<field number="1194" name="ExerciseStyle" type="STRING" >
+			<value enum="0" description="EUROPEAN" />
+			<value enum="1" description="AMERICAN" />
+		</field>
+		<field number="1201" name="NoStrikeRules" type="NUMINGROUP" />
+		<field number="1202" name="StartStrikePxRange" type="PRICE" />
+		<field number="1203" name="EndStrikePxRange" type="PRICE" />
+		<field number="1204" name="StrikeIncrement" type="FLOAT" />
+		<field number="1205" name="NoTickRules" type="INT" />
+		<field number="1206" name="StartTickPriceRange" type="PRICE" />
+		<field number="1207" name="EndTickPriceRange" type="PRICE" />
+		<field number="1208" name="TickIncrement" type="PRICE" />
+		<field number="1209" name="TickRuleType" type="INT" />
+		<field number="1210" name="NestedInstrAttribType" type="INT" />
+		<field number="1211" name="NestedInstrAttribValue" type="STRING" />
+		<field number="1222" name="MaturityRuleID" type="STRING" />
+		<field number="1223" name="StrikeRuleID" type="STRING" />
+		<field number="1226" name="EndMaturityMonthYear" type="MONTHYEAR" />
+		<field number="1229" name="MaturityMonthYearIncrement" type="INT" />
+		<field number="1231" name="MinLotSize" type="QTY" />
+		<field number="1232" name="NoExecInstRules" type="NUMINGROUP" />
+		<field number="1234" name="NoLotTypeRules" type="NUMINGROUP" />
+		<field number="1235" name="NoMatchRules" type="NUMINGROUP" />
+		<field number="1236" name="NoMaturityRules" type="NUMINGROUP" />
+		<field number="1237" name="NoOrdTypeRules" type="NUMINGROUP" />
+		<field number="1239" name="NoTimeInForceRules" type="NUMINGROUP" />
+		<field number="1241" name="StartMaturityMonthYear" type="MONTHYEAR" />
+		<field number="1245" name="TradingCurrency" type="CURRENCY" />
+		<field number="1300" name="MarketSegmentID" type="STRING" />
+		<field number="1301" name="MarketID" type="EXCHANGE" />
+		<field number="1302" name="MaturityMonthYearIncrementUnits" type="INT" >
+			<value enum="0" description="MONTHS" />
+			<value enum="1" description="DAYS" />
+			<value enum="2" description="WEEKS" />
+			<value enum="3" description="YEARS" />
+		</field>
+		<field number="1303" name="MaturityMonthYearFormat" type="INT" >
+			<value enum="0" description="YEARMONTH_ONLY" />
+			<value enum="1" description="YEARMONTHDAY" />
+			<value enum="2" description="YEARMONTHWEEK" />
+		</field>
+		<field number="1304" name="StrikeExerciseStyle" type="INT" />
+		<field number="1306" name="PriceLimitType" type="INT" >
+			<value enum="0" description="PRICE" />
+			<value enum="1" description="TICKS" />
+			<value enum="2" description="PERCENTAGE" />
+		</field>
+		<field number="1308" name="ExecInstValue" type="CHAR" />
+		<field number="1309" name="NoTradingSessionRules" type="NUMINGROUP" />
+		<field number="1312" name="NoNestedInstrAttrib" type="NUMINGROUP" />
+		<field number="1350" name="ApplLastSeqNum" type="SEQNUM" />
+		<field number="1351" name="NoApplIDs" type="NUMINGROUP" />
+		<field number="1352" name="ApplResendFlag" type="BOOLEAN" />
+		<field number="1377" name="MultilegModel" type="INT" >
+			<value enum="0" description="PREDEFINED_MULTILEG_SECURITY" />
+			<value enum="1" description="USER_DEFINED_MULTLEG_SECURITY" />
+			<value enum="2" description="USER_DEFINED_NON_SECURITIZED_MULTILEG" />
+		</field>
+		<field number="1377" name="MultiLegModel" type="INT" >
+			<value enum="0" description="PREDEFINED_MULTILEG_SECURITY" />
+			<value enum="1" description="USER_DEFINED_MULTILEG_SECURITY" />
+		</field>
+		<field number="1378" name="MultilegPriceMethod" type="INT" >
+			<value enum="0" description="NET_PRICE" />
+			<value enum="1" description="REVERSED_NET_PRICE" />
+			<value enum="2" description="YIELD_DIFFERENCE" />
+			<value enum="3" description="INDIVIDUAL" />
+			<value enum="4" description="CONTRACT_WEIGHTED_AVERAGE_PRICE" />
+			<value enum="5" description="MULTIPLIED_PRICE" />
+		</field>
+		<field number="1378" name="MultiLegPriceMethod" type="INT" >
+			<value enum="3" description="INDIVIDUAL" />
+		</field>
+		<field number="1465" name="SecurityListID" type="STRING" />
+		<field number="1466" name="SecurityListRefID" type="STRING" />
+		<field number="1467" name="SecurityListDesc" type="STRING" />
+		<field number="1468" name="EncodedSecurityListDescLen" type="LENGTH" />
+		<field number="1469" name="EncodedSecurityListDesc" type="DATA" />
+		<field number="1470" name="SecurityListType" type="INT" >
+			<value enum="1" description="INDUSTRY_CLASSIFICATION" />
+			<value enum="2" description="TRADING_LIST" />
+			<value enum="3" description="MARKET" />
+			<value enum="4" description="NEWSPAPER_LIST" />
+		</field>
+		<field number="1471" name="SecurityListTypeSource" type="INT" >
+			<value enum="1" description="ICB" />
+			<value enum="2" description="NAICS" />
+			<value enum="3" description="GICS" />
+		</field>
+		<field number="1472" name="NewsID" type="STRING" />
+		<field number="1474" name="LanguageCode" type="STRING" />
+		<field number="1482" name="OptPayoutType" type="INT" >
+			<value enum="1" description="Vanilla" />
+			<value enum="3" description="Binary" />
+		</field>
+		<field number="1500" name="MDStreamID" type="STRING" />
+		<field number="1504" name="RelSymTransactTime" type="UTCTIMESTAMP" />
+		<field number="5024" name="InternalSeqNo" type="SEQNUM" />
+		<field number="5149" name="Memo" type="STRING" />
+		<field number="5151" name="TickSizeDenominator" type="INT" />
+		<field number="6032" name="UniqueTradeID" type="STRING" />
+		<field number="6082" name="Duration" type="INT" />
+		<field number="6107" name="IndexID" type="STRING" />
+		<field number="6139" name="TotalNumOfTrades" type="INT" />
+		<field number="6290" name="ReferentialState" type="CHAR" >
+			<value enum="P" description="PREVIEW" />
+			<value enum="F" description="FINAL" />
+			<value enum="U" description="UPDATED" />
+			<value enum="O" description="OPEN" />
+			<value enum="C" description="CLOSED" />
+			<value enum="A" description="ACTIVE" />
+			<value enum="I" description="INACTIVE" />
+			<value enum="E" description="ENABLED" />
+			<value enum="D" description="DISABLED" />
+		</field>
+		<field number="6919" name="IndexPct" type="PERCENTAGE" />
+		<field number="6928" name="BTSRequesterIPAddress" type="STRING" />
+		<field number="6929" name="BTSRequesterOSIdentifier" type="STRING" />
+		<field number="6930" name="ApplicationLogonRspCode" type="INT" />
+		<field number="6931" name="DaysBeforePwdExpiration" type="INT" />
+		<field number="6932" name="NoReferentialPrices" type="NUMINGROUP" />
+		<field number="6933" name="ReferentialPx" type="PRICE" />
+		<field number="6934" name="ReferentialPxType" type="INT" >
+			<value enum="0" description="SETTLEMENT_PRICE" />
+			<value enum="1" description="REFERENTIAL_PRICE" />
+			<value enum="2" description="MAX_OPERATIONAL_TUNNEL" />
+			<value enum="3" description="MIN_OPERATIONAL_TUNNEL" />
+			<value enum="4" description="NOREFERENTIALPRICE" />
+			<value enum="5" description="PREVIOUS_DAY_SETTLEMENT_PRICE" />
+			<value enum="10000" description="TUNNEL_MIN" />
+			<value enum="10001" description="TUNNEL_MAX" />
+			<value enum="10002" description="TUNNEL_LOWER_BAND" />
+			<value enum="10003" description="TUNNEL_UPPER_BAND" />
+			<value enum="10004" description="ACTIVE" />
+			<value enum="10005" description="SURVEILLANCE_LOWER_LIMIT" />
+			<value enum="10006" description="SURVEILLANCE_UPPER_LIMIT" />
+			<value enum="10007" description="PRICE_UPDATE_POLICY" />
+			<value enum="10008" description="TUNNEL_BAND_TYPE" />
+			<value enum="10009" description="SURVEILLANCE_PRICE" />
+			<value enum="10010" description="PIVOT" />
+		</field>
+		<field number="6935" name="SecurityUpdatesSince" type="UTCTIMESTAMP" />
+		<field number="6936" name="Language" type="STRING" />
+		<field number="6937" name="Asset" type="STRING" />
+		<field number="6938" name="SecurityValidityTimestamp" type="UTCTIMESTAMP" />
+		<field number="6939" name="PriceBandType" type="INT" >
+			<value enum="1" description="HARD_LIMITS" />
+			<value enum="2" description="AUCTION_LIMITS" />
+			<value enum="3" description="REJECTION_BANDS" />
+			<value enum="4" description="STATIC_LIMITS" />
+		</field>
+		<field number="6940" name="NewsSource" type="STRING" />
+		<field number="7174" name="StartSequence" type="STRING" />
+		<field number="7175" name="EndSequence" type="STRING" />
+		<field number="7534" name="SecurityStrategyType" type="STRING" />
+		<field number="7595" name="NoSharesIssued" type="STRING" />
+		<field number="9219" name="InstrumentID" type="INT" />
+		<field number="9325" name="LastTradeDate" type="LOCALMKTDATE" />
+		<field number="9748" name="MaxOrderQty" type="QTY" />
+		<field number="9749" name="MinOrderQty" type="QTY" />
+		<field number="10016" name="BusinessSeqNum" type="STRING" />
+		<field number="10027" name="ContextId" type="INT" />
+		<field number="10031" name="SanityValidation" type="BOOLEAN" />
+		<field number="10034" name="LicenseRequestID" type="STRING" />
+		<field number="10035" name="Channel" type="STRING" />
+		<field number="10038" name="LicenseRequestStatus" type="INT" >
+			<value enum="1" description="ACCEPTED" />
+			<value enum="2" description="REJECTED" />
+			<value enum="3" description="PASSWORD_EXPIRED" />
+			<value enum="4" description="LESSER_PASSWORD" />
+			<value enum="5" description="BIGGER_PASSWORD" />
+			<value enum="6" description="SUSPENDED_OPERATOR" />
+			<value enum="7" description="INCOMPATIBLE_VERSION" />
+			<value enum="8" description="SUSPENDED_FIRM" />
+			<value enum="9" description="INVALID_FIRM" />
+			<value enum="10" description="LOGIN_NOT_EXIST" />
+			<value enum="11" description="INTERFACE_VERSION_NOT_EXIST" />
+			<value enum="12" description="INVALID_CHARACTER" />
+			<value enum="13" description="QTT_MIN_NUM_DIGITS_NOT_ATTENDED" />
+			<value enum="14" description="QTT_MIN_LETTERS_NOT_ATTENDED" />
+			<value enum="15" description="QTT_MIN_SPECIAL_CHAR_NOT_ATTENDED" />
+			<value enum="16" description="RESERVED_WORD_PASS" />
+			<value enum="17" description="SAME_PASS" />
+			<value enum="18" description="WEAK_PASS" />
+			<value enum="19" description="INTERFACE_TYPE_DOES_NOT_MATCH" />
+			<value enum="101" description="USER_ALREADY_CONNECTED" />
+			<value enum="102" description="TRADER_CODE_NOT_FOUND" />
+			<value enum="155" description="UNKNOWN_ERROR" />
+		</field>
+		<field number="10052" name="MicrosecondOrderTimestamp" type="STRING" />
+		<field number="10063" name="RLCMsgID" type="STRING" />
+		<field number="35002" name="CancelOnDisconnectType" type="INT" >
+			<value enum="0" description="DO_NOT_CANCEL_ON_DISCONNECT_OR_LOGOUT" />
+			<value enum="1" description="CANCEL_ON_DISCONNECT_ONLY" />
+			<value enum="2" description="CANCEL_ON_LOGOUT_ONLY" />
+			<value enum="3" description="CANCEL_ON_DISCONNECT_OR_LOGOUT" />
+		</field>
+		<field number="35003" name="CODTimeoutWindow" type="INT" />
+		<field number="35007" name="NoSupervisedIDs" type="NUMINGROUP" />
+		<field number="35008" name="SupervisedID" type="STRING" />
+		<field number="35009" name="UserType" type="STRING" />
+		<field number="35010" name="ForceLogin" type="BOOLEAN" />
+		<field number="35011" name="SubUnitID" type="STRING" />
+		<field number="35012" name="InterfaceVersion" type="STRING" />
+		<field number="35013" name="UserAssignedIdentifier" type="INT" />
+		<field number="35014" name="NoTradeIDs" type="NUMINGROUP" />
+		<field number="35015" name="NoBroadCastIDs" type="NUMINGROUP" />
+		<field number="35016" name="BroadCastID" type="STRING" />
+		<field number="35017" name="NoNewsAgencyIDs" type="NUMINGROUP" />
+		<field number="35018" name="NewsAgencyID" type="STRING" />
+		<field number="35020" name="AdministrativeMessage" type="BOOLEAN" />
+		<field number="35033" name="PossMissingApplMsg" type="BOOLEAN" />
+		<field number="35034" name="ControllerType" type="INT" >
+			<value enum="0" description="OEOPERATOR" />
+			<value enum="1" description="MDOPERATOR" />
+			<value enum="2" description="OERELAY" />
+			<value enum="3" description="MDRELAY" />
+			<value enum="4" description="SITEPORTAL" />
+		</field>
+		<field number="35035" name="InternalSeqNoVerID" type="STRING" />
+		<field number="35036" name="ProducerID" type="STRING" />
+		<field number="35038" name="NoUserRoleIDs" type="NUMINGROUP" />
+		<field number="35039" name="UserRoleID" type="STRING" />
+		<field number="35041" name="ControllerID" type="STRING" />
+		<field number="35046" name="MarketDate" type="LOCALMKTDATE" />
+		<field number="35047" name="TraderCode" type="STRING" />
+		<field number="35049" name="NoTraderCodeByProductIDs" type="NUMINGROUP" />
+		<field number="35114" name="BEITradingStatus" type="STRING" />
+		<field number="35487" name="RoutingInstruction" type="CHAR" >
+			<value enum="1" description="RETAIL_LIQUIDITY_TAKER" />
+			<value enum="2" description="WAIVED_PRIORITY" />
+		</field>
+		<field number="35561" name="MinCrossQty" type="QTY" />
+		<field number="37003" name="AvgDailyTradedQty" type="QTY" />
+		<field number="37008" name="PriceBandMidpointPriceType" type="INT" >
+			<value enum="0" description="LAST_TRADED_PRICE" />
+			<value enum="1" description="COMPLEMENTARY_LAST_PRICE" />
+			<value enum="2" description="THEORETICAL_PRICE" />
+		</field>
+		<field number="37010" name="CorporateActionEventID" type="STRING" />
+		<field number="37011" name="GovernanceIndicator" type="STRING" />
+		<field number="37012" name="PriceDivisor" type="FLOAT" />
+		<field number="37013" name="PriceAdjustmentMethod" type="INT" >
+			<value enum="0" description="NO_ADJUSTMENT" />
+			<value enum="1" description="THEORETICAL_PRICE_OF_EX_SHARE" />
+			<value enum="2" description="THEORETICAL_PRICE_OF_EX_SHARE_WHEN_GREATER_THEN_WITH_PRICE" />
+			<value enum="3" description="THEORETICAL_PRICE_OF_EX_SHARE_RESULTING_FROM_DIVIDENDS_IN_DIFFERENT_TYPE_OF_STOCKS" />
+			<value enum="4" description="PRICE_ARBRITADED_BY_MARKET_AUTHORITY" />
+		</field>
+		<field number="37014" name="MDEntryInterestRate" type="FLOAT" />
+		<field number="37015" name="SecurityMatchType" type="INT" />
+		<field number="37016" name="MDInsertDate" type="UTCDATEONLY" />
+		<field number="37017" name="MDInsertTime" type="UTCTIMEONLY" />
+		<field number="37018" name="UnderlyingPxType" type="PRICE" />
+		<field number="37019" name="EarlyTermination" type="INT" >
+			<value enum="0" description="NORMAL_TERMINATION" />
+			<value enum="1" description="EARLY_TERMINATION" />
+			<value enum="2" description="EARLY_TERMINATION_ALSO_IN_CASE_OF_PTO" />
+		</field>
+		<field number="37021" name="IndexTheoreticalQty" type="FLOAT" />
+		<field number="37022" name="NoSecurityGroups" type="NUMINGROUP" />
+		<field number="37023" name="BTBCertIndicator" type="INT" >
+			<value enum="0" description="CERTIFIED" />
+			<value enum="1" description="NOT_CERTIFIED" />
+		</field>
+		<field number="37024" name="BTBContractInfo" type="INT" >
+			<value enum="1" description="PRE_CONTRACT" />
+			<value enum="2" description="INTENTION" />
+		</field>
+		<field number="37025" name="BTBGraceDate" type="UTCDATEONLY" />
+		<field number="37100" name="IndexSeq" type="INT" />
+		<field number="37780" name="MDEntryPrevSize" type="QTY" />
+	</fields>
+</fix>

--- a/src/B3.Umdf.FixConflated/B3.Umdf.FixConflated.csproj
+++ b/src/B3.Umdf.FixConflated/B3.Umdf.FixConflated.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Umdf.FixConflated</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Only depends on B3.Umdf.Book for the IBookEventHandler /
+      IMarketDataEventHandler event contracts this project implements.
+      Deliberately has NO reference to B3.Umdf.Server / B3.MarketData.Wire:
+      this is an isolated, opt-in sandbox channel, never sharing code or
+      wire-format with the WireV2 WebSocket protocol.
+    -->
+    <ProjectReference Include="..\B3.Umdf.Book\B3.Umdf.Book.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Umdf.FixConflated.Tests" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Part of epic #89. Foundation for #90, #91, #92, #93, #94.

## What
- Vendors `schemas/fix-conflated/FIX44_UMDFConflated.xml` — the FIX 4.4 data dictionary published alongside B3's *UMDF PUMA Conflated Market Data Specification* v2.2.0 (2025-10-21).
- Adds `docs/FIX-CONFLATED-SANDBOX.md`: explicit non-official/non-certified labeling, scope, message catalog, and documented deviations from the real B3 product (no auth, no QuickFIX/n, configurable conflation cadence instead of hard-coded ~380ms, snapshot-based recovery instead of persisted cross-session resend).
- Scaffolds an isolated `src/B3.Umdf.FixConflated` project — references only `B3.Umdf.Book` for the event contracts (`IBookEventHandler`/`IMarketDataEventHandler`); **no dependency** on `B3.Umdf.Server`/`B3.MarketData.Wire`, so this sandbox channel never shares code or wire-format with the existing WireV2 WebSocket protocol.
- Wires the new project into `B3MarketDataPlatform.slnx` and cross-links the new doc/schema from `README.md`.

## Why this PR is separate from the actual codec/session implementation
Vendoring + docs is a distinct, low-risk change (mostly triggers the CI "Vendored schema guard", needs the `schema-upgrade` label) from the FIX wire/session logic that will land in #90. Landing this foundation first lets #90/#91/#92 build against a stable, merged base without re-scaffolding or conflicting with each other — #91 and #92 are meant to proceed in parallel once #90 merges.

## Routing note
Per `docs/PROTOCOL-CONTRACTS.md`, this is filed as non-protocol/general work: it does not change Binary UMDF/SBE decoding, cross-repo wire dependencies, or WireV2 WebSocket projection of upstream data — it's an additive, explicitly-labeled-non-official sandbox channel.

## Validation
- `dotnet build src/B3.Umdf.FixConflated/B3.Umdf.FixConflated.csproj` succeeds (0 warnings/errors).
- No changes to any existing project's behavior (purely additive).