### PR TITLE
Fix conflated sandbox wire and session engine

### DIFF
--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -28,6 +28,7 @@
     <Project Path="tests/B3.Umdf.Book.Tests/B3.Umdf.Book.Tests.csproj" />
     <Project Path="tests/B3.Umdf.ConsoleApp.Tests/B3.Umdf.ConsoleApp.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Feed.Tests/B3.Umdf.Feed.Tests.csproj" />
+    <Project Path="tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Fuzz.Tests/B3.Umdf.Fuzz.Tests.csproj" />
     <Project Path="tests/B3.Umdf.PcapReplay.Tests/B3.Umdf.PcapReplay.Tests.csproj" />
     <Project Path="tests/B3.Umdf.Sbe.Tests/B3.Umdf.Sbe.Tests.csproj" />

--- a/src/B3.Umdf.FixConflated/FixField.cs
+++ b/src/B3.Umdf.FixConflated/FixField.cs
@@ -1,0 +1,3 @@
+namespace B3.Umdf.FixConflated;
+
+public readonly record struct FixField(int Tag, string Value);

--- a/src/B3.Umdf.FixConflated/FixMessage.cs
+++ b/src/B3.Umdf.FixConflated/FixMessage.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixMessage
+{
+    private readonly List<FixField> _fields;
+
+    public FixMessage()
+    {
+        _fields = new List<FixField>();
+    }
+
+    public FixMessage(IEnumerable<FixField> fields)
+    {
+        _fields = new List<FixField>(fields);
+    }
+
+    public IReadOnlyList<FixField> Fields => _fields;
+
+    public void Add(int tag, string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        _fields.Add(new FixField(tag, value));
+    }
+
+    public void Add(int tag, int value) => Add(tag, value.ToString(CultureInfo.InvariantCulture));
+
+    public void AddBoolean(int tag, bool value) => Add(tag, value ? "Y" : "N");
+
+    public bool RemoveAll(int tag)
+    {
+        int removed = _fields.RemoveAll(f => f.Tag == tag);
+        return removed != 0;
+    }
+
+    public void Upsert(int tag, string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        for (int i = 0; i < _fields.Count; i++)
+        {
+            if (_fields[i].Tag != tag)
+                continue;
+
+            _fields[i] = new FixField(tag, value);
+            return;
+        }
+
+        _fields.Add(new FixField(tag, value));
+    }
+
+    public bool TryGetString(int tag, out string? value)
+    {
+        for (int i = 0; i < _fields.Count; i++)
+        {
+            if (_fields[i].Tag != tag)
+                continue;
+
+            value = _fields[i].Value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    public bool TryGetInt32(int tag, out int value)
+    {
+        if (TryGetString(tag, out var raw) &&
+            int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out value))
+            return true;
+
+        value = 0;
+        return false;
+    }
+
+    public bool TryGetBoolean(int tag, out bool value)
+    {
+        if (TryGetString(tag, out var raw))
+        {
+            if (string.Equals(raw, "Y", StringComparison.Ordinal))
+            {
+                value = true;
+                return true;
+            }
+
+            if (string.Equals(raw, "N", StringComparison.Ordinal))
+            {
+                value = false;
+                return true;
+            }
+        }
+
+        value = false;
+        return false;
+    }
+
+    public FixMessage Clone() => new(_fields);
+}

--- a/src/B3.Umdf.FixConflated/FixMessageCodec.cs
+++ b/src/B3.Umdf.FixConflated/FixMessageCodec.cs
@@ -1,0 +1,210 @@
+using System.Globalization;
+using System.Text;
+
+namespace B3.Umdf.FixConflated;
+
+public enum FixDecodeError
+{
+    None = 0,
+    Incomplete,
+    MissingBeginString,
+    InvalidBeginString,
+    MissingBodyLength,
+    InvalidBodyLength,
+    MissingMsgType,
+    MissingCheckSum,
+    InvalidCheckSum,
+    CheckSumMismatch,
+    BodyLengthMismatch,
+    MalformedField,
+    InvalidTag,
+}
+
+public readonly record struct FixDecodeResult(
+    bool Success,
+    FixMessage? Message,
+    int BytesConsumed,
+    FixDecodeError Error)
+{
+    public static FixDecodeResult Incomplete => new(false, null, 0, FixDecodeError.Incomplete);
+    public static FixDecodeResult Failure(FixDecodeError error) => new(false, null, 0, error);
+    public static FixDecodeResult Completed(FixMessage message, int bytesConsumed) => new(true, message, bytesConsumed, FixDecodeError.None);
+}
+
+public static class FixMessageCodec
+{
+    public const byte Soh = 0x01;
+    public const string BeginString = "FIX.4.4";
+
+    public static byte[] Encode(FixMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        string beginString = message.TryGetString(FixTags.BeginString, out var begin)
+            ? begin!
+            : BeginString;
+
+        if (!message.TryGetString(FixTags.MsgType, out var msgType) || string.IsNullOrEmpty(msgType))
+            throw new InvalidOperationException("FIX message requires MsgType (35) before encoding.");
+
+        List<FixField> fields = CollectFields(message, msgType);
+
+        var bodyBuilder = new StringBuilder();
+        bodyBuilder.Append("35=").Append(msgType).Append((char)Soh);
+        foreach (var field in fields)
+            AppendField(bodyBuilder, field);
+
+        string body = bodyBuilder.ToString();
+        string prefix = $"8={beginString}{(char)Soh}9={Encoding.ASCII.GetByteCount(body).ToString(CultureInfo.InvariantCulture)}{(char)Soh}";
+        string messageWithoutChecksum = prefix + body;
+
+        int checksum = 0;
+        byte[] payloadBytes = Encoding.ASCII.GetBytes(messageWithoutChecksum);
+        for (int i = 0; i < payloadBytes.Length; i++)
+            checksum = (checksum + payloadBytes[i]) & 0xFF;
+
+        string finalMessage = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{messageWithoutChecksum}10={checksum:000}{(char)Soh}");
+
+        return Encoding.ASCII.GetBytes(finalMessage);
+    }
+
+    public static FixDecodeResult Decode(ReadOnlySpan<byte> buffer)
+    {
+        if (buffer.IsEmpty)
+            return FixDecodeResult.Incomplete;
+
+        int firstEnd = buffer.IndexOf(Soh);
+        if (firstEnd < 0)
+            return FixDecodeResult.Incomplete;
+
+        if (!TryParseField(buffer[..firstEnd], out var beginField))
+            return FixDecodeResult.Failure(FixDecodeError.MalformedField);
+        if (beginField.Tag != FixTags.BeginString)
+            return FixDecodeResult.Failure(FixDecodeError.MissingBeginString);
+        if (!string.Equals(beginField.Value, BeginString, StringComparison.Ordinal))
+            return FixDecodeResult.Failure(FixDecodeError.InvalidBeginString);
+
+        int secondStart = firstEnd + 1;
+        int secondEndOffset = buffer[secondStart..].IndexOf(Soh);
+        if (secondEndOffset < 0)
+            return FixDecodeResult.Incomplete;
+        int secondEnd = secondStart + secondEndOffset;
+
+        if (!TryParseField(buffer[secondStart..secondEnd], out var bodyLengthField))
+            return FixDecodeResult.Failure(FixDecodeError.MalformedField);
+        if (bodyLengthField.Tag != FixTags.BodyLength)
+            return FixDecodeResult.Failure(FixDecodeError.MissingBodyLength);
+        if (!int.TryParse(bodyLengthField.Value, NumberStyles.None, CultureInfo.InvariantCulture, out int bodyLength) || bodyLength < 0)
+            return FixDecodeResult.Failure(FixDecodeError.InvalidBodyLength);
+
+        int bodyStart = secondEnd + 1;
+        int checksumFieldStart = bodyStart + bodyLength;
+        if (checksumFieldStart + 7 > buffer.Length)
+            return FixDecodeResult.Incomplete;
+        if (buffer[checksumFieldStart] != (byte)'1' || buffer[checksumFieldStart + 1] != (byte)'0' || buffer[checksumFieldStart + 2] != (byte)'=')
+            return FixDecodeResult.Failure(FixDecodeError.BodyLengthMismatch);
+
+        int checksumFieldEndOffset = buffer[checksumFieldStart..].IndexOf(Soh);
+        if (checksumFieldEndOffset < 0)
+            return FixDecodeResult.Incomplete;
+        int checksumFieldEnd = checksumFieldStart + checksumFieldEndOffset;
+        int totalLength = checksumFieldEnd + 1;
+        if (totalLength > buffer.Length)
+            return FixDecodeResult.Incomplete;
+
+        ReadOnlySpan<byte> checksumSpan = buffer[(checksumFieldStart + 3)..checksumFieldEnd];
+        if (checksumSpan.Length != 3 ||
+            !int.TryParse(Encoding.ASCII.GetString(checksumSpan), NumberStyles.None, CultureInfo.InvariantCulture, out int expectedChecksum))
+            return FixDecodeResult.Failure(FixDecodeError.InvalidCheckSum);
+
+        int actualChecksum = 0;
+        for (int i = 0; i < checksumFieldStart; i++)
+            actualChecksum = (actualChecksum + buffer[i]) & 0xFF;
+        if (actualChecksum != expectedChecksum)
+            return FixDecodeResult.Failure(FixDecodeError.CheckSumMismatch);
+
+        var message = new FixMessage();
+        message.Add(beginField.Tag, beginField.Value);
+        message.Add(bodyLengthField.Tag, bodyLengthField.Value);
+
+        int cursor = bodyStart;
+        bool sawMsgType = false;
+        while (cursor < checksumFieldStart)
+        {
+            int fieldEndOffset = buffer[cursor..checksumFieldStart].IndexOf(Soh);
+            if (fieldEndOffset < 0)
+                return FixDecodeResult.Failure(FixDecodeError.BodyLengthMismatch);
+
+            int fieldEnd = cursor + fieldEndOffset;
+            if (!TryParseField(buffer[cursor..fieldEnd], out var field))
+                return FixDecodeResult.Failure(FixDecodeError.MalformedField);
+
+            if (!sawMsgType)
+            {
+                if (field.Tag != FixTags.MsgType)
+                    return FixDecodeResult.Failure(FixDecodeError.MissingMsgType);
+                sawMsgType = true;
+            }
+
+            message.Add(field.Tag, field.Value);
+            cursor = fieldEnd + 1;
+        }
+
+        if (!sawMsgType)
+            return FixDecodeResult.Failure(FixDecodeError.MissingMsgType);
+
+        message.Add(FixTags.CheckSum, expectedChecksum.ToString("000", CultureInfo.InvariantCulture));
+        return FixDecodeResult.Completed(message, totalLength);
+    }
+
+    private static List<FixField> CollectFields(FixMessage message, string msgType)
+    {
+        var fields = new List<FixField>(message.Fields.Count);
+        for (int i = 0; i < message.Fields.Count; i++)
+        {
+            var field = message.Fields[i];
+            if (field.Tag is FixTags.BeginString or FixTags.BodyLength or FixTags.CheckSum)
+                continue;
+            if (field.Tag == FixTags.MsgType)
+            {
+                if (!string.Equals(field.Value, msgType, StringComparison.Ordinal))
+                    continue;
+                continue;
+            }
+
+            fields.Add(field);
+        }
+
+        return fields;
+    }
+
+    private static bool TryParseField(ReadOnlySpan<byte> span, out FixField field)
+    {
+        int equals = span.IndexOf((byte)'=');
+        if (equals <= 0)
+        {
+            field = default;
+            return false;
+        }
+
+        if (!int.TryParse(Encoding.ASCII.GetString(span[..equals]), NumberStyles.None, CultureInfo.InvariantCulture, out int tag))
+        {
+            field = default;
+            return false;
+        }
+
+        field = new FixField(tag, Encoding.ASCII.GetString(span[(equals + 1)..]));
+        return true;
+    }
+
+    private static void AppendField(StringBuilder builder, FixField field)
+    {
+        builder
+            .Append(field.Tag.ToString(CultureInfo.InvariantCulture))
+            .Append('=')
+            .Append(field.Value)
+            .Append((char)Soh);
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixSessionConnection.cs
+++ b/src/B3.Umdf.FixConflated/FixSessionConnection.cs
@@ -1,0 +1,387 @@
+using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
+
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Minimal acceptor-side FIX session engine for the sandbox channel. It keeps a
+/// bounded in-memory resend buffer only for the current process/session and does
+/// not attempt any cross-session replay beyond the B3-documented immediate
+/// disconnect rule for reconnects that arrive with a lower-than-expected
+/// inbound sequence number.
+/// </summary>
+public sealed class FixSessionConnection
+{
+    private readonly FixSessionStateStore _stateStore;
+    private readonly IFixClock _clock;
+    private readonly FixSessionOptions _options;
+    private readonly Queue<int> _applicationSequenceOrder = new();
+    private readonly Dictionary<int, FixMessage> _applicationMessages = new();
+
+    private FixSessionIdentity? _identity;
+    private FixPersistentSessionState _state;
+    private int _heartbeatIntervalSeconds;
+    private long _lastReceivedTicks;
+    private long _lastSentTicks;
+
+    public FixSessionConnection(
+        FixSessionStateStore stateStore,
+        FixSessionOptions? options = null,
+        IFixClock? clock = null)
+    {
+        _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
+        _options = options ?? new FixSessionOptions();
+        _clock = clock ?? SystemFixClock.Instance;
+        _heartbeatIntervalSeconds = _options.DefaultHeartbeatIntervalSecondsValue;
+        State = FixSessionState.AwaitingLogon;
+    }
+
+    public FixSessionState State { get; private set; }
+    public FixSessionIdentity? Identity => _identity;
+    public int NextExpectedInboundSeqNum => _state.NextExpectedInboundSeqNum;
+    public int NextOutboundSeqNum => _state.NextOutboundSeqNum;
+    public int HeartbeatIntervalSeconds => _heartbeatIntervalSeconds;
+
+    public FixSessionUpdate ReceiveFrame(ReadOnlySpan<byte> frame)
+    {
+        var decode = FixMessageCodec.Decode(frame);
+        if (!decode.Success)
+        {
+            State = FixSessionState.Disconnected;
+            return new FixSessionUpdate([], true, "Invalid FIX frame.", decode.Error);
+        }
+
+        return Receive(decode.Message!);
+    }
+
+    public FixSessionUpdate Receive(FixMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (State == FixSessionState.Disconnected)
+            return FixSessionUpdate.None;
+
+        var nowUtc = _clock.UtcNow;
+        long nowTicks = _clock.MonotonicTicks;
+        _lastReceivedTicks = nowTicks;
+
+        if (!TryGetRequiredString(message, FixTags.MsgType, out string? msgType) ||
+            !TryGetRequiredInt(message, FixTags.MsgSeqNum, out int inboundSeqNum))
+            return DisconnectWithLogout("Missing session header.", nowUtc, nowTicks);
+
+        if (State == FixSessionState.AwaitingLogon)
+        {
+            if (!string.Equals(msgType, FixMsgTypes.Logon, StringComparison.Ordinal))
+                return DisconnectWithLogout("First message must be Logon.", nowUtc, nowTicks);
+
+            return HandleLogon(message, inboundSeqNum, nowUtc, nowTicks);
+        }
+
+        if (inboundSeqNum != _state.NextExpectedInboundSeqNum)
+            return DisconnectWithLogout($"Unexpected inbound sequence number {inboundSeqNum.ToString(CultureInfo.InvariantCulture)}.", nowUtc, nowTicks);
+
+        _state = _state with { NextExpectedInboundSeqNum = inboundSeqNum + 1 };
+        PersistState();
+
+        return msgType switch
+        {
+            FixMsgTypes.Heartbeat => FixSessionUpdate.None,
+            FixMsgTypes.TestRequest => HandleTestRequest(message, nowUtc, nowTicks),
+            FixMsgTypes.ResendRequest => HandleResendRequest(message),
+            FixMsgTypes.Logout => HandleLogout(nowUtc, nowTicks),
+            FixMsgTypes.Reject => FixSessionUpdate.None,
+            FixMsgTypes.Logon => DisconnectImmediately("Unexpected secondary Logon."),
+            _ => DisconnectWithLogout($"Unsupported session MsgType {msgType}.", nowUtc, nowTicks),
+        };
+    }
+
+    public FixSessionUpdate Advance()
+    {
+        if (State is FixSessionState.AwaitingLogon or FixSessionState.Disconnected)
+            return FixSessionUpdate.None;
+
+        var nowUtc = _clock.UtcNow;
+        long nowTicks = _clock.MonotonicTicks;
+        long heartbeatWindow = _heartbeatIntervalSeconds * 1000L;
+
+        if (nowTicks - _lastReceivedTicks >= heartbeatWindow * 2)
+            return DisconnectWithLogout("Peer heartbeat timeout.", nowUtc, nowTicks);
+
+        if (nowTicks - _lastSentTicks < heartbeatWindow)
+            return FixSessionUpdate.None;
+
+        var heartbeat = CreateLiveMessage(FixMsgTypes.Heartbeat, nowUtc, static _ => { });
+        return UpdateWith(heartbeat, disconnect: false, reason: null);
+    }
+
+    public bool TrySendApplication(FixMessage applicationMessage, out FixSessionUpdate update)
+    {
+        ArgumentNullException.ThrowIfNull(applicationMessage);
+        if (State != FixSessionState.Active)
+        {
+            update = FixSessionUpdate.None;
+            return false;
+        }
+
+        var nowUtc = _clock.UtcNow;
+        long nowTicks = _clock.MonotonicTicks;
+        int seqNum = _state.NextOutboundSeqNum;
+        _state = _state with { NextOutboundSeqNum = seqNum + 1 };
+        PersistState();
+
+        var outbound = CreateOutgoingMessage(
+            GetRequiredIdentity(),
+            applicationMessage,
+            seqNum,
+            nowUtc,
+            possDup: false);
+
+        StoreApplicationMessage(seqNum, outbound.Clone());
+        _lastSentTicks = nowTicks;
+        update = UpdateWith(outbound, disconnect: false, reason: null);
+        return true;
+    }
+
+    private FixSessionUpdate HandleLogon(FixMessage message, int inboundSeqNum, DateTimeOffset nowUtc, long nowTicks)
+    {
+        if (!TryGetRequiredString(message, FixTags.SenderCompId, out string? senderCompId) ||
+            !TryGetRequiredString(message, FixTags.TargetCompId, out string? targetCompId) ||
+            !TryGetRequiredInt(message, FixTags.HeartBtInt, out int heartbeatIntervalSeconds) ||
+            !TryGetRequiredInt(message, FixTags.EncryptMethod, out int encryptMethod))
+            return DisconnectImmediately("Malformed Logon.");
+
+        if (heartbeatIntervalSeconds <= 0 || encryptMethod != 0)
+            return DisconnectImmediately("Malformed Logon.");
+
+        var identity = new FixSessionIdentity(senderCompId!, targetCompId!);
+        FixPersistentSessionState persistent = _stateStore.GetOrCreate(identity);
+        if (inboundSeqNum < persistent.NextExpectedInboundSeqNum)
+            return DisconnectImmediately("Reconnect sequence number lower than expected.");
+
+        _identity = identity;
+        _state = persistent with { NextExpectedInboundSeqNum = inboundSeqNum + 1 };
+        _heartbeatIntervalSeconds = heartbeatIntervalSeconds;
+        _lastReceivedTicks = nowTicks;
+
+        bool resetRequested = message.TryGetBoolean(FixTags.ResetSeqNumFlag, out bool resetValue) && resetValue;
+        if (resetRequested && persistent.NextExpectedInboundSeqNum == 1 && persistent.NextOutboundSeqNum == 1)
+            _state = new FixPersistentSessionState(2, 1);
+
+        PersistState();
+        State = FixSessionState.Active;
+
+        var logon = CreateLiveMessage(FixMsgTypes.Logon, nowUtc, outbound =>
+        {
+            outbound.Add(FixTags.EncryptMethod, 0);
+            outbound.Add(FixTags.HeartBtInt, heartbeatIntervalSeconds);
+            if (resetRequested && persistent.NextExpectedInboundSeqNum == 1 && persistent.NextOutboundSeqNum == 1)
+                outbound.AddBoolean(FixTags.ResetSeqNumFlag, true);
+        });
+
+        return UpdateWith(logon, disconnect: false, reason: null);
+    }
+
+    private FixSessionUpdate HandleTestRequest(FixMessage message, DateTimeOffset nowUtc, long nowTicks)
+    {
+        if (!TryGetRequiredString(message, FixTags.TestReqId, out string? testReqId))
+            return DisconnectWithLogout("Malformed TestRequest.", nowUtc, nowTicks);
+
+        var heartbeat = CreateLiveMessage(FixMsgTypes.Heartbeat, nowUtc, outbound => outbound.Add(FixTags.TestReqId, testReqId!));
+        return UpdateWith(heartbeat, disconnect: false, reason: null);
+    }
+
+    private FixSessionUpdate HandleResendRequest(FixMessage message)
+    {
+        if (!TryGetRequiredInt(message, FixTags.BeginSeqNo, out int beginSeqNo) ||
+            !TryGetRequiredInt(message, FixTags.EndSeqNo, out int endSeqNo))
+            return DisconnectImmediately("Malformed ResendRequest.");
+
+        if (beginSeqNo <= 0)
+            return DisconnectImmediately("Malformed ResendRequest.");
+
+        int highestSentSeqNum = _state.NextOutboundSeqNum - 1;
+        if (highestSentSeqNum <= 0)
+            return FixSessionUpdate.None;
+
+        int requestedEnd = endSeqNo == 0 ? highestSentSeqNum : Math.Min(endSeqNo, highestSentSeqNum);
+        if (requestedEnd < beginSeqNo)
+            return FixSessionUpdate.None;
+
+        List<FixMessage> outbound = new();
+        int cursor = beginSeqNo;
+        while (cursor <= requestedEnd)
+        {
+            if (_applicationMessages.TryGetValue(cursor, out var stored))
+            {
+                outbound.Add(CloneForReplay(stored));
+                cursor++;
+                continue;
+            }
+
+            int gapStart = cursor;
+            while (cursor <= requestedEnd && !_applicationMessages.ContainsKey(cursor))
+                cursor++;
+
+            outbound.Add(CreateGapFill(gapStart, cursor));
+        }
+
+        return outbound.Count == 0
+            ? FixSessionUpdate.None
+            : new FixSessionUpdate(outbound, false, null, FixDecodeError.None);
+    }
+
+    private FixSessionUpdate HandleLogout(DateTimeOffset nowUtc, long nowTicks)
+    {
+        if (State == FixSessionState.LogoutSent)
+        {
+            State = FixSessionState.Disconnected;
+            return new FixSessionUpdate([], true, null, FixDecodeError.None);
+        }
+
+        var logout = CreateLiveMessage(FixMsgTypes.Logout, nowUtc, static _ => { });
+        State = FixSessionState.Disconnected;
+        _lastSentTicks = nowTicks;
+        return new FixSessionUpdate([logout], true, null, FixDecodeError.None);
+    }
+
+    private FixSessionUpdate DisconnectWithLogout(string reason, DateTimeOffset nowUtc, long nowTicks)
+    {
+        if (State == FixSessionState.Disconnected)
+            return new FixSessionUpdate([], true, reason, FixDecodeError.None);
+
+        if (_identity is null)
+            return DisconnectImmediately(reason);
+
+        var logout = CreateLiveMessage(FixMsgTypes.Logout, nowUtc, outbound => outbound.Add(58, reason));
+        State = FixSessionState.Disconnected;
+        _lastSentTicks = nowTicks;
+        return new FixSessionUpdate([logout], true, reason, FixDecodeError.None);
+    }
+
+    private FixSessionUpdate DisconnectImmediately(string reason)
+    {
+        State = FixSessionState.Disconnected;
+        return new FixSessionUpdate([], true, reason, FixDecodeError.None);
+    }
+
+    private FixMessage CreateLiveMessage(string msgType, DateTimeOffset nowUtc, Action<FixMessage> populate)
+    {
+        int seqNum = _state.NextOutboundSeqNum;
+        _state = _state with { NextOutboundSeqNum = seqNum + 1 };
+        PersistState();
+
+        var outbound = CreateOutgoingMessage(GetRequiredIdentity(), CreateBareMessage(msgType, populate), seqNum, nowUtc, possDup: false);
+        _lastSentTicks = _clock.MonotonicTicks;
+        return outbound;
+    }
+
+    private FixMessage CreateGapFill(int gapStart, int newSeqNo)
+    {
+        var outbound = CreateBareMessage(FixMsgTypes.SequenceReset, message =>
+        {
+            message.AddBoolean(FixTags.GapFillFlag, true);
+            message.Add(FixTags.NewSeqNo, newSeqNo);
+        });
+
+        return CreateOutgoingMessage(GetRequiredIdentity(), outbound, gapStart, _clock.UtcNow, possDup: true);
+    }
+
+    private static FixMessage CloneForReplay(FixMessage message)
+    {
+        var replay = message.Clone();
+        replay.Upsert(FixTags.PossDupFlag, "Y");
+        return replay;
+    }
+
+    private static FixMessage CreateBareMessage(string msgType, Action<FixMessage> populate)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, msgType);
+        populate(message);
+        return message;
+    }
+
+    private static FixMessage CreateOutgoingMessage(
+        FixSessionIdentity identity,
+        FixMessage payload,
+        int seqNum,
+        DateTimeOffset nowUtc,
+        bool possDup)
+    {
+        var outbound = new FixMessage();
+        outbound.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        outbound.Add(FixTags.MsgType, GetRequiredString(payload, FixTags.MsgType));
+        outbound.Add(FixTags.SenderCompId, identity.TargetCompId);
+        outbound.Add(FixTags.TargetCompId, identity.SenderCompId);
+        outbound.Add(FixTags.MsgSeqNum, seqNum);
+        outbound.Add(FixTags.SendingTime, FixValueFormatting.FormatUtcTimestamp(nowUtc));
+        if (possDup)
+            outbound.AddBoolean(FixTags.PossDupFlag, true);
+
+        foreach (var field in payload.Fields)
+        {
+            if (field.Tag == FixTags.MsgType)
+                continue;
+            if (field.Tag == FixTags.PossDupFlag)
+            {
+                outbound.Upsert(field.Tag, field.Value);
+                continue;
+            }
+
+            outbound.Add(field.Tag, field.Value);
+        }
+
+        return outbound;
+    }
+
+    private void StoreApplicationMessage(int seqNum, FixMessage message)
+    {
+        if (_options.ApplicationResendBufferCapacity <= 0)
+            return;
+
+        _applicationMessages[seqNum] = message;
+        _applicationSequenceOrder.Enqueue(seqNum);
+        while (_applicationSequenceOrder.Count > _options.ApplicationResendBufferCapacity)
+        {
+            int evicted = _applicationSequenceOrder.Dequeue();
+            _applicationMessages.Remove(evicted);
+        }
+    }
+
+    private FixSessionIdentity GetRequiredIdentity()
+        => _identity ?? throw new InvalidOperationException("Session identity not established.");
+
+    private void PersistState()
+    {
+        if (_identity is { } identity)
+            _stateStore.Save(identity, _state);
+    }
+
+    private static bool TryGetRequiredString(FixMessage message, int tag, [NotNullWhen(true)] out string? value)
+    {
+        if (message.TryGetString(tag, out value) && !string.IsNullOrEmpty(value))
+            return true;
+
+        value = null;
+        return false;
+    }
+
+    private static string GetRequiredString(FixMessage message, int tag)
+    {
+        if (TryGetRequiredString(message, tag, out var value))
+            return value!;
+
+        throw new InvalidOperationException($"Missing FIX field {tag.ToString(CultureInfo.InvariantCulture)}.");
+    }
+
+    private static bool TryGetRequiredInt(FixMessage message, int tag, out int value)
+    {
+        if (message.TryGetInt32(tag, out value))
+            return true;
+
+        value = 0;
+        return false;
+    }
+
+    private static FixSessionUpdate UpdateWith(FixMessage outbound, bool disconnect, string? reason)
+        => new([outbound], disconnect, reason, FixDecodeError.None);
+}

--- a/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace B3.Umdf.FixConflated;
+
+public interface IFixClock
+{
+    DateTimeOffset UtcNow { get; }
+    long MonotonicTicks { get; }
+}
+
+public sealed class SystemFixClock : IFixClock
+{
+    public static readonly SystemFixClock Instance = new();
+    private SystemFixClock() { }
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+    public long MonotonicTicks => Environment.TickCount64;
+}
+
+public sealed class FixSessionOptions
+{
+    public const int DefaultHeartbeatIntervalSeconds = 30;
+    public const int DefaultApplicationResendBufferCapacity = 10_000;
+
+    public int DefaultHeartbeatIntervalSecondsValue { get; init; } = DefaultHeartbeatIntervalSeconds;
+    public int ApplicationResendBufferCapacity { get; init; } = DefaultApplicationResendBufferCapacity;
+}
+
+public enum FixSessionState
+{
+    AwaitingLogon = 0,
+    Active,
+    LogoutSent,
+    Disconnected,
+}
+
+public readonly record struct FixSessionIdentity(string SenderCompId, string TargetCompId);
+
+public readonly record struct FixPersistentSessionState(int NextExpectedInboundSeqNum, int NextOutboundSeqNum);
+
+public sealed class FixSessionStateStore
+{
+    private readonly ConcurrentDictionary<FixSessionIdentity, PersistentState> _states = new();
+
+    public FixPersistentSessionState GetOrCreate(FixSessionIdentity identity)
+    {
+        PersistentState state = _states.GetOrAdd(identity, static _ => new PersistentState());
+        lock (state.Sync)
+            return new FixPersistentSessionState(state.NextExpectedInboundSeqNum, state.NextOutboundSeqNum);
+    }
+
+    public void Save(FixSessionIdentity identity, FixPersistentSessionState state)
+    {
+        PersistentState entry = _states.GetOrAdd(identity, static _ => new PersistentState());
+        lock (entry.Sync)
+        {
+            entry.NextExpectedInboundSeqNum = state.NextExpectedInboundSeqNum;
+            entry.NextOutboundSeqNum = state.NextOutboundSeqNum;
+        }
+    }
+
+    private sealed class PersistentState
+    {
+        public object Sync { get; } = new();
+        public int NextExpectedInboundSeqNum { get; set; } = 1;
+        public int NextOutboundSeqNum { get; set; } = 1;
+    }
+}
+
+public sealed class FixSessionUpdate
+{
+    public static readonly FixSessionUpdate None = new([], false, null, FixDecodeError.None);
+
+    public FixSessionUpdate(
+        IReadOnlyList<FixMessage> outboundMessages,
+        bool disconnectTransport,
+        string? disconnectReason,
+        FixDecodeError decodeError)
+    {
+        OutboundMessages = outboundMessages;
+        DisconnectTransport = disconnectTransport;
+        DisconnectReason = disconnectReason;
+        DecodeError = decodeError;
+    }
+
+    public IReadOnlyList<FixMessage> OutboundMessages { get; }
+    public bool DisconnectTransport { get; }
+    public string? DisconnectReason { get; }
+    public FixDecodeError DecodeError { get; }
+}
+
+internal static class FixTags
+{
+    public const int BeginString = 8;
+    public const int BodyLength = 9;
+    public const int MsgType = 35;
+    public const int SenderCompId = 49;
+    public const int TargetCompId = 56;
+    public const int MsgSeqNum = 34;
+    public const int SendingTime = 52;
+    public const int PossDupFlag = 43;
+    public const int EncryptMethod = 98;
+    public const int HeartBtInt = 108;
+    public const int TestReqId = 112;
+    public const int GapFillFlag = 123;
+    public const int ResetSeqNumFlag = 141;
+    public const int BeginSeqNo = 7;
+    public const int EndSeqNo = 16;
+    public const int NewSeqNo = 36;
+    public const int NextExpectedMsgSeqNum = 789;
+    public const int CheckSum = 10;
+}
+
+internal static class FixMsgTypes
+{
+    public const string Heartbeat = "0";
+    public const string TestRequest = "1";
+    public const string ResendRequest = "2";
+    public const string Reject = "3";
+    public const string SequenceReset = "4";
+    public const string Logout = "5";
+    public const string Logon = "A";
+}
+
+internal static class FixValueFormatting
+{
+    public static string FormatUtcTimestamp(DateTimeOffset value)
+        => value.UtcDateTime.ToString("yyyyMMdd-HH:mm:ss.fff", CultureInfo.InvariantCulture);
+}

--- a/src/B3.Umdf.FixConflated/FixZlibCompression.cs
+++ b/src/B3.Umdf.FixConflated/FixZlibCompression.cs
@@ -1,0 +1,17 @@
+using System.IO.Compression;
+
+namespace B3.Umdf.FixConflated;
+
+public static class FixZlibCompression
+{
+    public static byte[] Compress(ReadOnlySpan<byte> payload, CompressionLevel compressionLevel = CompressionLevel.Fastest)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, compressionLevel, leaveOpen: true))
+        {
+            zlib.Write(payload);
+        }
+
+        return output.ToArray();
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj
+++ b/tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Umdf.FixConflated\B3.Umdf.FixConflated.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Umdf.FixConflated.Tests/FixMessageCodecTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixMessageCodecTests.cs
@@ -1,0 +1,96 @@
+using System.IO.Compression;
+using System.Text;
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixMessageCodecTests
+{
+    [Fact]
+    public void EncodeDecode_RoundTrips_WithValidBodyLengthAndChecksum()
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, FixMsgTypes.Logon);
+        message.Add(FixTags.SenderCompId, "CLIENT");
+        message.Add(FixTags.TargetCompId, "SERVER");
+        message.Add(FixTags.MsgSeqNum, 1);
+        message.Add(FixTags.SendingTime, "20260812-18:32:01.333");
+        message.Add(FixTags.EncryptMethod, 0);
+        message.Add(FixTags.HeartBtInt, 30);
+
+        byte[] encoded = FixMessageCodec.Encode(message);
+        string encodedText = Encoding.ASCII.GetString(encoded);
+
+        Assert.StartsWith($"8=FIX.4.4{(char)FixMessageCodec.Soh}9=", encodedText, StringComparison.Ordinal);
+        Assert.Contains($"{(char)FixMessageCodec.Soh}35=A{(char)FixMessageCodec.Soh}", encodedText, StringComparison.Ordinal);
+        Assert.EndsWith(((char)FixMessageCodec.Soh).ToString(), encodedText, StringComparison.Ordinal);
+
+        var decoded = FixMessageCodec.Decode(encoded);
+        Assert.True(decoded.Success);
+        Assert.Equal(encoded.Length, decoded.BytesConsumed);
+        Assert.NotNull(decoded.Message);
+        Assert.Equal("CLIENT", GetRequired(decoded.Message!, FixTags.SenderCompId));
+        Assert.Equal("SERVER", GetRequired(decoded.Message!, FixTags.TargetCompId));
+        Assert.Equal("30", GetRequired(decoded.Message!, FixTags.HeartBtInt));
+    }
+
+    [Fact]
+    public void Decode_Rejects_InvalidChecksum()
+    {
+        var message = CreateHeartbeat(seqNum: 1);
+        byte[] encoded = FixMessageCodec.Encode(message);
+        encoded[^2] = encoded[^2] == (byte)'0' ? (byte)'1' : (byte)'0';
+
+        var decoded = FixMessageCodec.Decode(encoded);
+
+        Assert.False(decoded.Success);
+        Assert.Equal(FixDecodeError.CheckSumMismatch, decoded.Error);
+    }
+
+    [Fact]
+    public void Decode_Rejects_InvalidBodyLength()
+    {
+        var message = CreateHeartbeat(seqNum: 1);
+        byte[] encoded = FixMessageCodec.Encode(message);
+        int bodyLengthIndex = Array.IndexOf(encoded, (byte)'9');
+        encoded[bodyLengthIndex + 2] = (byte)'0';
+
+        var decoded = FixMessageCodec.Decode(encoded);
+
+        Assert.False(decoded.Success);
+        Assert.Equal(FixDecodeError.BodyLengthMismatch, decoded.Error);
+    }
+
+    [Fact]
+    public void Compress_UsesZlibWrapper()
+    {
+        byte[] raw = FixMessageCodec.Encode(CreateHeartbeat(seqNum: 7));
+
+        byte[] compressed = FixZlibCompression.Compress(raw);
+        using var input = new MemoryStream(compressed);
+        using var zlib = new ZLibStream(input, CompressionMode.Decompress);
+        using var output = new MemoryStream();
+        zlib.CopyTo(output);
+
+        Assert.Equal(raw, output.ToArray());
+    }
+
+    private static FixMessage CreateHeartbeat(int seqNum)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, FixMsgTypes.Heartbeat);
+        message.Add(FixTags.SenderCompId, "SERVER");
+        message.Add(FixTags.TargetCompId, "CLIENT");
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260812-18:32:01.333");
+        return message;
+    }
+
+    private static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/FixSessionConnectionTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixSessionConnectionTests.cs
@@ -1,0 +1,187 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixSessionConnectionTests
+{
+    [Fact]
+    public void Session_Flows_Logon_Heartbeat_TestRequest_Logout()
+    {
+        var clock = new FakeFixClock();
+        var store = new FixSessionStateStore();
+        var session = new FixSessionConnection(store, clock: clock);
+
+        var logon = CreateInbound(FixMsgTypes.Logon, 1, message =>
+        {
+            message.Add(FixTags.EncryptMethod, 0);
+            message.Add(FixTags.HeartBtInt, 30);
+        });
+
+        FixSessionUpdate logonUpdate = session.Receive(logon);
+
+        var outboundLogon = Assert.Single(logonUpdate.OutboundMessages);
+        Assert.False(logonUpdate.DisconnectTransport);
+        Assert.Equal(FixMsgTypes.Logon, GetRequired(outboundLogon, FixTags.MsgType));
+        Assert.Equal("SERVER", GetRequired(outboundLogon, FixTags.SenderCompId));
+        Assert.Equal("CLIENT", GetRequired(outboundLogon, FixTags.TargetCompId));
+        Assert.Equal("1", GetRequired(outboundLogon, FixTags.MsgSeqNum));
+
+        clock.AdvanceSeconds(31);
+        FixSessionUpdate heartbeatUpdate = session.Advance();
+        var heartbeat = Assert.Single(heartbeatUpdate.OutboundMessages);
+        Assert.Equal(FixMsgTypes.Heartbeat, GetRequired(heartbeat, FixTags.MsgType));
+        Assert.Equal("2", GetRequired(heartbeat, FixTags.MsgSeqNum));
+
+        clock.AdvanceSeconds(1);
+        FixSessionUpdate inboundHeartbeat = session.Receive(CreateInbound(FixMsgTypes.Heartbeat, 2));
+        Assert.Empty(inboundHeartbeat.OutboundMessages);
+
+        clock.AdvanceSeconds(1);
+        FixSessionUpdate testRequestUpdate = session.Receive(CreateInbound(FixMsgTypes.TestRequest, 3, message => message.Add(FixTags.TestReqId, "ping-1")));
+        var echoedHeartbeat = Assert.Single(testRequestUpdate.OutboundMessages);
+        Assert.Equal(FixMsgTypes.Heartbeat, GetRequired(echoedHeartbeat, FixTags.MsgType));
+        Assert.Equal("ping-1", GetRequired(echoedHeartbeat, FixTags.TestReqId));
+
+        clock.AdvanceSeconds(1);
+        FixSessionUpdate logoutUpdate = session.Receive(CreateInbound(FixMsgTypes.Logout, 4));
+        var logout = Assert.Single(logoutUpdate.OutboundMessages);
+        Assert.True(logoutUpdate.DisconnectTransport);
+        Assert.Equal(FixMsgTypes.Logout, GetRequired(logout, FixTags.MsgType));
+        Assert.Equal(FixSessionState.Disconnected, session.State);
+    }
+
+    [Fact]
+    public void ResendRequest_Replays_Buffered_ApplicationMessages()
+    {
+        var clock = new FakeFixClock();
+        var session = CreateLoggedOnSession(clock, new FixSessionOptions { ApplicationResendBufferCapacity = 8 });
+
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m1"), out _));
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m2"), out _));
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m3"), out _));
+
+        clock.AdvanceSeconds(1);
+        FixSessionUpdate resendUpdate = session.Receive(CreateInbound(FixMsgTypes.ResendRequest, 2, message =>
+        {
+            message.Add(FixTags.BeginSeqNo, 2);
+            message.Add(FixTags.EndSeqNo, 4);
+        }));
+
+        Assert.Equal(3, resendUpdate.OutboundMessages.Count);
+        Assert.All(resendUpdate.OutboundMessages, message => Assert.Equal("Y", GetRequired(message, FixTags.PossDupFlag)));
+        Assert.Equal(new[] { "2", "3", "4" }, resendUpdate.OutboundMessages.Select(m => GetRequired(m, FixTags.MsgSeqNum)).ToArray());
+    }
+
+    [Fact]
+    public void ResendRequest_GapFills_Messages_Evicted_FromCurrentSessionBuffer()
+    {
+        var clock = new FakeFixClock();
+        var session = CreateLoggedOnSession(clock, new FixSessionOptions { ApplicationResendBufferCapacity = 2 });
+
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m1"), out _));
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m2"), out _));
+        Assert.True(session.TrySendApplication(CreateApplicationMessage("m3"), out _));
+
+        clock.AdvanceSeconds(1);
+        FixSessionUpdate resendUpdate = session.Receive(CreateInbound(FixMsgTypes.ResendRequest, 2, message =>
+        {
+            message.Add(FixTags.BeginSeqNo, 2);
+            message.Add(FixTags.EndSeqNo, 4);
+        }));
+
+        Assert.Equal(3, resendUpdate.OutboundMessages.Count);
+
+        FixMessage gapFill = resendUpdate.OutboundMessages[0];
+        Assert.Equal(FixMsgTypes.SequenceReset, GetRequired(gapFill, FixTags.MsgType));
+        Assert.Equal("Y", GetRequired(gapFill, FixTags.PossDupFlag));
+        Assert.Equal("2", GetRequired(gapFill, FixTags.MsgSeqNum));
+        Assert.Equal("3", GetRequired(gapFill, FixTags.NewSeqNo));
+
+        Assert.Equal("3", GetRequired(resendUpdate.OutboundMessages[1], FixTags.MsgSeqNum));
+        Assert.Equal("4", GetRequired(resendUpdate.OutboundMessages[2], FixTags.MsgSeqNum));
+    }
+
+    [Fact]
+    public void Reconnect_WithLowerSequence_Disconnects_Immediately_WithoutLogout()
+    {
+        var clock = new FakeFixClock();
+        var store = new FixSessionStateStore();
+        var firstSession = new FixSessionConnection(store, clock: clock);
+
+        _ = firstSession.Receive(CreateInbound(FixMsgTypes.Logon, 1, message =>
+        {
+            message.Add(FixTags.EncryptMethod, 0);
+            message.Add(FixTags.HeartBtInt, 30);
+        }));
+        clock.AdvanceSeconds(1);
+        _ = firstSession.Receive(CreateInbound(FixMsgTypes.Heartbeat, 2));
+        clock.AdvanceSeconds(1);
+        _ = firstSession.Receive(CreateInbound(FixMsgTypes.Logout, 3));
+
+        var secondSession = new FixSessionConnection(store, clock: clock);
+        FixSessionUpdate reconnect = secondSession.Receive(CreateInbound(FixMsgTypes.Logon, 1, message =>
+        {
+            message.Add(FixTags.EncryptMethod, 0);
+            message.Add(FixTags.HeartBtInt, 30);
+        }));
+
+        Assert.True(reconnect.DisconnectTransport);
+        Assert.Empty(reconnect.OutboundMessages);
+        Assert.Equal(FixSessionState.Disconnected, secondSession.State);
+    }
+
+    private static FixSessionConnection CreateLoggedOnSession(FakeFixClock clock, FixSessionOptions options)
+    {
+        var session = new FixSessionConnection(new FixSessionStateStore(), options, clock);
+        FixSessionUpdate logonUpdate = session.Receive(CreateInbound(FixMsgTypes.Logon, 1, message =>
+        {
+            message.Add(FixTags.EncryptMethod, 0);
+            message.Add(FixTags.HeartBtInt, 30);
+        }));
+        Assert.Single(logonUpdate.OutboundMessages);
+        return session;
+    }
+
+    private static FixMessage CreateInbound(string msgType, int seqNum, Action<FixMessage>? configure = null)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, msgType);
+        message.Add(FixTags.SenderCompId, "CLIENT");
+        message.Add(FixTags.TargetCompId, "SERVER");
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260812-18:32:01.333");
+        configure?.Invoke(message);
+        return message;
+    }
+
+    private static FixMessage CreateApplicationMessage(string mdReqId)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, "X");
+        message.Add(262, mdReqId);
+        message.Add(55, "PETR4");
+        return message;
+    }
+
+    private static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+
+    private sealed class FakeFixClock : IFixClock
+    {
+        private DateTimeOffset _utcNow = new(2026, 8, 12, 18, 32, 1, TimeSpan.Zero);
+        private long _monotonicTicks;
+
+        public DateTimeOffset UtcNow => _utcNow;
+        public long MonotonicTicks => _monotonicTicks;
+
+        public void AdvanceSeconds(int seconds)
+        {
+            _utcNow = _utcNow.AddSeconds(seconds);
+            _monotonicTicks += seconds * 1000L;
+        }
+    }
+}


