### PR TITLE
FIX Conflated sandbox: map status/news/security list/totals

### DIFF
--- a/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
@@ -1,0 +1,315 @@
+using System.Globalization;
+
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Small, self-contained instrument descriptor used by the low-frequency FIX
+/// application message builders in this project. Future transport wiring can
+/// populate it from <c>SymbolRegistry</c>, <c>InstrumentInfo</c>, or any other
+/// upstream source without introducing extra project references here.
+/// </summary>
+public sealed record FixInstrumentReference
+{
+    public string? Symbol { get; init; }
+    public string? SecurityId { get; init; }
+    public string? SecurityIdSource { get; init; }
+    public string? SecurityExchange { get; init; }
+    public int? InstrumentId { get; init; }
+    public int? PutOrCall { get; init; }
+    public int? Product { get; init; }
+    public string? CfiCode { get; init; }
+    public string? SecurityGroup { get; init; }
+    public string? SecurityType { get; init; }
+    public string? SecuritySubType { get; init; }
+    public DateOnly? MaturityDate { get; init; }
+    public decimal? ContractMultiplier { get; init; }
+    public string? SecurityDescription { get; init; }
+}
+
+public sealed record FixSecurityStatusDefinition
+{
+    public required FixInstrumentReference Instrument { get; init; }
+    public required int SecurityTradingStatus { get; init; }
+    public required long SourceTimestampNanoseconds { get; init; }
+    public string? SecurityStatusReqId { get; init; }
+    public bool? UnsolicitedIndicator { get; init; }
+    public long? TradSesOpenTimeNanoseconds { get; init; }
+    public int? SecurityTradingEvent { get; init; }
+    public char? HaltReason { get; init; }
+    public decimal? BuyVolume { get; init; }
+    public decimal? SellVolume { get; init; }
+    public decimal? HighPrice { get; init; }
+    public decimal? LowPrice { get; init; }
+    public decimal? LastPrice { get; init; }
+    public DateOnly? TradeDate { get; init; }
+    public string? Text { get; init; }
+}
+
+public sealed record FixNewsDefinition
+{
+    public required long OrigTimeNanoseconds { get; init; }
+    public required string Headline { get; init; }
+    public required string NewsSource { get; init; }
+    public string BodyText { get; init; } = string.Empty;
+    public char? Urgency { get; init; }
+    public string? NewsId { get; init; }
+    public string? LanguageCode { get; init; }
+    public string? Language { get; init; }
+    public IReadOnlyList<FixInstrumentReference> RelatedInstruments { get; init; } = [];
+    public string? UrlLink { get; init; }
+}
+
+public readonly record struct FixMarketDataFeed(string MdFeedType, int MarketDepth, int MdBookType);
+
+public sealed record FixSecurityListEntry
+{
+    public required FixInstrumentReference Instrument { get; init; }
+    public IReadOnlyList<FixMarketDataFeed> MarketDataFeeds { get; init; } = [];
+}
+
+public sealed record FixSecurityListDefinition
+{
+    public IReadOnlyList<FixSecurityListEntry> Securities { get; init; } = [];
+    public string? SecurityReqId { get; init; }
+    public string? SecurityResponseId { get; init; }
+    public char? SecurityRequestResult { get; init; }
+    public bool LastFragment { get; init; } = true;
+    public string? SecurityListId { get; init; }
+    public string? SecurityListRefId { get; init; }
+    public string? SecurityListDesc { get; init; }
+    public int? SecurityListType { get; init; }
+    public int? SecurityListTypeSource { get; init; }
+    public DateTimeOffset? TransactTimeUtc { get; init; }
+}
+
+public sealed record FixSecurityListRequestDefinition
+{
+    public required string SecurityReqId { get; init; }
+    public required char SubscriptionRequestType { get; init; }
+    public string? SecurityType { get; init; }
+    public int? Product { get; init; }
+    public string? CfiCode { get; init; }
+    public int? SecurityListRequestType { get; init; }
+    public DateTimeOffset? SecurityUpdatesSinceUtc { get; init; }
+}
+
+public readonly record struct FixMarketTotalsBroadcastEntry(
+    char MdEntryType,
+    string Symbol,
+    DateOnly EntryDateUtc,
+    TimeOnly EntryTimeUtc,
+    decimal GrossTradeAmount,
+    decimal TotalVolumeTraded,
+    int TotalNumberOfTrades);
+
+public sealed record FixMarketTotalsBroadcastDefinition
+{
+    public IReadOnlyList<FixMarketTotalsBroadcastEntry> Entries { get; init; } = [];
+}
+
+public sealed record FixMarketTotalsCompositionEntry
+{
+    public required string Symbol { get; init; }
+    public required string SecurityDescription { get; init; }
+    public IReadOnlyList<string> SecurityGroups { get; init; } = [];
+}
+
+public sealed record FixMarketTotalsCompositionDefinition
+{
+    public IReadOnlyList<FixMarketTotalsCompositionEntry> Entries { get; init; } = [];
+    public bool LastFragment { get; init; } = true;
+    public string? IndexId { get; init; }
+}
+
+public sealed record FixMarketTotalsRequestDefinition
+{
+    public required string MdReqId { get; init; }
+    public required char SubscriptionRequestType { get; init; }
+}
+
+public sealed record FixMarketTotalsResponseDefinition
+{
+    public required string MdReqId { get; init; }
+    public char? MdReqRejReason { get; init; }
+    public string? Text { get; init; }
+}
+
+internal static class FixApplicationMsgTypes
+{
+    public const string News = "B";
+    public const string SecurityStatus = "f";
+    public const string SecurityListRequest = "x";
+    public const string SecurityList = "y";
+    public const string MarketTotalsBroadcast = "UTOT";
+    public const string MarketTotalsComposition = "UTOTC";
+    public const string MarketTotalsRequest = "UTOTQ";
+    public const string MarketTotalsResponse = "UTOTP";
+}
+
+internal static class FixApplicationTags
+{
+    public const int SecurityIdSource = 22;
+    public const int NoLinesOfText = 33;
+    public const int OrigTime = 42;
+    public const int SecurityId = 48;
+    public const int Symbol = 55;
+    public const int Text = 58;
+    public const int TransactTime = 60;
+    public const int Urgency = 61;
+    public const int TradeDate = 75;
+    public const int SecurityDescription = 107;
+    public const int Headline = 148;
+    public const int UrlLink = 149;
+    public const int NoRelatedSym = 146;
+    public const int SecurityType = 167;
+    public const int PutOrCall = 201;
+    public const int SecurityExchange = 207;
+    public const int ContractMultiplier = 231;
+    public const int MDReqID = 262;
+    public const int SubscriptionRequestType = 263;
+    public const int MarketDepth = 264;
+    public const int NoMdEntries = 268;
+    public const int MdEntryType = 269;
+    public const int MdEntryDate = 272;
+    public const int MdEntryTime = 273;
+    public const int MdReqRejReason = 281;
+    public const int SecurityReqId = 320;
+    public const int SecurityResponseId = 322;
+    public const int SecurityStatusReqId = 324;
+    public const int UnsolicitedIndicator = 325;
+    public const int SecurityTradingStatus = 326;
+    public const int HaltReason = 327;
+    public const int BuyVolume = 330;
+    public const int SellVolume = 331;
+    public const int HighPrice = 332;
+    public const int LowPrice = 333;
+    public const int TradSesOpenTime = 342;
+    public const int GrossTradeAmt = 381;
+    public const int TotalVolumeTraded = 387;
+    public const int TotNoRelatedSym = 393;
+    public const int LastPx = 31;
+    public const int Product = 460;
+    public const int CfiCode = 461;
+    public const int MaturityDate = 541;
+    public const int SecurityListRequestType = 559;
+    public const int SecurityRequestResult = 560;
+    public const int SecuritySubType = 762;
+    public const int LastFragment = 893;
+    public const int MdBookType = 1021;
+    public const int MdFeedType = 1022;
+    public const int NoMdFeedTypes = 1141;
+    public const int SecurityGroup = 1151;
+    public const int SecurityTradingEvent = 1174;
+    public const int SecurityListId = 1465;
+    public const int SecurityListRefId = 1466;
+    public const int SecurityListDesc = 1467;
+    public const int SecurityListType = 1470;
+    public const int SecurityListTypeSource = 1471;
+    public const int NewsId = 1472;
+    public const int LanguageCode = 1474;
+    public const int IndexId = 6107;
+    public const int TotalNumOfTrades = 6139;
+    public const int SecurityUpdatesSince = 6935;
+    public const int Language = 6936;
+    public const int NewsSource = 6940;
+    public const int InstrumentId = 9219;
+    public const int NoSecurityGroups = 37022;
+}
+
+internal static class FixApplicationMessageBuilderSupport
+{
+    public static DateTimeOffset FromUnixNanoseconds(long value)
+        => DateTimeOffset.UnixEpoch.AddTicks(value / 100);
+
+    public static string FormatLocalDate(DateOnly value)
+        => value.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+    public static string FormatUtcTime(TimeOnly value)
+        => value.Millisecond == 0
+            ? value.ToString("HH:mm:ss", CultureInfo.InvariantCulture)
+            : value.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
+
+    public static string FormatDecimal(decimal value)
+        => value.ToString(CultureInfo.InvariantCulture);
+
+    public static string[] SplitTextLines(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n', StringSplitOptions.None);
+
+    public static void AppendInstrumentPrefix(FixMessage message, FixInstrumentReference instrument)
+    {
+        AddOptionalString(message, FixApplicationTags.Symbol, instrument.Symbol);
+        AddOptionalString(message, FixApplicationTags.SecurityId, instrument.SecurityId);
+        AddOptionalString(message, FixApplicationTags.SecurityIdSource, instrument.SecurityIdSource);
+        AddOptionalString(message, FixApplicationTags.SecurityExchange, instrument.SecurityExchange);
+    }
+
+    public static void AppendInstrumentSuffix(FixMessage message, FixInstrumentReference instrument)
+    {
+        AddOptionalInt(message, FixApplicationTags.InstrumentId, instrument.InstrumentId);
+        AddOptionalInt(message, FixApplicationTags.PutOrCall, instrument.PutOrCall);
+        AddOptionalInt(message, FixApplicationTags.Product, instrument.Product);
+        AddOptionalString(message, FixApplicationTags.CfiCode, instrument.CfiCode);
+        AddOptionalString(message, FixApplicationTags.SecurityGroup, instrument.SecurityGroup);
+        AddOptionalString(message, FixApplicationTags.SecurityType, instrument.SecurityType);
+        AddOptionalString(message, FixApplicationTags.SecuritySubType, instrument.SecuritySubType);
+        AddOptionalDate(message, FixApplicationTags.MaturityDate, instrument.MaturityDate);
+        AddOptionalDecimal(message, FixApplicationTags.ContractMultiplier, instrument.ContractMultiplier);
+        AddOptionalString(message, FixApplicationTags.SecurityDescription, instrument.SecurityDescription);
+    }
+
+    public static void AddRequiredString(FixMessage message, int tag, string value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(value);
+        message.Add(tag, value);
+    }
+
+    public static void AddOptionalString(FixMessage message, int tag, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+            message.Add(tag, value);
+    }
+
+    public static void AddOptionalInt(FixMessage message, int tag, int? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, actual);
+    }
+
+    public static void AddOptionalBoolean(FixMessage message, int tag, bool? value)
+    {
+        if (value is { } actual)
+            message.AddBoolean(tag, actual);
+    }
+
+    public static void AddOptionalChar(FixMessage message, int tag, char? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, actual.ToString());
+    }
+
+    public static void AddOptionalDecimal(FixMessage message, int tag, decimal? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, FormatDecimal(actual));
+    }
+
+    public static void AddOptionalDate(FixMessage message, int tag, DateOnly? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, FormatLocalDate(actual));
+    }
+
+    public static void AddOptionalUtcTimestamp(FixMessage message, int tag, DateTimeOffset? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, FixValueFormatting.FormatUtcTimestamp(actual));
+    }
+
+    public static void AddOptionalUnixNanosTimestamp(FixMessage message, int tag, long? value)
+    {
+        if (value is { } actual)
+            message.Add(tag, FixValueFormatting.FormatUtcTimestamp(FromUnixNanoseconds(actual)));
+    }
+}

