### PR TITLE
Implement FIX conflated book/trade encoding and batching

### DIFF
--- a/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
@@ -1,0 +1,397 @@
+using System.Buffers;
+using System.Buffers.Text;
+using System.Text;
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixApplicationMessageWriter : IDisposable
+{
+    private const int MaxReservedPrefixLength = 32;
+    private static readonly Encoding s_ascii = Encoding.ASCII;
+
+    private readonly ArrayPool<byte> _bufferPool;
+    private byte[] _buffer;
+    private bool _disposed;
+    private int _writtenLength;
+
+    public FixApplicationMessageWriter(int initialBufferSize = 4 * 1024, ArrayPool<byte>? bufferPool = null)
+    {
+        if (initialBufferSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(initialBufferSize));
+
+        _bufferPool = bufferPool ?? ArrayPool<byte>.Shared;
+        _buffer = _bufferPool.Rent(initialBufferSize);
+    }
+
+    public ReadOnlyMemory<byte> WriteIncrementalRefresh(
+        FixApplicationSessionHeader header,
+        FixMarketDataInstrument instrument,
+        ReadOnlySpan<FixMarketDataIncrementalEntry> entries,
+        string? mdReqId = null)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (entries.IsEmpty)
+            throw new ArgumentException("At least one incremental entry is required.", nameof(entries));
+
+        EnsureCapacity(EstimateIncrementalFrameSize(header, instrument, entries.Length, mdReqId));
+
+        int bodyStart = MaxReservedPrefixLength;
+        int bodyLength = WriteIncrementalBody(
+            _buffer.AsSpan(bodyStart),
+            header,
+            instrument,
+            entries,
+            mdReqId);
+
+        return FinalizeFrame(header.BeginString, bodyStart, bodyLength);
+    }
+
+    public ReadOnlyMemory<byte> WriteSnapshotFullRefresh(
+        FixApplicationSessionHeader header,
+        FixMarketDataSnapshotRequest request,
+        OrderBook book)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        int entryCount = book.Bids.OrderCount + book.Asks.OrderCount;
+        EnsureCapacity(EstimateSnapshotFrameSize(header, request, entryCount));
+
+        int bodyStart = MaxReservedPrefixLength;
+        int bodyLength = WriteSnapshotBody(
+            _buffer.AsSpan(bodyStart),
+            header,
+            request,
+            book,
+            entryCount);
+
+        return FinalizeFrame(header.BeginString, bodyStart, bodyLength);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _bufferPool.Return(_buffer);
+        _buffer = [];
+        _writtenLength = 0;
+        _disposed = true;
+    }
+
+    private ReadOnlyMemory<byte> FinalizeFrame(string beginString, int bodyStart, int bodyLength)
+    {
+        Span<byte> beginStringBytes = stackalloc byte[Math.Max(beginString.Length, 1)];
+        int beginStringLength = s_ascii.GetBytes(beginString, beginStringBytes);
+        int prefixLength = FixFrameEncoding.WritePrefix(_buffer, beginStringBytes[..beginStringLength], bodyLength);
+
+        if (prefixLength != bodyStart)
+            _buffer.AsSpan(bodyStart, bodyLength).CopyTo(_buffer.AsSpan(prefixLength));
+
+        int checksumOffset = prefixLength + bodyLength;
+        int checksum = FixFrameEncoding.CalculateChecksum(_buffer.AsSpan(0, checksumOffset));
+        int checksumLength = FixFrameEncoding.WriteChecksumField(_buffer.AsSpan(checksumOffset), checksum);
+
+        _writtenLength = checksumOffset + checksumLength;
+        return _buffer.AsMemory(0, _writtenLength);
+    }
+
+    private static int WriteIncrementalBody(
+        Span<byte> destination,
+        FixApplicationSessionHeader header,
+        FixMarketDataInstrument instrument,
+        ReadOnlySpan<FixMarketDataIncrementalEntry> entries,
+        string? mdReqId)
+    {
+        int offset = 0;
+        offset += WriteSessionHeader(destination[offset..], header, FixMsgTypes.MarketDataIncrementalRefresh);
+
+        if (!string.IsNullOrEmpty(mdReqId))
+            offset += WriteStringField(destination[offset..], FixTags.MDReqId, mdReqId);
+
+        offset += WriteIntField(destination[offset..], FixTags.NoMDEntries, entries.Length);
+
+        foreach (ref readonly var entry in entries)
+        {
+            offset += WriteCharField(destination[offset..], FixTags.MDUpdateAction, (char)entry.UpdateAction);
+            offset += WriteCharField(destination[offset..], FixTags.MDEntryType, (char)entry.EntryType);
+            offset += WriteStringField(destination[offset..], FixTags.Symbol, instrument.Symbol);
+            offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, instrument.SecurityId);
+
+            if ((entry.Fields & FixMarketDataEntryFields.Price) != 0)
+                offset += WriteScaledInt64Field(destination[offset..], FixTags.MDEntryPx, entry.Price, instrument.PriceScale);
+            if ((entry.Fields & FixMarketDataEntryFields.Size) != 0)
+                offset += WriteInt64Field(destination[offset..], FixTags.MDEntrySize, entry.Size);
+
+            offset += WriteUtcDateField(destination[offset..], FixTags.MDEntryDate, entry.EntryTime);
+            offset += WriteUtcTimeField(destination[offset..], FixTags.MDEntryTime, entry.EntryTime);
+
+            if ((entry.Fields & FixMarketDataEntryFields.OrderId) != 0)
+                offset += WriteUInt64Field(destination[offset..], FixTags.OrderId, entry.OrderId);
+            if ((entry.Fields & FixMarketDataEntryFields.TradeId) != 0)
+                offset += WriteInt64Field(destination[offset..], FixTags.TradeId, entry.TradeId);
+        }
+
+        return offset;
+    }
+
+    private static int WriteSnapshotBody(
+        Span<byte> destination,
+        FixApplicationSessionHeader header,
+        FixMarketDataSnapshotRequest request,
+        OrderBook book,
+        int entryCount)
+    {
+        int offset = 0;
+        offset += WriteSessionHeader(destination[offset..], header, FixMsgTypes.MarketDataSnapshotFullRefresh);
+        offset += WriteStringField(destination[offset..], FixTags.MDReqId, request.MdReqId);
+        offset += WriteStringField(destination[offset..], FixTags.Symbol, request.Instrument.Symbol);
+        offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, request.Instrument.SecurityId);
+        offset += WriteIntField(destination[offset..], FixTags.NoMDEntries, entryCount);
+
+        offset += WriteSnapshotSide(destination[offset..], book.Bids, FixMdEntryType.Bid, request.Instrument.PriceScale, header.SendingTime);
+        offset += WriteSnapshotSide(destination[offset..], book.Asks, FixMdEntryType.Offer, request.Instrument.PriceScale, header.SendingTime);
+        return offset;
+    }
+
+    private static int WriteSnapshotSide(
+        Span<byte> destination,
+        BookSide side,
+        FixMdEntryType entryType,
+        int priceScale,
+        DateTimeOffset entryTime)
+    {
+        int offset = 0;
+        foreach (var (_, orders) in side.PriceLevels)
+        {
+            foreach (var order in orders)
+            {
+                offset += WriteCharField(destination[offset..], FixTags.MDEntryType, (char)entryType);
+                offset += WriteScaledInt64Field(destination[offset..], FixTags.MDEntryPx, order.Price, priceScale);
+                offset += WriteInt64Field(destination[offset..], FixTags.MDEntrySize, order.Quantity);
+                offset += WriteUtcDateField(destination[offset..], FixTags.MDEntryDate, entryTime);
+                offset += WriteUtcTimeField(destination[offset..], FixTags.MDEntryTime, entryTime);
+                offset += WriteUInt64Field(destination[offset..], FixTags.OrderId, order.OrderId);
+            }
+        }
+
+        return offset;
+    }
+
+    private void EnsureCapacity(int required)
+    {
+        if (_buffer.Length >= required)
+            return;
+
+        byte[] grown = _bufferPool.Rent(required);
+        _bufferPool.Return(_buffer);
+        _buffer = grown;
+    }
+
+    private static int EstimateIncrementalFrameSize(
+        FixApplicationSessionHeader header,
+        FixMarketDataInstrument instrument,
+        int entryCount,
+        string? mdReqId)
+    {
+        int beginStringLength = header.BeginString.Length;
+        int mdReqIdLength = string.IsNullOrEmpty(mdReqId) ? 0 : mdReqId!.Length + 16;
+        int bodyLength = 96 + header.SenderCompId.Length + header.TargetCompId.Length + mdReqIdLength + entryCount * (160 + instrument.Symbol.Length);
+        return MaxReservedPrefixLength + bodyLength + FixFrameEncoding.ChecksumFieldLength + beginStringLength;
+    }
+
+    private static int EstimateSnapshotFrameSize(
+        FixApplicationSessionHeader header,
+        FixMarketDataSnapshotRequest request,
+        int entryCount)
+    {
+        int beginStringLength = header.BeginString.Length;
+        int bodyLength = 96 + header.SenderCompId.Length + header.TargetCompId.Length + request.MdReqId.Length + request.Instrument.Symbol.Length + entryCount * 96;
+        return MaxReservedPrefixLength + bodyLength + FixFrameEncoding.ChecksumFieldLength + beginStringLength;
+    }
+
+    private static int WriteSessionHeader(Span<byte> destination, FixApplicationSessionHeader header, string msgType)
+    {
+        int offset = 0;
+        offset += WriteStringField(destination[offset..], FixTags.MsgType, msgType);
+        offset += WriteStringField(destination[offset..], FixTags.SenderCompId, header.SenderCompId);
+        offset += WriteStringField(destination[offset..], FixTags.TargetCompId, header.TargetCompId);
+        offset += WriteIntField(destination[offset..], FixTags.MsgSeqNum, header.MsgSeqNum);
+        offset += WriteUtcTimestampField(destination[offset..], FixTags.SendingTime, header.SendingTime);
+        return offset;
+    }
+
+    private static int WriteStringField(Span<byte> destination, int tag, string value)
+    {
+        int offset = WriteTag(destination, tag);
+        offset += s_ascii.GetBytes(value, destination[offset..]);
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteCharField(Span<byte> destination, int tag, char value)
+    {
+        int offset = WriteTag(destination, tag);
+        destination[offset++] = (byte)value;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteIntField(Span<byte> destination, int tag, int value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!Utf8Formatter.TryFormat(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX int field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteInt64Field(Span<byte> destination, int tag, long value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!Utf8Formatter.TryFormat(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX long field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteUInt64Field(Span<byte> destination, int tag, ulong value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!Utf8Formatter.TryFormat(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX ulong field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteScaledInt64Field(Span<byte> destination, int tag, long value, int scale)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!TryFormatScaledInt64(value, scale, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX decimal field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteUtcTimestampField(Span<byte> destination, int tag, DateTimeOffset value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!FixValueFormatting.TryFormatUtcTimestamp(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX timestamp field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteUtcDateField(Span<byte> destination, int tag, DateTimeOffset value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!FixValueFormatting.TryFormatUtcDate(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX date field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteUtcTimeField(Span<byte> destination, int tag, DateTimeOffset value)
+    {
+        int offset = WriteTag(destination, tag);
+        if (!FixValueFormatting.TryFormatUtcTime(value, destination[offset..], out int written))
+            throw new InvalidOperationException($"Unable to format FIX time field {tag}.");
+
+        offset += written;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    private static int WriteTag(Span<byte> destination, int tag)
+    {
+        if (!Utf8Formatter.TryFormat(tag, destination, out int written))
+            throw new InvalidOperationException($"Unable to format FIX tag {tag}.");
+
+        destination[written++] = (byte)'=';
+        return written;
+    }
+
+    private static bool TryFormatScaledInt64(long value, int scale, Span<byte> destination, out int written)
+    {
+        if (scale == 0)
+            return Utf8Formatter.TryFormat(value, destination, out written);
+
+        ulong divisor = Pow10(scale);
+        bool negative = value < 0;
+        ulong absolute = negative
+            ? unchecked((ulong)(-(value + 1)) + 1UL)
+            : (ulong)value;
+
+        ulong whole = absolute / divisor;
+        ulong fractional = absolute % divisor;
+
+        int offset = 0;
+        if (negative)
+        {
+            if (destination.IsEmpty)
+            {
+                written = 0;
+                return false;
+            }
+
+            destination[offset++] = (byte)'-';
+        }
+
+        if (!Utf8Formatter.TryFormat(whole, destination[offset..], out int wholeWritten))
+        {
+            written = 0;
+            return false;
+        }
+
+        offset += wholeWritten;
+        if (destination.Length <= offset)
+        {
+            written = 0;
+            return false;
+        }
+
+        destination[offset++] = (byte)'.';
+
+        Span<byte> fractionalBytes = stackalloc byte[20];
+        if (!Utf8Formatter.TryFormat(fractional, fractionalBytes, out int fractionalWritten))
+        {
+            written = 0;
+            return false;
+        }
+
+        int zeroPadding = scale - fractionalWritten;
+        if (destination.Length < offset + zeroPadding + fractionalWritten)
+        {
+            written = 0;
+            return false;
+        }
+
+        destination.Slice(offset, zeroPadding).Fill((byte)'0');
+        offset += zeroPadding;
+        fractionalBytes[..fractionalWritten].CopyTo(destination[offset..]);
+        offset += fractionalWritten;
+        written = offset;
+        return true;
+    }
+
+    private static ulong Pow10(int power)
+    {
+        ulong result = 1;
+        for (int i = 0; i < power; i++)
+            result *= 10;
+
+        return result;
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
@@ -1,0 +1,103 @@
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+[Flags]
+public enum FixMarketDataEntryFields : byte
+{
+    None = 0,
+    Price = 1 << 0,
+    Size = 1 << 1,
+    OrderId = 1 << 2,
+    TradeId = 1 << 3,
+}
+
+public enum FixMdEntryType : byte
+{
+    Bid = (byte)'0',
+    Offer = (byte)'1',
+    Trade = (byte)'2',
+}
+
+public enum FixMdUpdateAction : byte
+{
+    New = (byte)'0',
+    Change = (byte)'1',
+    Delete = (byte)'2',
+    DeleteThru = (byte)'3',
+}
+
+public readonly record struct FixApplicationSessionHeader(
+    string SenderCompId,
+    string TargetCompId,
+    int MsgSeqNum,
+    DateTimeOffset SendingTime,
+    string BeginString = FixMessageCodec.BeginString);
+
+public readonly record struct FixMarketDataInstrument
+{
+    public FixMarketDataInstrument(string symbol, ulong securityId, int priceScale = 0)
+    {
+        ArgumentNullException.ThrowIfNull(symbol);
+        if (priceScale is < 0 or > 18)
+            throw new ArgumentOutOfRangeException(nameof(priceScale));
+
+        Symbol = symbol;
+        SecurityId = securityId;
+        PriceScale = priceScale;
+    }
+
+    public string Symbol { get; }
+    public ulong SecurityId { get; }
+    public int PriceScale { get; }
+
+    public FixMdEntryType GetEntryType(BookSideType side)
+        => side == BookSideType.Bid ? FixMdEntryType.Bid : FixMdEntryType.Offer;
+}
+
+public readonly record struct FixMarketDataSnapshotRequest
+{
+    public FixMarketDataSnapshotRequest(string mdReqId, FixMarketDataInstrument instrument)
+    {
+        ArgumentNullException.ThrowIfNull(mdReqId);
+        MdReqId = mdReqId;
+        Instrument = instrument;
+    }
+
+    public string MdReqId { get; }
+    public FixMarketDataInstrument Instrument { get; }
+}
+
+public readonly record struct FixMarketDataIncrementalEntry(
+    FixMdUpdateAction UpdateAction,
+    FixMdEntryType EntryType,
+    DateTimeOffset EntryTime,
+    FixMarketDataEntryFields Fields = FixMarketDataEntryFields.None,
+    long Price = 0,
+    long Size = 0,
+    ulong OrderId = 0,
+    long TradeId = 0);
+
+public interface IFixApplicationHeaderProvider
+{
+    FixApplicationSessionHeader NextHeader(DateTimeOffset sendingTime);
+}
+
+public interface IFixApplicationMessageSink
+{
+    void OnMessage(ReadOnlyMemory<byte> message);
+}
+
+public interface IFixMarketDataInstrumentResolver
+{
+    bool TryResolve(ulong securityId, out FixMarketDataInstrument instrument);
+}
+
+public sealed class FixConflatedMarketDataOptions
+{
+    public static readonly TimeSpan DefaultConflationInterval = TimeSpan.FromMilliseconds(380);
+
+    public TimeSpan ConflationInterval { get; init; } = DefaultConflationInterval;
+    public int InitialBufferSize { get; init; } = 4 * 1024;
+    public bool StartBackgroundWorker { get; init; } = true;
+}

--- a/src/B3.Umdf.FixConflated/FixConflatedMarketDataPublisher.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedMarketDataPublisher.cs
@@ -1,0 +1,365 @@
+using System.Collections.Concurrent;
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDisposable
+{
+    private readonly IFixApplicationMessageSink _sink;
+    private readonly IFixApplicationHeaderProvider _headerProvider;
+    private readonly IFixMarketDataInstrumentResolver _instrumentResolver;
+    private readonly IFixClock _clock;
+    private readonly FixApplicationMessageWriter _writer;
+    private readonly ConcurrentQueue<QueuedBookDelta> _pendingBookDeltas = new();
+    private readonly Dictionary<ConflationKey, List<QueuedBookDelta>> _bufferedBookDeltas = new();
+    private readonly List<ConflationKey> _bufferedOrder = new();
+    private readonly object _stateGate = new();
+    private readonly object _emitGate = new();
+    private readonly AutoResetEvent _wakeSignal = new(false);
+    private readonly TimeSpan _conflationInterval;
+    private readonly long _conflationIntervalMs;
+    private readonly Thread? _workerThread;
+    private volatile bool _disposed;
+    private volatile bool _stopRequested;
+    private long _nextFlushTicks;
+
+    public FixConflatedMarketDataPublisher(
+        IFixApplicationMessageSink sink,
+        IFixApplicationHeaderProvider headerProvider,
+        IFixMarketDataInstrumentResolver instrumentResolver,
+        FixConflatedMarketDataOptions? options = null,
+        IFixClock? clock = null)
+    {
+        _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        _headerProvider = headerProvider ?? throw new ArgumentNullException(nameof(headerProvider));
+        _instrumentResolver = instrumentResolver ?? throw new ArgumentNullException(nameof(instrumentResolver));
+        _clock = clock ?? SystemFixClock.Instance;
+
+        var resolvedOptions = options ?? new FixConflatedMarketDataOptions();
+        if (resolvedOptions.ConflationInterval <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(options), "ConflationInterval must be positive.");
+
+        _conflationInterval = resolvedOptions.ConflationInterval;
+        _conflationIntervalMs = checked((long)Math.Ceiling(_conflationInterval.TotalMilliseconds));
+        _writer = new FixApplicationMessageWriter(resolvedOptions.InitialBufferSize);
+
+        if (resolvedOptions.StartBackgroundWorker)
+        {
+            _workerThread = new Thread(RunWorker)
+            {
+                IsBackground = true,
+                Name = "FixConflatedMarketDataPublisher",
+            };
+            _workerThread.Start();
+        }
+    }
+
+    public TimeSpan ConflationInterval => _conflationInterval;
+
+    public void PublishSnapshot(FixMarketDataSnapshotRequest request, OrderBook book)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+        ThrowIfDisposed();
+
+        lock (_emitGate)
+        {
+            DateTimeOffset now = _clock.UtcNow;
+            FixApplicationSessionHeader header = _headerProvider.NextHeader(now);
+            ReadOnlyMemory<byte> frame = _writer.WriteSnapshotFullRefresh(header, request, book);
+            _sink.OnMessage(frame);
+        }
+    }
+
+    public void OnOrderAdded(OrderBook book, in OrderBookEntry entry)
+        => EnqueueBookDelta(CreateBookDelta(
+            book.SecurityId,
+            entry.Side,
+            FixMdUpdateAction.New,
+            entry.Price,
+            entry.Quantity,
+            entry.OrderId,
+            FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.OrderId));
+
+    public void OnOrderUpdated(OrderBook book, in OrderBookEntry entry)
+        => EnqueueBookDelta(CreateBookDelta(
+            book.SecurityId,
+            entry.Side,
+            FixMdUpdateAction.Change,
+            entry.Price,
+            entry.Quantity,
+            entry.OrderId,
+            FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.OrderId));
+
+    public void OnOrderDeleted(OrderBook book, ulong orderId, BookSideType side)
+        => EnqueueBookDelta(CreateBookDelta(
+            book.SecurityId,
+            side,
+            FixMdUpdateAction.Delete,
+            0,
+            0,
+            orderId,
+            FixMarketDataEntryFields.OrderId));
+
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+        => OnTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
+
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+        => PublishTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+        => OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
+
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
+        => PublishTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+
+    public void OnBookCleared(ulong securityId, BookClearSide side)
+    {
+        long nowTicks = _clock.MonotonicTicks;
+        if (side is BookClearSide.Bid or BookClearSide.Both)
+        {
+            _pendingBookDeltas.Enqueue(new QueuedBookDelta(
+                securityId,
+                BookSideType.Bid,
+                FixMdUpdateAction.DeleteThru,
+                FixMarketDataEntryFields.None,
+                nowTicks));
+        }
+
+        if (side is BookClearSide.Ask or BookClearSide.Both)
+        {
+            _pendingBookDeltas.Enqueue(new QueuedBookDelta(
+                securityId,
+                BookSideType.Ask,
+                FixMdUpdateAction.DeleteThru,
+                FixMarketDataEntryFields.None,
+                nowTicks));
+        }
+
+        _wakeSignal.Set();
+    }
+
+    public void OnEpochReset(SnapshotClearReason reason)
+    {
+        ThrowIfDisposed();
+        lock (_stateGate)
+        {
+            while (_pendingBookDeltas.TryDequeue(out _))
+            {
+            }
+
+            _bufferedBookDeltas.Clear();
+            _bufferedOrder.Clear();
+            _nextFlushTicks = 0;
+        }
+    }
+
+    public void FlushIfDue()
+    {
+        ThrowIfDisposed();
+        FlushBuffered(force: false);
+    }
+
+    public void FlushNow()
+    {
+        ThrowIfDisposed();
+        FlushBuffered(force: true);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _stopRequested = true;
+        _wakeSignal.Set();
+        _workerThread?.Join(TimeSpan.FromSeconds(2));
+        FlushBuffered(force: true);
+        _writer.Dispose();
+        _wakeSignal.Dispose();
+        _disposed = true;
+    }
+
+    private void RunWorker()
+    {
+        while (!_stopRequested)
+        {
+            FlushBuffered(force: false);
+            _wakeSignal.WaitOne(GetWaitDurationMilliseconds());
+        }
+    }
+
+    private int GetWaitDurationMilliseconds()
+    {
+        lock (_stateGate)
+        {
+            if (_bufferedOrder.Count == 0)
+                return 50;
+
+            long remaining = _nextFlushTicks - _clock.MonotonicTicks;
+            if (remaining <= 0)
+                return 1;
+
+            return remaining >= int.MaxValue ? int.MaxValue : (int)remaining;
+        }
+    }
+
+    private void PublishTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
+    {
+        ThrowIfDisposed();
+        if (!_instrumentResolver.TryResolve(securityId, out FixMarketDataInstrument instrument))
+            return;
+
+        DateTimeOffset entryTime = ConvertToTimestamp(sendingTimeNs);
+        FixApplicationSessionHeader header = _headerProvider.NextHeader(entryTime);
+
+        Span<FixMarketDataIncrementalEntry> entries = stackalloc FixMarketDataIncrementalEntry[1];
+        entries[0] = new FixMarketDataIncrementalEntry(
+            FixMdUpdateAction.New,
+            FixMdEntryType.Trade,
+            entryTime,
+            FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.TradeId,
+            price,
+            quantity,
+            TradeId: tradeId);
+
+        lock (_emitGate)
+        {
+            ReadOnlyMemory<byte> frame = _writer.WriteIncrementalRefresh(header, instrument, entries);
+            _sink.OnMessage(frame);
+        }
+    }
+
+    private void EnqueueBookDelta(QueuedBookDelta delta)
+    {
+        ThrowIfDisposed();
+        _pendingBookDeltas.Enqueue(delta);
+        _wakeSignal.Set();
+    }
+
+    private QueuedBookDelta CreateBookDelta(
+        ulong securityId,
+        BookSideType side,
+        FixMdUpdateAction updateAction,
+        long price,
+        long quantity,
+        ulong orderId,
+        FixMarketDataEntryFields fields)
+        => new(
+            securityId,
+            side,
+            updateAction,
+            fields,
+            _clock.MonotonicTicks,
+            price,
+            quantity,
+            orderId);
+
+    private void FlushBuffered(bool force)
+    {
+        List<BufferedBatch>? batches = null;
+
+        lock (_stateGate)
+        {
+            DrainPendingDeltas();
+
+            if (_bufferedOrder.Count == 0)
+                return;
+
+            long nowTicks = _clock.MonotonicTicks;
+            if (!force && nowTicks < _nextFlushTicks)
+                return;
+
+            DateTimeOffset flushTime = _clock.UtcNow;
+            batches = new List<BufferedBatch>(_bufferedOrder.Count);
+            foreach (ConflationKey key in _bufferedOrder)
+            {
+                List<QueuedBookDelta> deltas = _bufferedBookDeltas[key];
+                var entries = new FixMarketDataIncrementalEntry[deltas.Count];
+                for (int i = 0; i < deltas.Count; i++)
+                {
+                    QueuedBookDelta delta = deltas[i];
+                    entries[i] = new FixMarketDataIncrementalEntry(
+                        delta.UpdateAction,
+                        key.EntryType,
+                        flushTime,
+                        delta.Fields,
+                        delta.Price,
+                        delta.Size,
+                        delta.OrderId);
+                }
+
+                batches.Add(new BufferedBatch(key.SecurityId, entries));
+            }
+
+            _bufferedBookDeltas.Clear();
+            _bufferedOrder.Clear();
+            _nextFlushTicks = 0;
+        }
+
+        lock (_emitGate)
+        {
+            if (batches is null)
+                return;
+
+            foreach (BufferedBatch batch in batches)
+            {
+                if (!_instrumentResolver.TryResolve(batch.SecurityId, out FixMarketDataInstrument instrument))
+                    continue;
+
+                FixApplicationSessionHeader header = _headerProvider.NextHeader(batch.Entries[0].EntryTime);
+                ReadOnlyMemory<byte> frame = _writer.WriteIncrementalRefresh(header, instrument, batch.Entries);
+                _sink.OnMessage(frame);
+            }
+        }
+    }
+
+    private void DrainPendingDeltas()
+    {
+        while (_pendingBookDeltas.TryDequeue(out QueuedBookDelta delta))
+        {
+            var key = new ConflationKey(delta.SecurityId, delta.Side);
+            if (!_bufferedBookDeltas.TryGetValue(key, out List<QueuedBookDelta>? entries))
+            {
+                entries = [];
+                _bufferedBookDeltas.Add(key, entries);
+                _bufferedOrder.Add(key);
+            }
+
+            entries.Add(delta);
+            if (_nextFlushTicks == 0)
+                _nextFlushTicks = delta.EnqueueTicks + _conflationIntervalMs;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+    }
+
+    private DateTimeOffset ConvertToTimestamp(long sendingTimeNs)
+    {
+        if (sendingTimeNs <= 0)
+            return _clock.UtcNow;
+
+        return DateTimeOffset.FromUnixTimeMilliseconds(sendingTimeNs / 1_000_000);
+    }
+
+    private readonly record struct ConflationKey(ulong SecurityId, BookSideType Side)
+    {
+        public FixMdEntryType EntryType => Side == BookSideType.Bid ? FixMdEntryType.Bid : FixMdEntryType.Offer;
+    }
+
+    private readonly record struct QueuedBookDelta(
+        ulong SecurityId,
+        BookSideType Side,
+        FixMdUpdateAction UpdateAction,
+        FixMarketDataEntryFields Fields,
+        long EnqueueTicks,
+        long Price = 0,
+        long Size = 0,
+        ulong OrderId = 0);
+
+    private readonly record struct BufferedBatch(
+        ulong SecurityId,
+        FixMarketDataIncrementalEntry[] Entries);
+}

--- a/src/B3.Umdf.FixConflated/FixFrameEncoding.cs
+++ b/src/B3.Umdf.FixConflated/FixFrameEncoding.cs
@@ -1,0 +1,70 @@
+using System.Buffers.Text;
+
+namespace B3.Umdf.FixConflated;
+
+internal static class FixFrameEncoding
+{
+    public const int ChecksumFieldLength = 7;
+
+    public static int GetFrameLength(int beginStringLength, int bodyLength)
+        => GetPrefixLength(beginStringLength, bodyLength) + bodyLength + ChecksumFieldLength;
+
+    public static int GetPrefixLength(int beginStringLength, int bodyLength)
+        => 2 + beginStringLength + 1 + 2 + CountDigits(bodyLength) + 1;
+
+    public static int WritePrefix(Span<byte> destination, ReadOnlySpan<byte> beginString, int bodyLength)
+    {
+        int offset = 0;
+        destination[offset++] = (byte)'8';
+        destination[offset++] = (byte)'=';
+        beginString.CopyTo(destination[offset..]);
+        offset += beginString.Length;
+        destination[offset++] = FixMessageCodec.Soh;
+
+        destination[offset++] = (byte)'9';
+        destination[offset++] = (byte)'=';
+        if (!Utf8Formatter.TryFormat(bodyLength, destination[offset..], out int digitsWritten))
+            throw new InvalidOperationException("Unable to format FIX body length.");
+
+        offset += digitsWritten;
+        destination[offset++] = FixMessageCodec.Soh;
+        return offset;
+    }
+
+    public static int CalculateChecksum(ReadOnlySpan<byte> payload)
+    {
+        int checksum = 0;
+        for (int i = 0; i < payload.Length; i++)
+            checksum = (checksum + payload[i]) & 0xFF;
+
+        return checksum;
+    }
+
+    public static int WriteChecksumField(Span<byte> destination, int checksum)
+    {
+        destination[0] = (byte)'1';
+        destination[1] = (byte)'0';
+        destination[2] = (byte)'=';
+        destination[3] = (byte)('0' + (checksum / 100));
+        destination[4] = (byte)('0' + ((checksum / 10) % 10));
+        destination[5] = (byte)('0' + (checksum % 10));
+        destination[6] = FixMessageCodec.Soh;
+        return ChecksumFieldLength;
+    }
+
+    private static int CountDigits(int value)
+    {
+        if (value == 0)
+            return 1;
+
+        int digits = 0;
+        int remaining = value;
+        while (remaining != 0)
+        {
+            remaining /= 10;
+            digits++;
+        }
+
+        return digits;
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixMessageCodec.cs
+++ b/src/B3.Umdf.FixConflated/FixMessageCodec.cs
@@ -55,19 +55,17 @@ public static class FixMessageCodec
             AppendField(bodyBuilder, field);
 
         string body = bodyBuilder.ToString();
-        string prefix = $"8={beginString}{(char)Soh}9={Encoding.ASCII.GetByteCount(body).ToString(CultureInfo.InvariantCulture)}{(char)Soh}";
-        string messageWithoutChecksum = prefix + body;
+        byte[] bodyBytes = Encoding.ASCII.GetBytes(body);
+        byte[] beginStringBytes = Encoding.ASCII.GetBytes(beginString);
+        byte[] payload = new byte[FixFrameEncoding.GetFrameLength(beginStringBytes.Length, bodyBytes.Length)];
 
-        int checksum = 0;
-        byte[] payloadBytes = Encoding.ASCII.GetBytes(messageWithoutChecksum);
-        for (int i = 0; i < payloadBytes.Length; i++)
-            checksum = (checksum + payloadBytes[i]) & 0xFF;
+        int prefixLength = FixFrameEncoding.WritePrefix(payload, beginStringBytes, bodyBytes.Length);
+        bodyBytes.CopyTo(payload.AsSpan(prefixLength));
 
-        string finalMessage = string.Create(
-            CultureInfo.InvariantCulture,
-            $"{messageWithoutChecksum}10={checksum:000}{(char)Soh}");
-
-        return Encoding.ASCII.GetBytes(finalMessage);
+        int checksumOffset = prefixLength + bodyBytes.Length;
+        int checksum = FixFrameEncoding.CalculateChecksum(payload.AsSpan(0, checksumOffset));
+        FixFrameEncoding.WriteChecksumField(payload.AsSpan(checksumOffset), checksum);
+        return payload;
     }
 
     public static FixDecodeResult Decode(ReadOnlySpan<byte> buffer)
@@ -119,9 +117,7 @@ public static class FixMessageCodec
             !int.TryParse(Encoding.ASCII.GetString(checksumSpan), NumberStyles.None, CultureInfo.InvariantCulture, out int expectedChecksum))
             return FixDecodeResult.Failure(FixDecodeError.InvalidCheckSum);
 
-        int actualChecksum = 0;
-        for (int i = 0; i < checksumFieldStart; i++)
-            actualChecksum = (actualChecksum + buffer[i]) & 0xFF;
+        int actualChecksum = FixFrameEncoding.CalculateChecksum(buffer[..checksumFieldStart]);
         if (actualChecksum != expectedChecksum)
             return FixDecodeResult.Failure(FixDecodeError.CheckSumMismatch);
 

--- a/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
@@ -94,7 +94,11 @@ internal static class FixTags
     public const int BeginString = 8;
     public const int BodyLength = 9;
     public const int MsgType = 35;
+    public const int OrderId = 37;
+    public const int SecurityId = 48;
     public const int SenderCompId = 49;
+    public const int Symbol = 55;
+    public const int Text = 58;
     public const int TargetCompId = 56;
     public const int MsgSeqNum = 34;
     public const int SendingTime = 52;
@@ -108,7 +112,17 @@ internal static class FixTags
     public const int EndSeqNo = 16;
     public const int NewSeqNo = 36;
     public const int NextExpectedMsgSeqNum = 789;
+    public const int MDReqId = 262;
+    public const int NoMDEntries = 268;
+    public const int MDEntryType = 269;
+    public const int MDEntryPx = 270;
+    public const int MDEntrySize = 271;
+    public const int MDEntryDate = 272;
+    public const int MDEntryTime = 273;
+    public const int TradeCondition = 277;
+    public const int MDUpdateAction = 279;
     public const int CheckSum = 10;
+    public const int TradeId = 1003;
 }
 
 internal static class FixMsgTypes
@@ -120,10 +134,93 @@ internal static class FixMsgTypes
     public const string SequenceReset = "4";
     public const string Logout = "5";
     public const string Logon = "A";
+    public const string MarketDataSnapshotFullRefresh = "W";
+    public const string MarketDataIncrementalRefresh = "X";
 }
 
 internal static class FixValueFormatting
 {
     public static string FormatUtcTimestamp(DateTimeOffset value)
         => value.UtcDateTime.ToString("yyyyMMdd-HH:mm:ss.fff", CultureInfo.InvariantCulture);
+
+    public static bool TryFormatUtcTimestamp(DateTimeOffset value, Span<byte> destination, out int written)
+    {
+        if (destination.Length < 21)
+        {
+            written = 0;
+            return false;
+        }
+
+        DateTime utc = value.UtcDateTime;
+        Write4(destination, utc.Year);
+        Write2(destination[4..], utc.Month);
+        Write2(destination[6..], utc.Day);
+        destination[8] = (byte)'-';
+        Write2(destination[9..], utc.Hour);
+        destination[11] = (byte)':';
+        Write2(destination[12..], utc.Minute);
+        destination[14] = (byte)':';
+        Write2(destination[15..], utc.Second);
+        destination[17] = (byte)'.';
+        Write3(destination[18..], utc.Millisecond);
+        written = 21;
+        return true;
+    }
+
+    public static bool TryFormatUtcDate(DateTimeOffset value, Span<byte> destination, out int written)
+    {
+        if (destination.Length < 8)
+        {
+            written = 0;
+            return false;
+        }
+
+        DateTime utc = value.UtcDateTime;
+        Write4(destination, utc.Year);
+        Write2(destination[4..], utc.Month);
+        Write2(destination[6..], utc.Day);
+        written = 8;
+        return true;
+    }
+
+    public static bool TryFormatUtcTime(DateTimeOffset value, Span<byte> destination, out int written)
+    {
+        if (destination.Length < 12)
+        {
+            written = 0;
+            return false;
+        }
+
+        DateTime utc = value.UtcDateTime;
+        Write2(destination, utc.Hour);
+        destination[2] = (byte)':';
+        Write2(destination[3..], utc.Minute);
+        destination[5] = (byte)':';
+        Write2(destination[6..], utc.Second);
+        destination[8] = (byte)'.';
+        Write3(destination[9..], utc.Millisecond);
+        written = 12;
+        return true;
+    }
+
+    private static void Write2(Span<byte> destination, int value)
+    {
+        destination[0] = (byte)('0' + (value / 10));
+        destination[1] = (byte)('0' + (value % 10));
+    }
+
+    private static void Write3(Span<byte> destination, int value)
+    {
+        destination[0] = (byte)('0' + (value / 100));
+        destination[1] = (byte)('0' + ((value / 10) % 10));
+        destination[2] = (byte)('0' + (value % 10));
+    }
+
+    private static void Write4(Span<byte> destination, int value)
+    {
+        destination[0] = (byte)('0' + ((value / 1000) % 10));
+        destination[1] = (byte)('0' + ((value / 100) % 10));
+        destination[2] = (byte)('0' + ((value / 10) % 10));
+        destination[3] = (byte)('0' + (value % 10));
+    }
 }

--- a/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
@@ -1,0 +1,192 @@
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixApplicationMessageWriterTests
+{
+    [Fact]
+    public void IncrementalRefresh_Writes_DirectFixFrame_ThatDecodesCorrectly()
+    {
+        using var writer = new FixApplicationMessageWriter();
+        var header = new FixApplicationSessionHeader(
+            "SERVER",
+            "CLIENT",
+            7,
+            new DateTimeOffset(2026, 8, 12, 19, 10, 11, 123, TimeSpan.Zero));
+        var instrument = new FixMarketDataInstrument("PETR4", 1234, priceScale: 2);
+        FixMarketDataIncrementalEntry[] entries =
+        [
+            new(
+                FixMdUpdateAction.New,
+                FixMdEntryType.Bid,
+                new DateTimeOffset(2026, 8, 12, 19, 10, 11, 123, TimeSpan.Zero),
+                FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.OrderId,
+                Price: 2810,
+                Size: 100,
+                OrderId: 501),
+            new(
+                FixMdUpdateAction.Change,
+                FixMdEntryType.Bid,
+                new DateTimeOffset(2026, 8, 12, 19, 10, 11, 456, TimeSpan.Zero),
+                FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.OrderId,
+                Price: 2811,
+                Size: 120,
+                OrderId: 501),
+        ];
+
+        ReadOnlyMemory<byte> frame = writer.WriteIncrementalRefresh(header, instrument, entries);
+
+        FixMessage decoded = Decode(frame);
+        Assert.Equal(FixMsgTypes.MarketDataIncrementalRefresh, GetRequired(decoded, FixTags.MsgType));
+        Assert.Equal("SERVER", GetRequired(decoded, FixTags.SenderCompId));
+        Assert.Equal("CLIENT", GetRequired(decoded, FixTags.TargetCompId));
+        Assert.Equal("7", GetRequired(decoded, FixTags.MsgSeqNum));
+        Assert.Equal("2", GetRequired(decoded, FixTags.NoMDEntries));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> parsedEntries = ParseIncrementalEntries(decoded);
+        Assert.Equal(2, parsedEntries.Count);
+
+        Assert.Equal("0", parsedEntries[0][FixTags.MDUpdateAction]);
+        Assert.Equal("0", parsedEntries[0][FixTags.MDEntryType]);
+        Assert.Equal("PETR4", parsedEntries[0][FixTags.Symbol]);
+        Assert.Equal("1234", parsedEntries[0][FixTags.SecurityId]);
+        Assert.Equal("28.10", parsedEntries[0][FixTags.MDEntryPx]);
+        Assert.Equal("100", parsedEntries[0][FixTags.MDEntrySize]);
+        Assert.Equal("501", parsedEntries[0][FixTags.OrderId]);
+
+        Assert.Equal("1", parsedEntries[1][FixTags.MDUpdateAction]);
+        Assert.Equal("28.11", parsedEntries[1][FixTags.MDEntryPx]);
+        Assert.Equal("120", parsedEntries[1][FixTags.MDEntrySize]);
+    }
+
+    [Fact]
+    public void SnapshotFullRefresh_Writes_All_Current_Prices_In_One_Message()
+    {
+        using var writer = new FixApplicationMessageWriter();
+        var header = new FixApplicationSessionHeader(
+            "SERVER",
+            "CLIENT",
+            11,
+            new DateTimeOffset(2026, 8, 12, 19, 15, 00, TimeSpan.Zero));
+        var request = new FixMarketDataSnapshotRequest(
+            "snap-1",
+            new FixMarketDataInstrument("PETR4", 1234, priceScale: 2));
+        OrderBook book = CreateBook(
+            (1UL, BookSideType.Bid, 2810L, 100L),
+            (2UL, BookSideType.Bid, 2809L, 150L),
+            (3UL, BookSideType.Ask, 2812L, 90L),
+            (4UL, BookSideType.Ask, 2813L, 110L));
+
+        ReadOnlyMemory<byte> frame = writer.WriteSnapshotFullRefresh(header, request, book);
+
+        FixMessage decoded = Decode(frame);
+        Assert.Equal(FixMsgTypes.MarketDataSnapshotFullRefresh, GetRequired(decoded, FixTags.MsgType));
+        Assert.Equal("snap-1", GetRequired(decoded, FixTags.MDReqId));
+        Assert.Equal("PETR4", GetRequired(decoded, FixTags.Symbol));
+        Assert.Equal("1234", GetRequired(decoded, FixTags.SecurityId));
+        Assert.Equal("4", GetRequired(decoded, FixTags.NoMDEntries));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseSnapshotEntries(decoded);
+        Assert.Equal(4, entries.Count);
+        Assert.Equal("0", entries[0][FixTags.MDEntryType]);
+        Assert.Equal("28.10", entries[0][FixTags.MDEntryPx]);
+        Assert.Equal("1", entries[0][FixTags.OrderId]);
+        Assert.Equal("1", entries[2][FixTags.MDEntryType]);
+        Assert.Equal("28.12", entries[2][FixTags.MDEntryPx]);
+        Assert.Equal("3", entries[2][FixTags.OrderId]);
+    }
+
+    private static OrderBook CreateBook(params (ulong OrderId, BookSideType Side, long Price, long Quantity)[] orders)
+    {
+        var book = new OrderBook(1234);
+        foreach (var order in orders)
+        {
+            var entry = new OrderBookEntry
+            {
+                OrderId = order.OrderId,
+                Side = order.Side,
+                SecurityId = book.SecurityId,
+                Price = order.Price,
+                Quantity = order.Quantity,
+            };
+
+            book.GetSide(order.Side).Add(in entry);
+        }
+
+        return book;
+    }
+
+    private static FixMessage Decode(ReadOnlyMemory<byte> frame)
+    {
+        FixDecodeResult decoded = FixMessageCodec.Decode(frame.Span);
+        Assert.True(decoded.Success, decoded.Error.ToString());
+        return decoded.Message!;
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseIncrementalEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDUpdateAction)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseSnapshotEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDEntryType)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataPublisherTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataPublisherTests.cs
@@ -1,0 +1,251 @@
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixConflatedMarketDataPublisherTests
+{
+    [Fact]
+    public void ConflationWindow_Batches_Multiple_Deltas_Into_One_Message()
+    {
+        var clock = new FakeFixClock();
+        var sink = new CapturingSink();
+        var publisher = CreatePublisher(clock, sink);
+        OrderBook book = new(1234);
+
+        var add = CreateEntry(book.SecurityId, 7001, BookSideType.Bid, 2810, 100);
+        var update = CreateEntry(book.SecurityId, 7001, BookSideType.Bid, 2811, 90);
+
+        publisher.OnOrderAdded(book, in add);
+        publisher.OnOrderUpdated(book, in update);
+        publisher.FlushIfDue();
+        Assert.Empty(sink.Messages);
+
+        clock.AdvanceMilliseconds(400);
+        publisher.FlushIfDue();
+
+        byte[] raw = Assert.Single(sink.Messages);
+        FixMessage decoded = Decode(raw);
+        Assert.Equal("1", GetRequired(decoded, FixTags.MsgSeqNum));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseIncrementalEntries(decoded);
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("0", entries[0][FixTags.MDUpdateAction]);
+        Assert.Equal("28.10", entries[0][FixTags.MDEntryPx]);
+        Assert.Equal("1", entries[1][FixTags.MDUpdateAction]);
+        Assert.Equal("28.11", entries[1][FixTags.MDEntryPx]);
+    }
+
+    [Fact]
+    public void ConflationWindow_Splits_Deltas_Across_Window_Boundaries()
+    {
+        var clock = new FakeFixClock();
+        var sink = new CapturingSink();
+        var publisher = CreatePublisher(clock, sink);
+        OrderBook book = new(1234);
+
+        var first = CreateEntry(book.SecurityId, 8001, BookSideType.Bid, 2810, 100);
+        publisher.OnOrderAdded(book, in first);
+        publisher.FlushIfDue();
+
+        clock.AdvanceMilliseconds(400);
+        publisher.FlushIfDue();
+
+        publisher.OnOrderDeleted(book, 8001, BookSideType.Bid);
+        publisher.FlushIfDue();
+
+        clock.AdvanceMilliseconds(400);
+        publisher.FlushIfDue();
+
+        Assert.Equal(2, sink.Messages.Count);
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> firstEntries = ParseIncrementalEntries(Decode(sink.Messages[0]));
+        IReadOnlyList<IReadOnlyDictionary<int, string>> secondEntries = ParseIncrementalEntries(Decode(sink.Messages[1]));
+
+        Assert.Single(firstEntries);
+        Assert.Single(secondEntries);
+        Assert.Equal("0", firstEntries[0][FixTags.MDUpdateAction]);
+        Assert.Equal("2", secondEntries[0][FixTags.MDUpdateAction]);
+    }
+
+    [Fact]
+    public void Trades_Bypass_Conflation_And_Flush_Immediately()
+    {
+        var clock = new FakeFixClock();
+        var sink = new CapturingSink();
+        var publisher = CreatePublisher(clock, sink);
+        OrderBook book = new(1234);
+
+        var add = CreateEntry(book.SecurityId, 9001, BookSideType.Bid, 2810, 100);
+        publisher.OnOrderAdded(book, in add);
+        publisher.FlushIfDue();
+        Assert.Empty(sink.Messages);
+
+        var tradeTime = new DateTimeOffset(2026, 8, 12, 19, 20, 30, 555, TimeSpan.Zero);
+        publisher.OnTrade(1234, 2812, 250, 771122, tradeTime.ToUnixTimeMilliseconds() * 1_000_000);
+
+        Assert.Single(sink.Messages);
+        FixMessage tradeMessage = Decode(sink.Messages[0]);
+        IReadOnlyList<IReadOnlyDictionary<int, string>> tradeEntries = ParseIncrementalEntries(tradeMessage);
+        Assert.Single(tradeEntries);
+        Assert.Equal("2", tradeEntries[0][FixTags.MDEntryType]);
+        Assert.Equal("28.12", tradeEntries[0][FixTags.MDEntryPx]);
+        Assert.Equal("250", tradeEntries[0][FixTags.MDEntrySize]);
+        Assert.Equal("771122", tradeEntries[0][FixTags.TradeId]);
+
+        clock.AdvanceMilliseconds(400);
+        publisher.FlushIfDue();
+
+        Assert.Equal(2, sink.Messages.Count);
+        FixMessage bookMessage = Decode(sink.Messages[1]);
+        IReadOnlyList<IReadOnlyDictionary<int, string>> bookEntries = ParseIncrementalEntries(bookMessage);
+        Assert.Single(bookEntries);
+        Assert.Equal("0", bookEntries[0][FixTags.MDEntryType]);
+    }
+
+    [Fact]
+    public void BookClear_Maps_To_DeleteThru()
+    {
+        var clock = new FakeFixClock();
+        var sink = new CapturingSink();
+        var publisher = CreatePublisher(clock, sink);
+
+        publisher.OnBookCleared(1234, BookClearSide.Bid);
+        publisher.FlushIfDue();
+        Assert.Empty(sink.Messages);
+
+        clock.AdvanceMilliseconds(400);
+        publisher.FlushIfDue();
+
+        byte[] raw = Assert.Single(sink.Messages);
+        FixMessage decoded = Decode(raw);
+        IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseIncrementalEntries(decoded);
+        Assert.Single(entries);
+        Assert.Equal("3", entries[0][FixTags.MDUpdateAction]);
+        Assert.Equal("0", entries[0][FixTags.MDEntryType]);
+        Assert.False(entries[0].ContainsKey(FixTags.OrderId));
+        Assert.False(entries[0].ContainsKey(FixTags.MDEntryPx));
+    }
+
+    private static FixConflatedMarketDataPublisher CreatePublisher(FakeFixClock clock, CapturingSink sink)
+    {
+        return new FixConflatedMarketDataPublisher(
+            sink,
+            new SequentialHeaderProvider(),
+            new StaticInstrumentResolver(new FixMarketDataInstrument("PETR4", 1234, 2)),
+            new FixConflatedMarketDataOptions
+            {
+                ConflationInterval = TimeSpan.FromMilliseconds(380),
+                StartBackgroundWorker = false,
+            },
+            clock);
+    }
+
+    private static OrderBookEntry CreateEntry(ulong securityId, ulong orderId, BookSideType side, long price, long quantity)
+    {
+        return new OrderBookEntry
+        {
+            SecurityId = securityId,
+            OrderId = orderId,
+            Side = side,
+            Price = price,
+            Quantity = quantity,
+        };
+    }
+
+    private static FixMessage Decode(byte[] raw)
+    {
+        FixDecodeResult decoded = FixMessageCodec.Decode(raw);
+        Assert.True(decoded.Success, decoded.Error.ToString());
+        return decoded.Message!;
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseIncrementalEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDUpdateAction)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+
+    private sealed class FakeFixClock : IFixClock
+    {
+        private DateTimeOffset _utcNow = new(2026, 8, 12, 19, 0, 0, TimeSpan.Zero);
+        private long _monotonicTicks;
+
+        public DateTimeOffset UtcNow => _utcNow;
+        public long MonotonicTicks => _monotonicTicks;
+
+        public void AdvanceMilliseconds(int milliseconds)
+        {
+            _utcNow = _utcNow.AddMilliseconds(milliseconds);
+            _monotonicTicks += milliseconds;
+        }
+    }
+
+    private sealed class SequentialHeaderProvider : IFixApplicationHeaderProvider
+    {
+        private int _nextSequenceNumber = 1;
+
+        public FixApplicationSessionHeader NextHeader(DateTimeOffset sendingTime)
+            => new("SERVER", "CLIENT", _nextSequenceNumber++, sendingTime);
+    }
+
+    private sealed class StaticInstrumentResolver : IFixMarketDataInstrumentResolver
+    {
+        private readonly FixMarketDataInstrument _instrument;
+
+        public StaticInstrumentResolver(FixMarketDataInstrument instrument)
+        {
+            _instrument = instrument;
+        }
+
+        public bool TryResolve(ulong securityId, out FixMarketDataInstrument instrument)
+        {
+            if (_instrument.SecurityId == securityId)
+            {
+                instrument = _instrument;
+                return true;
+            }
+
+            instrument = default;
+            return false;
+        }
+    }
+
+    private sealed class CapturingSink : IFixApplicationMessageSink
+    {
+        public List<byte[]> Messages { get; } = [];
+
+        public void OnMessage(ReadOnlyMemory<byte> message)
+            => Messages.Add(message.ToArray());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated span/ArrayPool-based FIX application writer for market-data frames and keep the existing string-based codec/session path unchanged for admin traffic
- add a configurable book-delta conflation publisher that batches per instrument/side, maps clears to DeleteThru, and sends trades immediately as incremental refresh trade entries
- add snapshot full-refresh generation plus focused FIX conflated tests for writer framing, batching windows, trade bypass, and snapshots

## Two-writer design
- session/admin messages continue to use `FixField` / `FixMessage` / `FixMessageCodec`
- market-data messages now use `FixApplicationMessageWriter`, which formats fields directly into a rented byte buffer and reuses shared framing helpers for BodyLength/CheckSum

## Key files and types
- `src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs`
- `src/B3.Umdf.FixConflated/FixConflatedMarketDataPublisher.cs`
- `src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs`
- `src/B3.Umdf.FixConflated/FixFrameEncoding.cs`
- `tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs`
- `tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataPublisherTests.cs`

Closes #91