### PR DESCRIPTION
Closes #90
Part of epic #89

## What changed
- added a minimal in-repo FIX 4.4 tag=value wire codec for `B3.Umdf.FixConflated`, including BodyLength and CheckSum validation and safe decode failure reporting
- added outbound-only zlib compression wrapper using `System.IO.Compression.ZLibStream`
- added an acceptor-side session engine with Logon/Heartbeat/TestRequest/Logout/ResendRequest handling, per-CompID sequence tracking, and bounded in-memory resend buffering for the current session only
- added the B3-specific reconnect rule: a new Logon with inbound `MsgSeqNum` lower than the persisted expected value disconnects immediately without sending Logout
- added a new xUnit test project and wired it into `B3MarketDataPlatform.slnx`

## Design notes
- no authentication is performed on Logon: any `SenderCompID`/`TargetCompID` is accepted by design for this sandbox
- no QuickFIX/n or third-party FIX engine is used; the transport/session logic is intentionally minimal and purpose-built for this channel
- ResendRequest support is intentionally limited to application messages still retained in the current session's bounded in-memory buffer; evicted ranges are answered with `SequenceReset-GapFill`
- the session engine is transport-agnostic and testable without sockets so #91/#92 can build on it before #93 adds the TCP listener

## Validation
- `dotnet build B3MarketDataPlatform.slnx`
- `dotnet test B3MarketDataPlatform.slnx --no-build`