--- a/src/B3.Umdf.FixConflated/MarketTotalsMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/MarketTotalsMessageBuilder.cs
@@ -1,0 +1,89 @@
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Best-effort builders for the proprietary MarketTotals* messages exposed by
+/// the vendored UMDF conflated dictionary.
+/// </summary>
+public static class MarketTotalsMessageBuilder
+{
+    public static FixMessage BuildBroadcast(FixMarketTotalsBroadcastDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (definition.Entries.Count == 0)
+            throw new ArgumentException("MarketTotalsBroadcast requires at least one entry.", nameof(definition));
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.MarketTotalsBroadcast);
+        message.Add(FixApplicationTags.NoMdEntries, definition.Entries.Count);
+
+        foreach (FixMarketTotalsBroadcastEntry entry in definition.Entries)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(entry.Symbol);
+            message.Add(FixApplicationTags.MdEntryType, entry.MdEntryType.ToString());
+            message.Add(FixApplicationTags.Symbol, entry.Symbol);
+            message.Add(FixApplicationTags.MdEntryDate, FixApplicationMessageBuilderSupport.FormatLocalDate(entry.EntryDateUtc));
+            message.Add(FixApplicationTags.MdEntryTime, FixApplicationMessageBuilderSupport.FormatUtcTime(entry.EntryTimeUtc));
+            message.Add(FixApplicationTags.GrossTradeAmt, FixApplicationMessageBuilderSupport.FormatDecimal(entry.GrossTradeAmount));
+            message.Add(FixApplicationTags.TotalVolumeTraded, FixApplicationMessageBuilderSupport.FormatDecimal(entry.TotalVolumeTraded));
+            message.Add(FixApplicationTags.TotalNumOfTrades, entry.TotalNumberOfTrades);
+        }
+
+        return message;
+    }
+
+    public static FixMessage BuildComposition(FixMarketTotalsCompositionDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        if (definition.Entries.Count == 0)
+            throw new ArgumentException("MarketTotalsComposition requires at least one entry.", nameof(definition));
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.MarketTotalsComposition);
+        message.Add(FixApplicationTags.TotNoRelatedSym, definition.Entries.Count);
+        message.AddBoolean(FixApplicationTags.LastFragment, definition.LastFragment);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.IndexId, definition.IndexId);
+        message.Add(FixApplicationTags.NoRelatedSym, definition.Entries.Count);
+
+        foreach (FixMarketTotalsCompositionEntry entry in definition.Entries)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(entry.Symbol);
+            ArgumentException.ThrowIfNullOrEmpty(entry.SecurityDescription);
+            message.Add(FixApplicationTags.Symbol, entry.Symbol);
+            message.Add(FixApplicationTags.SecurityDescription, entry.SecurityDescription);
+
+            if (entry.SecurityGroups.Count == 0)
+                continue;
+
+            message.Add(FixApplicationTags.NoSecurityGroups, entry.SecurityGroups.Count);
+            foreach (string securityGroup in entry.SecurityGroups)
+                FixApplicationMessageBuilderSupport.AddRequiredString(message, FixApplicationTags.SecurityGroup, securityGroup);
+        }
+
+        return message;
+    }
+
+    public static FixMessage BuildRequest(FixMarketTotalsRequestDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(definition.MdReqId);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.MarketTotalsRequest);
+        message.Add(FixApplicationTags.MDReqID, definition.MdReqId);
+        message.Add(FixApplicationTags.SubscriptionRequestType, definition.SubscriptionRequestType.ToString());
+        return message;
+    }
+
+    public static FixMessage BuildResponse(FixMarketTotalsResponseDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(definition.MdReqId);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.MarketTotalsResponse);
+        message.Add(FixApplicationTags.MDReqID, definition.MdReqId);
+        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.MdReqRejReason, definition.MdReqRejReason);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Text, definition.Text);
+        return message;
+    }
+}

--- a/src/B3.Umdf.FixConflated/NewsMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/NewsMessageBuilder.cs
@@ -1,0 +1,45 @@
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Maps fully reassembled news payloads onto FIX 4.4 <c>News</c> messages.
+/// </summary>
+public static class NewsMessageBuilder
+{
+    public static FixMessage Build(FixNewsDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(definition.Headline);
+        ArgumentException.ThrowIfNullOrEmpty(definition.NewsSource);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.News);
+        message.Add(
+            FixApplicationTags.OrigTime,
+            FixValueFormatting.FormatUtcTimestamp(
+                FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.OrigTimeNanoseconds)));
+        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.Urgency, definition.Urgency);
+        message.Add(FixApplicationTags.Headline, definition.Headline);
+        message.Add(FixApplicationTags.NewsSource, definition.NewsSource);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.NewsId, definition.NewsId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.LanguageCode, definition.LanguageCode);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Language, definition.Language);
+
+        if (definition.RelatedInstruments.Count > 0)
+        {
+            message.Add(FixApplicationTags.NoRelatedSym, definition.RelatedInstruments.Count);
+            foreach (FixInstrumentReference instrument in definition.RelatedInstruments)
+            {
+                FixApplicationMessageBuilderSupport.AppendInstrumentPrefix(message, instrument);
+                FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, instrument);
+            }
+        }
+
+        string[] lines = FixApplicationMessageBuilderSupport.SplitTextLines(definition.BodyText);
+        message.Add(FixApplicationTags.NoLinesOfText, lines.Length);
+        foreach (string line in lines)
+            message.Add(FixApplicationTags.Text, line);
+
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.UrlLink, definition.UrlLink);
+        return message;
+    }
+}

--- a/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
@@ -1,0 +1,69 @@
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Builds <c>SecurityList</c> and <c>SecurityListRequest</c> messages from
+/// small DTOs so transport wiring can stay decoupled from upstream registries.
+/// </summary>
+public static class SecurityListMessageBuilder
+{
+    public static FixMessage Build(FixSecurityListDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.SecurityList);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityReqId, definition.SecurityReqId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityResponseId, definition.SecurityResponseId);
+        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.SecurityRequestResult, definition.SecurityRequestResult);
+        message.Add(FixApplicationTags.TotNoRelatedSym, definition.Securities.Count);
+        message.AddBoolean(FixApplicationTags.LastFragment, definition.LastFragment);
+
+        if (definition.Securities.Count > 0)
+        {
+            message.Add(FixApplicationTags.NoRelatedSym, definition.Securities.Count);
+            foreach (FixSecurityListEntry security in definition.Securities)
+            {
+                ArgumentNullException.ThrowIfNull(security.Instrument);
+                if (security.MarketDataFeeds.Count == 0)
+                    throw new ArgumentException("SecurityList entries require at least one MD feed type.", nameof(definition));
+
+                FixApplicationMessageBuilderSupport.AppendInstrumentPrefix(message, security.Instrument);
+                message.Add(FixApplicationTags.NoMdFeedTypes, security.MarketDataFeeds.Count);
+                foreach (FixMarketDataFeed feed in security.MarketDataFeeds)
+                {
+                    ArgumentException.ThrowIfNullOrEmpty(feed.MdFeedType);
+                    message.Add(FixApplicationTags.MdFeedType, feed.MdFeedType);
+                    message.Add(FixApplicationTags.MarketDepth, feed.MarketDepth);
+                    message.Add(FixApplicationTags.MdBookType, feed.MdBookType);
+                }
+
+                FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, security.Instrument);
+            }
+        }
+
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityListId, definition.SecurityListId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityListRefId, definition.SecurityListRefId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityListDesc, definition.SecurityListDesc);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityListType, definition.SecurityListType);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityListTypeSource, definition.SecurityListTypeSource);
+        FixApplicationMessageBuilderSupport.AddOptionalUtcTimestamp(message, FixApplicationTags.TransactTime, definition.TransactTimeUtc);
+        return message;
+    }
+
+    public static FixMessage BuildRequest(FixSecurityListRequestDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrEmpty(definition.SecurityReqId);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.SecurityListRequest);
+        message.Add(FixApplicationTags.SecurityReqId, definition.SecurityReqId);
+        message.Add(FixApplicationTags.SubscriptionRequestType, definition.SubscriptionRequestType.ToString());
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityType, definition.SecurityType);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.Product, definition.Product);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.CfiCode, definition.CfiCode);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityListRequestType, definition.SecurityListRequestType);
+        FixApplicationMessageBuilderSupport.AddOptionalUtcTimestamp(message, FixApplicationTags.SecurityUpdatesSince, definition.SecurityUpdatesSinceUtc);
+        return message;
+    }
+}

--- a/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
@@ -1,0 +1,43 @@
+namespace B3.Umdf.FixConflated;
+
+/// <summary>
+/// Builds low-frequency <c>SecurityStatus</c> application messages using the
+/// existing session-plane <see cref="FixMessage"/> model.
+/// </summary>
+public static class SecurityStatusMessageBuilder
+{
+    public static FixMessage Build(FixSecurityStatusDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(definition.Instrument);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixApplicationMsgTypes.SecurityStatus);
+
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityStatusReqId, definition.SecurityStatusReqId);
+        FixApplicationMessageBuilderSupport.AppendInstrumentPrefix(message, definition.Instrument);
+        FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, definition.Instrument);
+        FixApplicationMessageBuilderSupport.AddOptionalBoolean(message, FixApplicationTags.UnsolicitedIndicator, definition.UnsolicitedIndicator);
+        FixApplicationMessageBuilderSupport.AddOptionalUnixNanosTimestamp(message, FixApplicationTags.TradSesOpenTime, definition.TradSesOpenTimeNanoseconds);
+        message.Add(FixApplicationTags.SecurityTradingStatus, definition.SecurityTradingStatus);
+
+        DateOnly tradeDate = definition.TradeDate
+            ?? DateOnly.FromDateTime(FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds).UtcDateTime);
+        message.Add(FixApplicationTags.TradeDate, FixApplicationMessageBuilderSupport.FormatLocalDate(tradeDate));
+
+        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.HaltReason, definition.HaltReason);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.BuyVolume, definition.BuyVolume);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.SellVolume, definition.SellVolume);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.HighPrice, definition.HighPrice);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LowPrice, definition.LowPrice);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LastPx, definition.LastPrice);
+        message.Add(
+            FixApplicationTags.TransactTime,
+            FixValueFormatting.FormatUtcTimestamp(
+                FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds)));
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Text, definition.Text);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityTradingEvent, definition.SecurityTradingEvent);
+
+        return message;
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageTestHelpers.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageTestHelpers.cs
@@ -1,0 +1,24 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+internal static class FixApplicationMessageTestHelpers
+{
+    public static FixMessage RoundTrip(FixMessage message)
+    {
+        byte[] encoded = FixMessageCodec.Encode(message);
+        var decoded = FixMessageCodec.Decode(encoded);
+        Assert.True(decoded.Success);
+        Assert.NotNull(decoded.Message);
+        return decoded.Message!;
+    }
+
+    public static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+
+    public static string[] GetAllValues(FixMessage message, int tag)
+        => message.Fields.Where(f => f.Tag == tag).Select(f => f.Value).ToArray();
+}

--- a/tests/B3.Umdf.FixConflated.Tests/MarketTotalsMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/MarketTotalsMessageBuilderTests.cs
@@ -1,0 +1,87 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class MarketTotalsMessageBuilderTests
+{
+    [Fact]
+    public void BuildBroadcast_Produces_Parseable_MarketTotalsBroadcast()
+    {
+        var message = MarketTotalsMessageBuilder.BuildBroadcast(new FixMarketTotalsBroadcastDefinition
+        {
+            Entries =
+            [
+                new FixMarketTotalsBroadcastEntry('B', "PETR4", new DateOnly(2026, 8, 12), new TimeOnly(14, 15, 16, 789), 1_250_000.55m, 125_000m, 97),
+                new FixMarketTotalsBroadcastEntry('B', "VALE3", new DateOnly(2026, 8, 12), new TimeOnly(14, 15, 17), 980_000.10m, 87_500m, 61)
+            ]
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.MarketTotalsBroadcast, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoMdEntries));
+        Assert.Equal(["PETR4", "VALE3"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.Symbol));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal(["1250000.55", "980000.10"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.GrossTradeAmt));
+        Assert.Equal(["97", "61"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.TotalNumOfTrades));
+    }
+
+    [Fact]
+    public void BuildComposition_Produces_Parseable_MarketTotalsComposition()
+    {
+        var message = MarketTotalsMessageBuilder.BuildComposition(new FixMarketTotalsCompositionDefinition
+        {
+            IndexId = "IBOV",
+            LastFragment = true,
+            Entries =
+            [
+                new FixMarketTotalsCompositionEntry
+                {
+                    Symbol = "PETR4",
+                    SecurityDescription = "PETROBRAS PN",
+                    SecurityGroups = ["ENERGY", "IBOV"]
+                },
+                new FixMarketTotalsCompositionEntry
+                {
+                    Symbol = "VALE3",
+                    SecurityDescription = "VALE ON"
+                }
+            ]
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.MarketTotalsComposition, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TotNoRelatedSym));
+        Assert.Equal("Y", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.LastFragment));
+        Assert.Equal("IBOV", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.IndexId));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal(["PETR4", "VALE3"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.Symbol));
+        Assert.Equal(["2"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.NoSecurityGroups));
+        Assert.Equal(["ENERGY", "IBOV"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.SecurityGroup));
+    }
+
+    [Fact]
+    public void BuildRequestAndResponse_Produce_Parseable_MarketTotalsControlMessages()
+    {
+        FixMessage request = MarketTotalsMessageBuilder.BuildRequest(new FixMarketTotalsRequestDefinition
+        {
+            MdReqId = "totals-1",
+            SubscriptionRequestType = '0'
+        });
+
+        FixMessage response = MarketTotalsMessageBuilder.BuildResponse(new FixMarketTotalsResponseDefinition
+        {
+            MdReqId = "totals-1",
+            MdReqRejReason = '1',
+            Text = "Unsupported filter"
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.MarketTotalsRequest, FixApplicationMessageTestHelpers.GetRequired(request, FixTags.MsgType));
+        Assert.Equal(FixApplicationMsgTypes.MarketTotalsResponse, FixApplicationMessageTestHelpers.GetRequired(response, FixTags.MsgType));
+
+        FixMessage decodedRequest = FixApplicationMessageTestHelpers.RoundTrip(request);
+        FixMessage decodedResponse = FixApplicationMessageTestHelpers.RoundTrip(response);
+        Assert.Equal("0", FixApplicationMessageTestHelpers.GetRequired(decodedRequest, FixApplicationTags.SubscriptionRequestType));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(decodedResponse, FixApplicationTags.MdReqRejReason));
+        Assert.Equal("Unsupported filter", FixApplicationMessageTestHelpers.GetRequired(decodedResponse, FixApplicationTags.Text));
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/NewsMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/NewsMessageBuilderTests.cs
@@ -1,0 +1,45 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class NewsMessageBuilderTests
+{
+    [Fact]
+    public void Build_Splits_BodyText_Into_NoLinesOfText_Group()
+    {
+        var message = NewsMessageBuilder.Build(new FixNewsDefinition
+        {
+            OrigTimeNanoseconds = 1_786_544_116_789_000_000,
+            Headline = "PETR4 enters auction",
+            BodyText = "Line one\nLine two",
+            NewsSource = "B3",
+            NewsId = "9001",
+            LanguageCode = "pt",
+            Language = "pt-BR",
+            UrlLink = "https://example.test/news/9001",
+            RelatedInstruments =
+            [
+                new FixInstrumentReference
+                {
+                    Symbol = "PETR4",
+                    SecurityId = "12345",
+                    SecurityIdSource = "8",
+                    SecurityExchange = "BVMF",
+                    InstrumentId = 99
+                }
+            ]
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.News, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("20260812-14:15:16.789", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.OrigTime));
+        Assert.Equal("PETR4 enters auction", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Headline));
+        Assert.Equal("B3", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NewsSource));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoRelatedSym));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoLinesOfText));
+        Assert.Equal(["Line one", "Line two"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.Text));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal(["Line one", "Line two"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.Text));
+        Assert.Equal("https://example.test/news/9001", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.UrlLink));
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
@@ -1,0 +1,96 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class SecurityListMessageBuilderTests
+{
+    [Fact]
+    public void BuildRequest_Produces_Parseable_SecurityListRequest()
+    {
+        var message = SecurityListMessageBuilder.BuildRequest(new FixSecurityListRequestDefinition
+        {
+            SecurityReqId = "req-42",
+            SubscriptionRequestType = '1',
+            SecurityType = "CS",
+            Product = 4,
+            CfiCode = "ESVUFR",
+            SecurityListRequestType = 4,
+            SecurityUpdatesSinceUtc = new DateTimeOffset(2026, 8, 12, 14, 0, 0, TimeSpan.Zero)
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.SecurityListRequest, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("req-42", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityReqId));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SubscriptionRequestType));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal("20260812-14:00:00.000", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.SecurityUpdatesSince));
+    }
+
+    [Fact]
+    public void Build_Produces_Parseable_SecurityList_WithNestedFeedGroups()
+    {
+        var message = SecurityListMessageBuilder.Build(new FixSecurityListDefinition
+        {
+            SecurityReqId = "req-42",
+            SecurityResponseId = "resp-42",
+            SecurityRequestResult = '0',
+            LastFragment = true,
+            SecurityListId = "list-1",
+            SecurityListDesc = "Cash equities",
+            Securities =
+            [
+                new FixSecurityListEntry
+                {
+                    Instrument = new FixInstrumentReference
+                    {
+                        Symbol = "PETR4",
+                        SecurityId = "12345",
+                        SecurityIdSource = "8",
+                        SecurityExchange = "BVMF",
+                        InstrumentId = 99,
+                        Product = 4,
+                        CfiCode = "ESVUFR",
+                        SecurityGroup = "EQUITY",
+                        SecurityType = "CS"
+                    },
+                    MarketDataFeeds =
+                    [
+                        new FixMarketDataFeed("BOOK", 10, 1),
+                        new FixMarketDataFeed("TRADES", 1, 2)
+                    ]
+                },
+                new FixSecurityListEntry
+                {
+                    Instrument = new FixInstrumentReference
+                    {
+                        Symbol = "VALE3",
+                        SecurityId = "67890",
+                        SecurityIdSource = "8",
+                        SecurityExchange = "BVMF",
+                        InstrumentId = 100,
+                        Product = 4,
+                        CfiCode = "ESVUFR",
+                        SecurityGroup = "EQUITY",
+                        SecurityType = "CS"
+                    },
+                    MarketDataFeeds =
+                    [
+                        new FixMarketDataFeed("BOOK", 10, 1)
+                    ]
+                }
+            ]
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.SecurityList, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TotNoRelatedSym));
+        Assert.Equal("Y", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.LastFragment));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoRelatedSym));
+        Assert.Equal(["PETR4", "VALE3"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.Symbol));
+        Assert.Equal(["2", "1"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.NoMdFeedTypes));
+        Assert.Equal(["BOOK", "TRADES", "BOOK"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.MdFeedType));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal(["10", "1", "10"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.MarketDepth));
+        Assert.Equal("list-1", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.SecurityListId));
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
@@ -1,0 +1,52 @@
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class SecurityStatusMessageBuilderTests
+{
+    [Fact]
+    public void Build_Produces_Parseable_SecurityStatus_WithRequiredAndMappedFields()
+    {
+        var message = SecurityStatusMessageBuilder.Build(new FixSecurityStatusDefinition
+        {
+            Instrument = new FixInstrumentReference
+            {
+                Symbol = "PETR4",
+                SecurityId = "12345",
+                SecurityIdSource = "8",
+                SecurityExchange = "BVMF",
+                InstrumentId = 99,
+                Product = 4,
+                CfiCode = "ESVUFR",
+                SecurityGroup = "EQUITY",
+                SecurityType = "CS",
+                SecuritySubType = "PN",
+                ContractMultiplier = 1m,
+                SecurityDescription = "PETROBRAS PN"
+            },
+            SecurityTradingStatus = 2,
+            SourceTimestampNanoseconds = 1_786_544_116_789_000_000,
+            SecurityTradingEvent = 1,
+            UnsolicitedIndicator = true,
+            Text = "Trading halted",
+            BuyVolume = 1200m,
+            SellVolume = 800m,
+            HighPrice = 31.25m,
+            LowPrice = 29.80m,
+            LastPrice = 30.15m
+        });
+
+        Assert.Equal(FixApplicationMsgTypes.SecurityStatus, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
+        Assert.Equal("PETR4", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Symbol));
+        Assert.Equal("12345", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityId));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingStatus));
+        Assert.Equal("20260812", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradeDate));
+        Assert.Equal("20260812-14:15:16.789", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TransactTime));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingEvent));
+        Assert.Equal("Y", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.UnsolicitedIndicator));
+
+        FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
+        Assert.Equal("Trading halted", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.Text));
+        Assert.Equal("30.15", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.LastPx));
+    }
+}


### PR DESCRIPTION
## Summary
- add low-frequency FIX 4.4 builders for SecurityStatus, News, SecurityList/SecurityListRequest, and MarketTotals* messages on top of the existing #90 `FixMessage` / `FixMessageCodec`
- keep `B3.Umdf.FixConflated` decoupled from transport/server-only pipeline types by introducing small local DTOs future wiring can populate
- add unit coverage for required dictionary fields, repeating groups, and encode/decode round-trips

## Key files / types
- `src/B3.Umdf.FixConflated/FixApplicationMessages.cs`
- `src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs`
- `src/B3.Umdf.FixConflated/NewsMessageBuilder.cs`
- `src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs`
- `src/B3.Umdf.FixConflated/MarketTotalsMessageBuilder.cs`
- `tests/B3.Umdf.FixConflated.Tests/*MessageBuilderTests.cs`

## Design notes
- message builders take simple local DTOs instead of direct `NewsReassembler` / `SymbolRegistry` / server ranking types so #93 can wire real sources later without adding forbidden project references here
- `SecurityStatus` and `News` accept source timestamps as Unix nanoseconds and format the required FIX timestamps inside the builder
- `MarketTotals*` is implemented as best-effort builder-only support: request/response/broadcast/composition mapping exists, but live aggregate sourcing is intentionally deferred to future wiring

## Validation
- `dotnet build B3MarketDataPlatform.slnx`
- `dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj`

Closes #92
