### PR TITLE
Wire FIX conflated TCP transport into the hot path

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,11 +27,18 @@ The full set of `UMDF_*` knobs surfaced by `AppSettings` and `Program.cs`:
 | Environment Variable | CLI | Default | Description |
 |---------------------|-----|---------|-------------|
 | `UMDF_WS_PORT` | `--ws-port` | *(off)* | WebSocket server port |
+| `UMDF_FIX_CONFLATED_ENABLED` | — | `false` | Enable the opt-in FIX conflated TCP listener |
+| `UMDF_FIX_CONFLATED_PORT` | — | *(off)* | FIX conflated TCP listener port (required when enabled) |
 | `UMDF_SPEED` | `--speed` | `0` | Replay speed multiplier |
 | `UMDF_REPLAY_TO_MULTICAST` | `--replay-to-multicast` | `false` | Publish replayed PCAP payloads to multicast instead of consuming them in-process |
 | `UMDF_MULTICAST_CONFIG` | `--multicast-config` | — | Multicast JSON config path |
 | `UMDF_LOG_LEVEL` | — | `Information` | Minimum log level |
 | `UMDF_SHUTDOWN_DRAIN_SECONDS` | — | `5` | Graceful shutdown drain timeout |
+| **FIX conflated TCP** | | | |
+| `UMDF_FIX_CONFLATED_CONFLATION_MS` | — | `380` | Book-delta conflation window used by the FIX sandbox publisher |
+| `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY` | — | `10000` | Per-connection in-memory application resend buffer size for `ResendRequest` handling |
+| `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY` | — | `4096` | Per-connection bounded outbound queue; slow FIX consumers are disconnected when it fills |
+| `UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY` | — | `65536` | Per-group bounded hot-path event queue feeding the background FIX encoder |
 | **WebSocket / clients** | | | |
 | `UMDF_MAX_CONNECTIONS` | — | `0` (unlimited) | Max concurrent WebSocket connections |
 | `UMDF_CLIENT_CHANNEL_CAPACITY` | — | `4096` | Per-client outbound queue size (msgs) |

--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -110,7 +110,10 @@ the shared per-group hot path.
 
 ## Enabling
 
-Disabled by default. Enable with `UMDF_FIX_CONFLATED_ENABLED=true` and
-configure the listening port and conflation window per
-[docs/CONFIGURATION.md](CONFIGURATION.md) (reference added once the
-transport lands).
+Disabled by default. Enable with `UMDF_FIX_CONFLATED_ENABLED=true` plus
+at least `UMDF_FIX_CONFLATED_PORT=<port>`. Optional transport tuning
+includes `UMDF_FIX_CONFLATED_CONFLATION_MS`,
+`UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY`,
+`UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY`, and
+`UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY`; see
+[docs/CONFIGURATION.md](CONFIGURATION.md).

--- a/src/B3.Umdf.Book/CompositeMarketDataEventHandler.cs
+++ b/src/B3.Umdf.Book/CompositeMarketDataEventHandler.cs
@@ -27,8 +27,36 @@ public sealed class CompositeMarketDataEventHandler : IMarketDataEventHandler
         foreach (var h in _handlers) h.OnMarketDataUpdated(securityId, info);
     }
 
+    public void OnSecurityDefinitionChanged(ulong securityId, InstrumentInfo info)
+    {
+        foreach (var h in _handlers) h.OnSecurityDefinitionChanged(securityId, info);
+    }
+
+    public void OnPriceBandChanged(ulong securityId, InstrumentInfo info)
+    {
+        foreach (var h in _handlers) h.OnPriceBandChanged(securityId, info);
+    }
+
+    public void OnAuctionChanged(ulong securityId, InstrumentInfo info)
+    {
+        foreach (var h in _handlers) h.OnAuctionChanged(securityId, info);
+    }
+
     public void OnInstrumentReplaced(ulong securityId, string? oldSymbol, string newSymbol)
     {
         foreach (var h in _handlers) h.OnInstrumentReplaced(securityId, oldSymbol, newSymbol);
+    }
+
+    public void OnNews(
+        ulong securityIdOrZero,
+        ulong newsId,
+        byte source,
+        ushort language,
+        long origTimeNanos,
+        ReadOnlySpan<byte> headline,
+        ReadOnlySpan<byte> text,
+        ReadOnlySpan<byte> url)
+    {
+        foreach (var h in _handlers) h.OnNews(securityIdOrZero, newsId, source, language, origTimeNanos, headline, text, url);
     }
 }

--- a/src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj
+++ b/src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\B3.Umdf.Transport\B3.Umdf.Transport.csproj" />
     <ProjectReference Include="..\B3.Umdf.Feed\B3.Umdf.Feed.csproj" />
     <ProjectReference Include="..\B3.Umdf.Book\B3.Umdf.Book.csproj" />
+    <ProjectReference Include="..\B3.Umdf.FixConflated\B3.Umdf.FixConflated.csproj" />
     <ProjectReference Include="..\B3.Umdf.PcapReplay\B3.Umdf.PcapReplay.csproj" />
     <ProjectReference Include="..\B3.Umdf.Server\B3.Umdf.Server.csproj" />
   </ItemGroup>

--- a/src/B3.Umdf.ConsoleApp/FixConflatedFeatureGate.cs
+++ b/src/B3.Umdf.ConsoleApp/FixConflatedFeatureGate.cs
@@ -1,0 +1,29 @@
+using B3.Umdf.Server;
+
+namespace B3.Umdf.ConsoleApp;
+
+internal static class FixConflatedFeatureGate
+{
+    public static bool TryResolvePort(AppSettings settings, out int port, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (!settings.FixConflatedEnabled)
+        {
+            port = 0;
+            error = null;
+            return false;
+        }
+
+        if (settings.FixConflatedPort is not int configuredPort || configuredPort is < 1 or > 65535)
+        {
+            port = 0;
+            error = "UMDF_FIX_CONFLATED_ENABLED requires UMDF_FIX_CONFLATED_PORT to be set to a valid TCP port (1-65535).";
+            return false;
+        }
+
+        port = configuredPort;
+        error = null;
+        return true;
+    }
+}

--- a/src/B3.Umdf.ConsoleApp/Program.cs
+++ b/src/B3.Umdf.ConsoleApp/Program.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using B3.Umdf.Book;
 using B3.Umdf.ConsoleApp;
 using B3.Umdf.Feed;
+using B3.Umdf.FixConflated;
 using B3.Umdf.PcapReplay;
 using B3.Umdf.Server;
 using B3.Umdf.Transport;
@@ -22,6 +23,13 @@ if (!CliArgs.TryApply(args, settings, positionalArgs, out var cliError))
 }
 
 int? wsPort = settings.WsPort;
+bool fixConflatedEnabled = FixConflatedFeatureGate.TryResolvePort(settings, out int fixConflatedPort, out string? fixConflatedError);
+if (fixConflatedError is not null)
+{
+    Console.Error.WriteLine(fixConflatedError);
+    return 1;
+}
+
 double speed = settings.Speed;
 bool replayToMulticast = settings.ReplayToMulticast;
 var pcapPrefixes = new List<string>(settings.PcapPrefixes);
@@ -39,7 +47,44 @@ int shutdownDrainSeconds = settings.ShutdownDrainSeconds;
 int multicastMergeCapacity = settings.MulticastMergeCapacity;
 int feedChannelCapacity = settings.FeedChannelCapacity;
 int groupRingCapacity = settings.GroupRingCapacity;
+int fixConflatedConflationWindowMs = settings.FixConflatedConflationWindowMs;
+int fixConflatedResendBufferCapacity = settings.FixConflatedResendBufferCapacity;
+int fixConflatedOutboundQueueCapacity = settings.FixConflatedOutboundQueueCapacity;
+int fixConflatedEventQueueCapacity = settings.FixConflatedEventQueueCapacity;
 var logLevel = LogLevelParser.Parse(settings.LogLevel);
+
+if (fixConflatedEnabled)
+{
+    if (wsPort is int configuredWsPort && configuredWsPort == fixConflatedPort)
+    {
+        Console.Error.WriteLine("UMDF_FIX_CONFLATED_PORT must differ from UMDF_WS_PORT.");
+        return 1;
+    }
+
+    if (fixConflatedConflationWindowMs <= 0)
+    {
+        Console.Error.WriteLine("UMDF_FIX_CONFLATED_CONFLATION_MS must be greater than zero when FIX conflated transport is enabled.");
+        return 1;
+    }
+
+    if (fixConflatedResendBufferCapacity < 0)
+    {
+        Console.Error.WriteLine("UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY must be zero or greater.");
+        return 1;
+    }
+
+    if (fixConflatedOutboundQueueCapacity <= 0)
+    {
+        Console.Error.WriteLine("UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY must be greater than zero.");
+        return 1;
+    }
+
+    if (fixConflatedEventQueueCapacity <= 0)
+    {
+        Console.Error.WriteLine("UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY must be greater than zero.");
+        return 1;
+    }
+}
 
 using var loggerFactory = LoggerFactory.Create(builder =>
 {
@@ -373,6 +418,7 @@ var recoveryEventLog = new RecoveryEventLog(capacity: 256);
 // Wire up subscription manager if WebSocket port is specified
 SubscriptionManager? subscriptionManager = null;
 WebSocketHost? wsHost = null;
+FixConflatedTcpServer? fixConflatedServer = null;
 var symbolRegistry = new SymbolRegistry();
 
 if (wsPort is not null)
@@ -391,6 +437,7 @@ if (wsPort is not null)
 var bookManagers = new List<BookManager>();
 var marketDataManagers = new List<MarketDataManager>();
 var groupHandlers = new List<GroupConflationHandler>();
+var fixChannelHandlers = new List<FixConflatedChannelHandler>();
 var groupFeedHandlers = new Dictionary<int, IFeedEventHandler>();
 var groupMdHandlers = new Dictionary<int, IFeedEventHandler>();
 var epochCoordinators = new Dictionary<int, ChannelEpochCoordinator>();
@@ -405,11 +452,36 @@ var staleBufferLogger = loggerFactory.CreateLogger<StaleMboBuffer>();
 // SymbolStateRegistry + StaleMboBuffer.
 var registries = new Dictionary<int, SymbolStateRegistry>();
 var staleBuffers = new Dictionary<int, StaleMboBuffer>();
+FixConflatedSessionHub? fixSessionHub = null;
+FixLiveInstrumentResolver? fixInstrumentResolver = null;
+FixConflatedMarketDataOptions? fixConflatedOptions = null;
+
+if (fixConflatedEnabled)
+{
+    fixSessionHub = new FixConflatedSessionHub(loggerFactory.CreateLogger<FixConflatedSessionHub>());
+    fixInstrumentResolver = new FixLiveInstrumentResolver(symbolRegistry, marketDataManagers);
+    fixConflatedOptions = new FixConflatedMarketDataOptions
+    {
+        ConflationInterval = TimeSpan.FromMilliseconds(fixConflatedConflationWindowMs),
+        PendingEventCapacity = fixConflatedEventQueueCapacity,
+    };
+}
 
 foreach (var gid in groupIds)
 {
     IBookEventHandler bookHandler;
     IMarketDataEventHandler mdHandler = stats;
+    FixConflatedChannelHandler? fixChannelHandler = null;
+    if (fixSessionHub is not null && fixInstrumentResolver is not null && fixConflatedOptions is not null)
+    {
+        fixChannelHandler = new FixConflatedChannelHandler(
+            gid,
+            fixSessionHub,
+            fixInstrumentResolver,
+            fixConflatedOptions);
+        fixChannelHandlers.Add(fixChannelHandler);
+    }
+
     var epochCoordinator = new ChannelEpochCoordinator(
         loggerFactory.CreateLogger<ChannelEpochCoordinator>());
     epochCoordinators[gid] = epochCoordinator;
@@ -443,12 +515,17 @@ foreach (var gid in groupIds)
     if (subscriptionManager is not null)
     {
         var gh = subscriptionManager.CreateGroupHandler();
-        bookHandler = new CompositeBookEventHandler(stats, gh);
+        bookHandler = fixChannelHandler is null
+            ? new CompositeBookEventHandler(stats, gh)
+            : new CompositeBookEventHandler(stats, gh, fixChannelHandler);
         var bm = new BookManager(bookHandler, bmLogger,
             stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer,
             epochCoordinator: epochCoordinator);
-        mdHandler = new CompositeMarketDataEventHandler(stats, gh, bm,
-            new RecoveryEventLoggerHandler(recoveryEventLog, gid));
+        mdHandler = fixChannelHandler is null
+            ? new CompositeMarketDataEventHandler(stats, gh, bm,
+                new RecoveryEventLoggerHandler(recoveryEventLog, gid))
+            : new CompositeMarketDataEventHandler(stats, gh, bm,
+                new RecoveryEventLoggerHandler(recoveryEventLog, gid), fixChannelHandler);
         gh.SetBookManager(bm);
         gh.StartBroadcaster(gid);
         groupHandlers.Add(gh);
@@ -456,12 +533,17 @@ foreach (var gid in groupIds)
     }
     else
     {
-        bookHandler = stats;
+        bookHandler = fixChannelHandler is null
+            ? stats
+            : new CompositeBookEventHandler(stats, fixChannelHandler);
         var bm = new BookManager(bookHandler, bmLogger,
             stateRegistry: groupRegistry, staleBuffer: groupStaleBuffer,
             epochCoordinator: epochCoordinator);
-        mdHandler = new CompositeMarketDataEventHandler(stats, bm,
-            new RecoveryEventLoggerHandler(recoveryEventLog, gid));
+        mdHandler = fixChannelHandler is null
+            ? new CompositeMarketDataEventHandler(stats, bm,
+                new RecoveryEventLoggerHandler(recoveryEventLog, gid))
+            : new CompositeMarketDataEventHandler(stats, bm,
+                new RecoveryEventLoggerHandler(recoveryEventLog, gid), fixChannelHandler);
         bookManagers.Add(bm);
     }
 
@@ -580,7 +662,9 @@ if (subscriptionManager is not null)
 
     // Expose the ConsoleApp's MetricsBinder meter through the host's
     // /metrics endpoint alongside the Server's own "B3.Umdf" meter.
-    wsHost.AdditionalMeterNames = new[] { MetricsBinder.Meter.Name };
+    wsHost.AdditionalMeterNames = fixConflatedEnabled
+        ? [MetricsBinder.Meter.Name, FixConflatedMetrics.Meter.Name]
+        : [MetricsBinder.Meter.Name];
 
     // Wire the active-symbol gauge to SubscriptionManager. Captured once;
     // SubscriptionManager outlives the host.
@@ -589,6 +673,23 @@ if (subscriptionManager is not null)
     MetricsRegistry.ActiveConflatedSubscriptionsProvider = () => sm.ActiveConflatedSubscriptionCount;
 
     await wsHost.StartAsync(wsPort!.Value, cts.Token);
+}
+
+if (fixConflatedEnabled && fixSessionHub is not null && fixInstrumentResolver is not null)
+{
+    fixConflatedServer = new FixConflatedTcpServer(
+        fixSessionHub,
+        new FixConflatedTcpServerOptions
+        {
+            OutboundQueueCapacity = fixConflatedOutboundQueueCapacity,
+            SessionOptions = new FixSessionOptions
+            {
+                ApplicationResendBufferCapacity = fixConflatedResendBufferCapacity,
+            },
+        },
+        initialMessagesProvider: new FixInitialSnapshotProvider(bookManagers, fixInstrumentResolver).CreateMessages,
+        loggerFactory: loggerFactory);
+    await fixConflatedServer.StartAsync(fixConflatedPort, cts.Token);
 }
 
 // Periodic stats timer
@@ -705,10 +806,15 @@ if (singleFeed is not null)
     await singleFeed.StopAsync();
 subscriptionManager?.StopRankingsTimer();
 
-// Brief drain period for in-flight WebSocket writes
+// Brief drain period for in-flight socket writes
+if (wsHost is not null || fixConflatedServer is not null)
+    await Task.Delay(TimeSpan.FromSeconds(shutdownDrainSeconds));
+
+if (fixConflatedServer is not null)
+    await fixConflatedServer.DisposeAsync();
+
 if (wsHost is not null)
 {
-    await Task.Delay(TimeSpan.FromSeconds(shutdownDrainSeconds));
     await wsHost.StopAsync(TimeSpan.FromSeconds(shutdownDrainSeconds));
     await wsHost.DisposeAsync();
 }
@@ -719,6 +825,7 @@ singleFeed?.Dispose();
 // Stop broadcaster threads after feed sources are disposed so no more batches can be
 // published. StopBroadcaster signals the ring and joins the thread.
 foreach (var gh in groupHandlers) gh.StopBroadcaster();
+foreach (var fixHandler in fixChannelHandlers) fixHandler.Dispose();
 
 jitterProbe?.Dispose();
 

--- a/src/B3.Umdf.FixConflated/FixApplicationMessageAdapter.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessageAdapter.cs
@@ -1,0 +1,38 @@
+namespace B3.Umdf.FixConflated;
+
+internal static class FixApplicationMessageAdapter
+{
+    public static FixMessage FromEncodedFrame(ReadOnlySpan<byte> encodedFrame)
+    {
+        FixDecodeResult decoded = FixMessageCodec.Decode(encodedFrame);
+        if (!decoded.Success || decoded.Message is null)
+            throw new InvalidOperationException($"Unable to decode FIX application frame: {decoded.Error}.");
+
+        return StripSessionEnvelope(decoded.Message);
+    }
+
+    public static FixMessage StripSessionEnvelope(FixMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var applicationMessage = new FixMessage();
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag is FixTags.BeginString
+                or FixTags.BodyLength
+                or FixTags.SenderCompId
+                or FixTags.TargetCompId
+                or FixTags.MsgSeqNum
+                or FixTags.SendingTime
+                or FixTags.CheckSum
+                or FixTags.PossDupFlag)
+            {
+                continue;
+            }
+
+            applicationMessage.Add(field.Tag, field.Value);
+        }
+
+        return applicationMessage;
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
@@ -96,8 +96,10 @@ public interface IFixMarketDataInstrumentResolver
 public sealed class FixConflatedMarketDataOptions
 {
     public static readonly TimeSpan DefaultConflationInterval = TimeSpan.FromMilliseconds(380);
+    public const int DefaultPendingEventCapacity = 65_536;
 
     public TimeSpan ConflationInterval { get; init; } = DefaultConflationInterval;
     public int InitialBufferSize { get; init; } = 4 * 1024;
+    public int PendingEventCapacity { get; init; } = DefaultPendingEventCapacity;
     public bool StartBackgroundWorker { get; init; } = true;
 }

--- a/src/B3.Umdf.FixConflated/FixConflatedChannelHandler.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedChannelHandler.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using System.Text;
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixConflatedChannelHandler : IBookEventHandler, IMarketDataEventHandler, IDisposable, IFixConflatedQueueMetricsSource
+{
+    private readonly FixConflatedSessionHub _hub;
+    private readonly IFixClock _clock;
+    private readonly FixConflatedMarketDataPublisher _publisher;
+
+    public FixConflatedChannelHandler(
+        int groupId,
+        FixConflatedSessionHub hub,
+        IFixMarketDataInstrumentResolver instrumentResolver,
+        FixConflatedMarketDataOptions? options = null,
+        IFixClock? clock = null)
+    {
+        GroupId = groupId;
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _clock = clock ?? SystemFixClock.Instance;
+        _publisher = new FixConflatedMarketDataPublisher(
+            hub,
+            new SyntheticHeaderProvider(),
+            instrumentResolver ?? throw new ArgumentNullException(nameof(instrumentResolver)),
+            options,
+            _clock);
+        FixConflatedMetrics.RegisterGroup(groupId, this);
+    }
+
+    public int GroupId { get; }
+    public int PendingQueueDepth => _publisher.PendingEventCount;
+    public long DroppedQueueEntries => _publisher.DroppedEvents;
+
+    public void Dispose()
+    {
+        FixConflatedMetrics.UnregisterGroup(GroupId);
+        _publisher.Dispose();
+    }
+
+    public void OnOrderAdded(OrderBook book, in OrderBookEntry entry) => _publisher.OnOrderAdded(book, in entry);
+    public void OnOrderUpdated(OrderBook book, in OrderBookEntry entry) => _publisher.OnOrderUpdated(book, in entry);
+    public void OnOrderDeleted(OrderBook book, ulong orderId, BookSideType side) => _publisher.OnOrderDeleted(book, orderId, side);
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs) => _publisher.OnTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+    public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags) => _publisher.OnTrade(securityId, price, quantity, tradeId, sendingTimeNs, flags);
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs) => _publisher.OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+    public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags) => _publisher.OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs, flags);
+    public void OnBookCleared(ulong securityId, BookClearSide side) => _publisher.OnBookCleared(securityId, side);
+    public void OnBatchComplete()
+    {
+    }
+
+    public void FlushIfDue()
+    {
+    }
+
+    public void FlushNow() => _publisher.FlushNow();
+    public void OnEpochReset(SnapshotClearReason reason) => _publisher.OnEpochReset(reason);
+
+    public void OnSecurityStatusChanged(ulong securityId, InstrumentInfo info)
+    {
+        if (info.TradingStatus is not int tradingStatus || !TryCreateInstrumentReference(securityId, info, out FixInstrumentReference? instrument))
+            return;
+
+        _hub.BroadcastApplication(SecurityStatusMessageBuilder.Build(new FixSecurityStatusDefinition
+        {
+            Instrument = instrument!,
+            SecurityTradingStatus = tradingStatus,
+            SourceTimestampNanoseconds = GetTimestampNanoseconds(info.LastUpdateTimestamp),
+            TradSesOpenTimeNanoseconds = info.TradSesOpenTime is ulong openTime ? checked((long)openTime) : null,
+            SecurityTradingEvent = info.TradingEvent,
+            TradeDate = info.LastUpdateTimestamp == 0
+                ? DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime)
+                : DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeMilliseconds((long)info.LastUpdateTimestamp / 1_000_000).UtcDateTime),
+        }));
+    }
+
+    public void OnNews(
+        ulong securityIdOrZero,
+        ulong newsId,
+        byte source,
+        ushort language,
+        long origTimeNanos,
+        ReadOnlySpan<byte> headline,
+        ReadOnlySpan<byte> text,
+        ReadOnlySpan<byte> url)
+    {
+        _hub.BroadcastApplication(NewsMessageBuilder.Build(new FixNewsDefinition
+        {
+            OrigTimeNanoseconds = origTimeNanos > 0 ? origTimeNanos : GetTimestampNanoseconds(0),
+            Headline = DecodeUtf8(headline),
+            NewsSource = source.ToString(CultureInfo.InvariantCulture),
+            BodyText = DecodeUtf8(text),
+            NewsId = newsId == 0 ? null : newsId.ToString(CultureInfo.InvariantCulture),
+            LanguageCode = language == 0 ? null : language.ToString(CultureInfo.InvariantCulture),
+            UrlLink = url.IsEmpty ? null : DecodeUtf8(url),
+        }));
+    }
+
+    public void OnInstrumentStatusChanged(ulong securityId, InstrumentInfo info, in InstrumentStatusUpdate update)
+    {
+    }
+
+    public void OnMarketDataUpdated(ulong securityId, InstrumentInfo info)
+    {
+    }
+
+    public void OnSecurityDefinitionChanged(ulong securityId, InstrumentInfo info)
+    {
+    }
+
+    public void OnPriceBandChanged(ulong securityId, InstrumentInfo info)
+    {
+    }
+
+    public void OnAuctionChanged(ulong securityId, InstrumentInfo info)
+    {
+    }
+
+    public void OnInstrumentReplaced(ulong securityId, string? oldSymbol, string newSymbol)
+    {
+    }
+
+    private bool TryCreateInstrumentReference(ulong securityId, InstrumentInfo? info, out FixInstrumentReference? instrument)
+    {
+        string? symbol = info?.Symbol;
+        string? securityGroup = info?.SecurityGroup;
+        string? cfiCode = info?.CfiCode;
+        int? putOrCall = info?.PutOrCall;
+        int? product = info?.Product;
+        string? securityDescription = info?.SecurityDescription;
+        DateOnly? maturityDate = TryParseDateOnly(info?.MaturityDate);
+
+        if (string.IsNullOrWhiteSpace(symbol) && info is null)
+        {
+            instrument = null;
+            return false;
+        }
+
+        instrument = new FixInstrumentReference
+        {
+            Symbol = symbol,
+            SecurityId = securityId.ToString(CultureInfo.InvariantCulture),
+            SecurityGroup = securityGroup,
+            CfiCode = cfiCode,
+            PutOrCall = putOrCall,
+            Product = product,
+            MaturityDate = maturityDate,
+            SecurityDescription = securityDescription,
+        };
+        return true;
+    }
+
+    private static DateOnly? TryParseDateOnly(int? yyyymmdd)
+    {
+        if (yyyymmdd is not int value || value <= 0)
+            return null;
+        if (!DateOnly.TryParseExact(value.ToString(CultureInfo.InvariantCulture), "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly parsed))
+            return null;
+        return parsed;
+    }
+
+    private long GetTimestampNanoseconds(ulong lastUpdateTimestamp)
+    {
+        if (lastUpdateTimestamp > 0)
+            return checked((long)lastUpdateTimestamp);
+        return checked(_clock.UtcNow.ToUnixTimeMilliseconds() * 1_000_000);
+    }
+
+    private static string DecodeUtf8(ReadOnlySpan<byte> bytes)
+        => bytes.IsEmpty ? string.Empty : Encoding.UTF8.GetString(bytes);
+
+    private sealed class SyntheticHeaderProvider : IFixApplicationHeaderProvider
+    {
+        private int _nextSequenceNumber;
+
+        public FixApplicationSessionHeader NextHeader(DateTimeOffset sendingTime)
+            => new("UMDF-SANDBOX", "FIX-CLIENT", Interlocked.Increment(ref _nextSequenceNumber), sendingTime);
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixConflatedMarketDataPublisher.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedMarketDataPublisher.cs
@@ -11,6 +11,7 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
     private readonly IFixClock _clock;
     private readonly FixApplicationMessageWriter _writer;
     private readonly ConcurrentQueue<QueuedBookDelta> _pendingBookDeltas = new();
+    private readonly ConcurrentQueue<QueuedTrade> _pendingTrades = new();
     private readonly Dictionary<ConflationKey, List<QueuedBookDelta>> _bufferedBookDeltas = new();
     private readonly List<ConflationKey> _bufferedOrder = new();
     private readonly object _stateGate = new();
@@ -18,10 +19,13 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
     private readonly AutoResetEvent _wakeSignal = new(false);
     private readonly TimeSpan _conflationInterval;
     private readonly long _conflationIntervalMs;
+    private readonly int _pendingEventCapacity;
     private readonly Thread? _workerThread;
     private volatile bool _disposed;
     private volatile bool _stopRequested;
     private long _nextFlushTicks;
+    private int _pendingEventCount;
+    private long _droppedEvents;
 
     public FixConflatedMarketDataPublisher(
         IFixApplicationMessageSink sink,
@@ -41,6 +45,7 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
 
         _conflationInterval = resolvedOptions.ConflationInterval;
         _conflationIntervalMs = checked((long)Math.Ceiling(_conflationInterval.TotalMilliseconds));
+        _pendingEventCapacity = resolvedOptions.PendingEventCapacity;
         _writer = new FixApplicationMessageWriter(resolvedOptions.InitialBufferSize);
 
         if (resolvedOptions.StartBackgroundWorker)
@@ -55,6 +60,8 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
     }
 
     public TimeSpan ConflationInterval => _conflationInterval;
+    public int PendingEventCount => Volatile.Read(ref _pendingEventCount);
+    public long DroppedEvents => Volatile.Read(ref _droppedEvents);
 
     public void PublishSnapshot(FixMarketDataSnapshotRequest request, OrderBook book)
     {
@@ -104,35 +111,42 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
         => OnTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
 
     public void OnTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
-        => PublishTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+        => EnqueueTrade(new QueuedTrade(securityId, price, quantity, tradeId, sendingTimeNs));
 
     public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
         => OnForwardTrade(securityId, price, quantity, tradeId, sendingTimeNs, TradeFlags.None);
 
     public void OnForwardTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs, TradeFlags flags)
-        => PublishTrade(securityId, price, quantity, tradeId, sendingTimeNs);
+        => EnqueueTrade(new QueuedTrade(securityId, price, quantity, tradeId, sendingTimeNs));
 
     public void OnBookCleared(ulong securityId, BookClearSide side)
     {
+        ThrowIfDisposed();
         long nowTicks = _clock.MonotonicTicks;
         if (side is BookClearSide.Bid or BookClearSide.Both)
         {
-            _pendingBookDeltas.Enqueue(new QueuedBookDelta(
-                securityId,
-                BookSideType.Bid,
-                FixMdUpdateAction.DeleteThru,
-                FixMarketDataEntryFields.None,
-                nowTicks));
+            if (TryReservePendingEventSlot())
+            {
+                _pendingBookDeltas.Enqueue(new QueuedBookDelta(
+                    securityId,
+                    BookSideType.Bid,
+                    FixMdUpdateAction.DeleteThru,
+                    FixMarketDataEntryFields.None,
+                    nowTicks));
+            }
         }
 
         if (side is BookClearSide.Ask or BookClearSide.Both)
         {
-            _pendingBookDeltas.Enqueue(new QueuedBookDelta(
-                securityId,
-                BookSideType.Ask,
-                FixMdUpdateAction.DeleteThru,
-                FixMarketDataEntryFields.None,
-                nowTicks));
+            if (TryReservePendingEventSlot())
+            {
+                _pendingBookDeltas.Enqueue(new QueuedBookDelta(
+                    securityId,
+                    BookSideType.Ask,
+                    FixMdUpdateAction.DeleteThru,
+                    FixMarketDataEntryFields.None,
+                    nowTicks));
+            }
         }
 
         _wakeSignal.Set();
@@ -145,6 +159,12 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
         {
             while (_pendingBookDeltas.TryDequeue(out _))
             {
+                ReleasePendingEventSlot();
+            }
+
+            while (_pendingTrades.TryDequeue(out _))
+            {
+                ReleasePendingEventSlot();
             }
 
             _bufferedBookDeltas.Clear();
@@ -203,36 +223,23 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
         }
     }
 
-    private void PublishTrade(ulong securityId, long price, long quantity, long tradeId, long sendingTimeNs)
-    {
-        ThrowIfDisposed();
-        if (!_instrumentResolver.TryResolve(securityId, out FixMarketDataInstrument instrument))
-            return;
-
-        DateTimeOffset entryTime = ConvertToTimestamp(sendingTimeNs);
-        FixApplicationSessionHeader header = _headerProvider.NextHeader(entryTime);
-
-        Span<FixMarketDataIncrementalEntry> entries = stackalloc FixMarketDataIncrementalEntry[1];
-        entries[0] = new FixMarketDataIncrementalEntry(
-            FixMdUpdateAction.New,
-            FixMdEntryType.Trade,
-            entryTime,
-            FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.TradeId,
-            price,
-            quantity,
-            TradeId: tradeId);
-
-        lock (_emitGate)
-        {
-            ReadOnlyMemory<byte> frame = _writer.WriteIncrementalRefresh(header, instrument, entries);
-            _sink.OnMessage(frame);
-        }
-    }
-
     private void EnqueueBookDelta(QueuedBookDelta delta)
     {
         ThrowIfDisposed();
+        if (!TryReservePendingEventSlot())
+            return;
+
         _pendingBookDeltas.Enqueue(delta);
+        _wakeSignal.Set();
+    }
+
+    private void EnqueueTrade(QueuedTrade trade)
+    {
+        ThrowIfDisposed();
+        if (!TryReservePendingEventSlot())
+            return;
+
+        _pendingTrades.Enqueue(trade);
         _wakeSignal.Set();
     }
 
@@ -256,52 +263,64 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
 
     private void FlushBuffered(bool force)
     {
-        List<BufferedBatch>? batches = null;
+        List<BufferedBatch>? bookBatches = null;
+        List<QueuedTrade>? trades = null;
 
         lock (_stateGate)
         {
             DrainPendingDeltas();
+            trades = DrainPendingTrades();
 
-            if (_bufferedOrder.Count == 0)
+            if (_bufferedOrder.Count == 0 && (trades is null || trades.Count == 0))
                 return;
 
             long nowTicks = _clock.MonotonicTicks;
-            if (!force && nowTicks < _nextFlushTicks)
+            bool emitBookBatches = _bufferedOrder.Count != 0 && (force || nowTicks >= _nextFlushTicks);
+            if (!emitBookBatches && (trades is null || trades.Count == 0))
                 return;
 
-            DateTimeOffset flushTime = _clock.UtcNow;
-            batches = new List<BufferedBatch>(_bufferedOrder.Count);
-            foreach (ConflationKey key in _bufferedOrder)
+            if (emitBookBatches)
             {
-                List<QueuedBookDelta> deltas = _bufferedBookDeltas[key];
-                var entries = new FixMarketDataIncrementalEntry[deltas.Count];
-                for (int i = 0; i < deltas.Count; i++)
+                DateTimeOffset flushTime = _clock.UtcNow;
+                bookBatches = new List<BufferedBatch>(_bufferedOrder.Count);
+                foreach (ConflationKey key in _bufferedOrder)
                 {
-                    QueuedBookDelta delta = deltas[i];
-                    entries[i] = new FixMarketDataIncrementalEntry(
-                        delta.UpdateAction,
-                        key.EntryType,
-                        flushTime,
-                        delta.Fields,
-                        delta.Price,
-                        delta.Size,
-                        delta.OrderId);
+                    List<QueuedBookDelta> deltas = _bufferedBookDeltas[key];
+                    var entries = new FixMarketDataIncrementalEntry[deltas.Count];
+                    for (int i = 0; i < deltas.Count; i++)
+                    {
+                        QueuedBookDelta delta = deltas[i];
+                        entries[i] = new FixMarketDataIncrementalEntry(
+                            delta.UpdateAction,
+                            key.EntryType,
+                            flushTime,
+                            delta.Fields,
+                            delta.Price,
+                            delta.Size,
+                            delta.OrderId);
+                    }
+
+                    bookBatches.Add(new BufferedBatch(key.SecurityId, entries));
                 }
 
-                batches.Add(new BufferedBatch(key.SecurityId, entries));
+                _bufferedBookDeltas.Clear();
+                _bufferedOrder.Clear();
+                _nextFlushTicks = 0;
             }
-
-            _bufferedBookDeltas.Clear();
-            _bufferedOrder.Clear();
-            _nextFlushTicks = 0;
         }
 
         lock (_emitGate)
         {
-            if (batches is null)
+            if (trades is not null)
+            {
+                foreach (QueuedTrade trade in trades)
+                    EmitTrade(trade);
+            }
+
+            if (bookBatches is null)
                 return;
 
-            foreach (BufferedBatch batch in batches)
+            foreach (BufferedBatch batch in bookBatches)
             {
                 if (!_instrumentResolver.TryResolve(batch.SecurityId, out FixMarketDataInstrument instrument))
                     continue;
@@ -317,6 +336,7 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
     {
         while (_pendingBookDeltas.TryDequeue(out QueuedBookDelta delta))
         {
+            ReleasePendingEventSlot();
             var key = new ConflationKey(delta.SecurityId, delta.Side);
             if (!_bufferedBookDeltas.TryGetValue(key, out List<QueuedBookDelta>? entries))
             {
@@ -329,6 +349,69 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
             if (_nextFlushTicks == 0)
                 _nextFlushTicks = delta.EnqueueTicks + _conflationIntervalMs;
         }
+    }
+
+    private List<QueuedTrade>? DrainPendingTrades()
+    {
+        List<QueuedTrade>? trades = null;
+        while (_pendingTrades.TryDequeue(out QueuedTrade trade))
+        {
+            ReleasePendingEventSlot();
+            trades ??= new List<QueuedTrade>();
+            trades.Add(trade);
+        }
+
+        return trades;
+    }
+
+    private void EmitTrade(QueuedTrade trade)
+    {
+        if (!_instrumentResolver.TryResolve(trade.SecurityId, out FixMarketDataInstrument instrument))
+            return;
+
+        DateTimeOffset entryTime = ConvertToTimestamp(trade.SendingTimeNs);
+        FixApplicationSessionHeader header = _headerProvider.NextHeader(entryTime);
+
+        Span<FixMarketDataIncrementalEntry> entries = stackalloc FixMarketDataIncrementalEntry[1];
+        entries[0] = new FixMarketDataIncrementalEntry(
+            FixMdUpdateAction.New,
+            FixMdEntryType.Trade,
+            entryTime,
+            FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.TradeId,
+            trade.Price,
+            trade.Quantity,
+            TradeId: trade.TradeId);
+
+        ReadOnlyMemory<byte> frame = _writer.WriteIncrementalRefresh(header, instrument, entries);
+        _sink.OnMessage(frame);
+    }
+
+    private bool TryReservePendingEventSlot()
+    {
+        if (_pendingEventCapacity <= 0)
+        {
+            Interlocked.Increment(ref _pendingEventCount);
+            return true;
+        }
+
+        while (true)
+        {
+            int snapshot = Volatile.Read(ref _pendingEventCount);
+            if (snapshot >= _pendingEventCapacity)
+            {
+                Interlocked.Increment(ref _droppedEvents);
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _pendingEventCount, snapshot + 1, snapshot) == snapshot)
+                return true;
+        }
+    }
+
+    private void ReleasePendingEventSlot()
+    {
+        if (Interlocked.Decrement(ref _pendingEventCount) < 0)
+            Interlocked.Exchange(ref _pendingEventCount, 0);
     }
 
     private void ThrowIfDisposed()
@@ -358,6 +441,13 @@ public sealed class FixConflatedMarketDataPublisher : IBookEventHandler, IDispos
         long Price = 0,
         long Size = 0,
         ulong OrderId = 0);
+
+    private readonly record struct QueuedTrade(
+        ulong SecurityId,
+        long Price,
+        long Quantity,
+        long TradeId,
+        long SendingTimeNs);
 
     private readonly record struct BufferedBatch(
         ulong SecurityId,

--- a/src/B3.Umdf.FixConflated/FixConflatedMetrics.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedMetrics.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace B3.Umdf.FixConflated;
+
+public static class FixConflatedMetrics
+{
+    public static readonly Meter Meter = new("B3.Umdf.FixConflated", "1.0.0");
+    public static readonly UpDownCounter<int> ActiveConnections = Meter.CreateUpDownCounter<int>(
+        "b3.umdf.fix_conflated.connections.active",
+        unit: "{connections}",
+        description: "Active FIX conflated TCP sessions");
+    public static readonly Counter<long> MessagesSent = Meter.CreateCounter<long>(
+        "b3.umdf.fix_conflated.messages.sent",
+        unit: "{messages}",
+        description: "FIX session/application messages written to TCP sessions");
+    public static readonly Counter<long> BytesSent = Meter.CreateCounter<long>(
+        "b3.umdf.fix_conflated.bytes.sent",
+        unit: "By",
+        description: "Bytes written to FIX conflated TCP sessions");
+
+    private static readonly ConcurrentDictionary<int, IFixConflatedQueueMetricsSource> s_sources = new();
+
+    static FixConflatedMetrics()
+    {
+        Meter.CreateObservableGauge(
+            "b3.umdf.fix_conflated.queue.depth",
+            ObserveQueueDepth,
+            unit: "{events}",
+            description: "Pending queued hot-path events awaiting FIX encode per group");
+        Meter.CreateObservableCounter(
+            "b3.umdf.fix_conflated.queue.dropped",
+            ObserveQueueDrops,
+            unit: "{events}",
+            description: "Hot-path FIX conflated events dropped because the queue was full");
+    }
+
+    public static void RegisterGroup(int groupId, IFixConflatedQueueMetricsSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        s_sources[groupId] = source;
+    }
+
+    public static void UnregisterGroup(int groupId)
+    {
+        s_sources.TryRemove(groupId, out _);
+    }
+
+    private static IEnumerable<Measurement<int>> ObserveQueueDepth()
+    {
+        foreach (KeyValuePair<int, IFixConflatedQueueMetricsSource> entry in s_sources)
+            yield return new Measurement<int>(entry.Value.PendingQueueDepth, new KeyValuePair<string, object?>("group", $"G{entry.Key}"));
+    }
+
+    private static IEnumerable<Measurement<long>> ObserveQueueDrops()
+    {
+        foreach (KeyValuePair<int, IFixConflatedQueueMetricsSource> entry in s_sources)
+            yield return new Measurement<long>(entry.Value.DroppedQueueEntries, new KeyValuePair<string, object?>("group", $"G{entry.Key}"));
+    }
+}
+
+public interface IFixConflatedQueueMetricsSource
+{
+    int PendingQueueDepth { get; }
+    long DroppedQueueEntries { get; }
+}

--- a/src/B3.Umdf.FixConflated/FixConflatedSessionHub.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedSessionHub.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixConflatedSessionHub : IFixApplicationMessageSink
+{
+    private readonly ConcurrentDictionary<long, FixTcpClientSession> _sessions = new();
+    private readonly ILogger<FixConflatedSessionHub> _logger;
+
+    public FixConflatedSessionHub(ILogger<FixConflatedSessionHub>? logger = null)
+    {
+        _logger = logger ?? NullLogger<FixConflatedSessionHub>.Instance;
+    }
+
+    public int ActiveSessionCount => _sessions.Count;
+
+    public void Register(FixTcpClientSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        _sessions[session.Id] = session;
+    }
+
+    public void Unregister(long sessionId)
+    {
+        _sessions.TryRemove(sessionId, out _);
+    }
+
+    public void OnMessage(ReadOnlyMemory<byte> message)
+        => BroadcastApplication(FixApplicationMessageAdapter.FromEncodedFrame(message.Span));
+
+    public void BroadcastApplication(FixMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        foreach (KeyValuePair<long, FixTcpClientSession> entry in _sessions)
+        {
+            try
+            {
+                entry.Value.TrySendApplication(message);
+            }
+            catch (ObjectDisposedException)
+            {
+                _logger.LogDebug("Skipped disposed FIX session {SessionId} during broadcast", entry.Key);
+            }
+        }
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixConflatedTcpServer.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedTcpServer.cs
@@ -1,0 +1,129 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixConflatedTcpServer : IAsyncDisposable
+{
+    private readonly FixConflatedSessionHub _hub;
+    private readonly FixConflatedTcpServerOptions _options;
+    private readonly FixSessionStateStore _stateStore = new();
+    private readonly Func<IEnumerable<FixMessage>>? _initialMessagesProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<FixConflatedTcpServer> _logger;
+    private readonly ConcurrentDictionary<long, FixTcpClientSession> _sessions = new();
+    private readonly CancellationTokenSource _cts = new();
+    private TcpListener? _listener;
+    private Task? _acceptLoop;
+    private long _nextSessionId;
+
+    public FixConflatedTcpServer(
+        FixConflatedSessionHub hub,
+        FixConflatedTcpServerOptions? options = null,
+        Func<IEnumerable<FixMessage>>? initialMessagesProvider = null,
+        ILoggerFactory? loggerFactory = null,
+        ILogger<FixConflatedTcpServer>? logger = null)
+    {
+        _hub = hub ?? throw new ArgumentNullException(nameof(hub));
+        _options = options ?? new FixConflatedTcpServerOptions();
+        _initialMessagesProvider = initialMessagesProvider;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _logger = logger ?? (_loggerFactory == NullLoggerFactory.Instance
+            ? NullLogger<FixConflatedTcpServer>.Instance
+            : _loggerFactory.CreateLogger<FixConflatedTcpServer>());
+    }
+
+    public int Port { get; private set; }
+
+    public Task StartAsync(int port, CancellationToken cancellationToken = default)
+    {
+        if (port is < 1 or > 65535)
+            throw new ArgumentOutOfRangeException(nameof(port));
+        if (_listener is not null)
+            throw new InvalidOperationException("FIX conflated TCP server already started.");
+
+        _listener = new TcpListener(IPAddress.Any, port);
+        _listener.Start(_options.AcceptBacklog);
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+        _acceptLoop = Task.Run(() => AcceptLoopAsync(linkedCts.Token), linkedCts.Token);
+        _logger.LogInformation("FIX conflated TCP server listening on port {Port}", Port);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync()
+    {
+        _cts.Cancel();
+        _listener?.Stop();
+
+        if (_acceptLoop is not null)
+        {
+            try { await _acceptLoop.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch (ObjectDisposedException) { }
+        }
+
+        foreach (FixTcpClientSession session in _sessions.Values)
+            await session.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        _cts.Dispose();
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+    {
+        TcpListener listener = _listener ?? throw new InvalidOperationException("Listener not started.");
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient client = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                client.NoDelay = true;
+                long sessionId = Interlocked.Increment(ref _nextSessionId);
+                var session = new FixTcpClientSession(
+                    sessionId,
+                    client,
+                    new FixSessionConnection(_stateStore, _options.SessionOptions),
+                    _options.OutboundQueueCapacity,
+                    _initialMessagesProvider,
+                    OnSessionClosed,
+                    _loggerFactory.CreateLogger<FixTcpClientSession>());
+
+                _sessions[sessionId] = session;
+                _hub.Register(session);
+                FixConflatedMetrics.ActiveConnections.Add(1);
+                _logger.LogInformation("Accepted FIX conflated TCP session {SessionId} from {RemoteEndPoint}",
+                    sessionId,
+                    client.Client.RemoteEndPoint);
+                session.Start();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (SocketException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogDebug(ex, "FIX TCP accept loop cancelled");
+        }
+    }
+
+    private void OnSessionClosed(long sessionId)
+    {
+        if (_sessions.TryRemove(sessionId, out FixTcpClientSession? session))
+        {
+            _hub.Unregister(sessionId);
+            FixConflatedMetrics.ActiveConnections.Add(-1);
+            _logger.LogInformation("Closed FIX conflated TCP session {SessionId}", sessionId);
+            _ = Task.Run(async () => await session.DisposeAsync().ConfigureAwait(false));
+        }
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixConflatedTcpServerOptions.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedTcpServerOptions.cs
@@ -1,0 +1,8 @@
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixConflatedTcpServerOptions
+{
+    public int OutboundQueueCapacity { get; init; } = 4096;
+    public int AcceptBacklog { get; init; } = 128;
+    public FixSessionOptions SessionOptions { get; init; } = new();
+}

--- a/src/B3.Umdf.FixConflated/FixInitialSnapshotProvider.cs
+++ b/src/B3.Umdf.FixConflated/FixInitialSnapshotProvider.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixInitialSnapshotProvider
+{
+    private readonly IReadOnlyList<BookManager> _bookManagers;
+    private readonly IFixMarketDataInstrumentResolver _instrumentResolver;
+    private readonly IFixClock _clock;
+
+    public FixInitialSnapshotProvider(
+        IReadOnlyList<BookManager> bookManagers,
+        IFixMarketDataInstrumentResolver instrumentResolver,
+        IFixClock? clock = null)
+    {
+        _bookManagers = bookManagers ?? throw new ArgumentNullException(nameof(bookManagers));
+        _instrumentResolver = instrumentResolver ?? throw new ArgumentNullException(nameof(instrumentResolver));
+        _clock = clock ?? SystemFixClock.Instance;
+    }
+
+    public IEnumerable<FixMessage> CreateMessages()
+    {
+        var emitted = new HashSet<ulong>();
+        DateTimeOffset snapshotTime = _clock.UtcNow;
+
+        foreach (BookManager manager in _bookManagers)
+        {
+            foreach (KeyValuePair<ulong, OrderBook> entry in manager.Books)
+            {
+                if (!emitted.Add(entry.Key))
+                    continue;
+                if (!_instrumentResolver.TryResolve(entry.Key, out FixMarketDataInstrument instrument))
+                    continue;
+
+                yield return FixSnapshotMessageBuilder.Build(
+                    new FixMarketDataSnapshotRequest($"SNAP-{entry.Key.ToString(CultureInfo.InvariantCulture)}", instrument),
+                    entry.Value,
+                    snapshotTime);
+            }
+        }
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixLiveInstrumentResolver.cs
+++ b/src/B3.Umdf.FixConflated/FixLiveInstrumentResolver.cs
@@ -1,0 +1,54 @@
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixLiveInstrumentResolver : IFixMarketDataInstrumentResolver
+{
+    private const int DefaultPriceScale = 4;
+    private readonly SymbolRegistry _symbolRegistry;
+    private readonly IReadOnlyList<MarketDataManager> _marketDataManagers;
+
+    public FixLiveInstrumentResolver(SymbolRegistry symbolRegistry, IReadOnlyList<MarketDataManager> marketDataManagers)
+    {
+        _symbolRegistry = symbolRegistry ?? throw new ArgumentNullException(nameof(symbolRegistry));
+        _marketDataManagers = marketDataManagers ?? throw new ArgumentNullException(nameof(marketDataManagers));
+    }
+
+    public bool TryResolve(ulong securityId, out FixMarketDataInstrument instrument)
+    {
+        foreach (MarketDataManager manager in _marketDataManagers)
+        {
+            if (!manager.InstrumentData.TryGetValue(securityId, out InstrumentInfo? info) || string.IsNullOrWhiteSpace(info.Symbol))
+                continue;
+
+            instrument = new FixMarketDataInstrument(info.Symbol, securityId, ResolvePriceScale(info));
+            return true;
+        }
+
+        if (_symbolRegistry.TryGetSymbol(securityId, out string symbol))
+        {
+            instrument = new FixMarketDataInstrument(symbol, securityId, DefaultPriceScale);
+            return true;
+        }
+
+        instrument = default;
+        return false;
+    }
+
+    internal static int ResolvePriceScale(InstrumentInfo info)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        if (info.PriceDivisor is not long divisor || divisor <= 0)
+            return DefaultPriceScale;
+
+        int scale = 0;
+        long remaining = divisor;
+        while (remaining > 1 && remaining % 10 == 0)
+        {
+            remaining /= 10;
+            scale++;
+        }
+
+        return remaining == 1 ? scale : DefaultPriceScale;
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using B3.Umdf.Book;
+
+namespace B3.Umdf.FixConflated;
+
+internal static class FixSnapshotMessageBuilder
+{
+    public static FixMessage Build(FixMarketDataSnapshotRequest request, OrderBook book, DateTimeOffset entryTime)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixMsgTypes.MarketDataSnapshotFullRefresh);
+        message.Add(FixTags.MDReqId, request.MdReqId);
+        message.Add(FixTags.Symbol, request.Instrument.Symbol);
+        message.Add(FixTags.SecurityId, request.Instrument.SecurityId.ToString(CultureInfo.InvariantCulture));
+
+        int entryCount = book.Bids.OrderCount + book.Asks.OrderCount;
+        message.Add(FixTags.NoMDEntries, entryCount);
+
+        string entryDate = entryTime.UtcDateTime.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+        string entryTimeValue = entryTime.UtcDateTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);
+        AppendSide(message, book.Bids, FixMdEntryType.Bid, request.Instrument.PriceScale, entryDate, entryTimeValue);
+        AppendSide(message, book.Asks, FixMdEntryType.Offer, request.Instrument.PriceScale, entryDate, entryTimeValue);
+        return message;
+    }
+
+    private static void AppendSide(
+        FixMessage message,
+        BookSide side,
+        FixMdEntryType entryType,
+        int priceScale,
+        string entryDate,
+        string entryTime)
+    {
+        foreach (KeyValuePair<long, List<OrderBookEntry>> level in side.PriceLevels)
+        {
+            foreach (OrderBookEntry order in level.Value)
+            {
+                message.Add(FixTags.MDEntryType, ((char)entryType).ToString());
+                message.Add(FixTags.MDEntryPx, FormatScaledPrice(order.Price, priceScale));
+                message.Add(FixTags.MDEntrySize, order.Quantity.ToString(CultureInfo.InvariantCulture));
+                message.Add(FixTags.MDEntryDate, entryDate);
+                message.Add(FixTags.MDEntryTime, entryTime);
+                message.Add(FixTags.OrderId, order.OrderId.ToString(CultureInfo.InvariantCulture));
+            }
+        }
+    }
+
+    private static string FormatScaledPrice(long value, int scale)
+    {
+        if (scale <= 0)
+            return value.ToString(CultureInfo.InvariantCulture);
+
+        decimal divisor = 1m;
+        for (int i = 0; i < scale; i++)
+            divisor *= 10m;
+
+        decimal scaled = value / divisor;
+        return scaled.ToString($"F{scale}", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/B3.Umdf.FixConflated/FixTcpClientSession.cs
+++ b/src/B3.Umdf.FixConflated/FixTcpClientSession.cs
@@ -1,0 +1,272 @@
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.FixConflated;
+
+public sealed class FixTcpClientSession : IAsyncDisposable
+{
+    private readonly TcpClient _client;
+    private readonly NetworkStream _stream;
+    private readonly FixSessionConnection _session;
+    private readonly Func<IEnumerable<FixMessage>>? _initialMessagesProvider;
+    private readonly Action<long> _onClosed;
+    private readonly ILogger<FixTcpClientSession> _logger;
+    private readonly Channel<byte[]> _outbound;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly object _sessionGate = new();
+    private readonly ConcurrentBag<Task> _tasks = new();
+    private int _closed;
+
+    public FixTcpClientSession(
+        long id,
+        TcpClient client,
+        FixSessionConnection session,
+        int outboundQueueCapacity,
+        Func<IEnumerable<FixMessage>>? initialMessagesProvider,
+        Action<long> onClosed,
+        ILogger<FixTcpClientSession>? logger = null)
+    {
+        if (outboundQueueCapacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outboundQueueCapacity));
+
+        Id = id;
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _stream = client.GetStream();
+        _session = session ?? throw new ArgumentNullException(nameof(session));
+        _initialMessagesProvider = initialMessagesProvider;
+        _onClosed = onClosed ?? throw new ArgumentNullException(nameof(onClosed));
+        _logger = logger ?? NullLogger<FixTcpClientSession>.Instance;
+        _outbound = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(outboundQueueCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+    }
+
+    public long Id { get; }
+
+    public void Start()
+    {
+        _tasks.Add(Task.Run(ReadLoopAsync));
+        _tasks.Add(Task.Run(WriteLoopAsync));
+        _tasks.Add(Task.Run(HeartbeatLoopAsync));
+    }
+
+    public bool TrySendApplication(FixMessage applicationMessage)
+    {
+        ArgumentNullException.ThrowIfNull(applicationMessage);
+        if (_cts.IsCancellationRequested)
+            return false;
+
+        FixSessionUpdate update;
+        lock (_sessionGate)
+        {
+            if (!_session.TrySendApplication(applicationMessage, out update))
+                return false;
+        }
+
+        return ProcessUpdate(update);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Close();
+        try
+        {
+            await Task.WhenAll(_tasks.ToArray()).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+        catch (SocketException)
+        {
+        }
+        finally
+        {
+            _stream.Dispose();
+            _client.Dispose();
+            _cts.Dispose();
+        }
+    }
+
+    private async Task ReadLoopAsync()
+    {
+        byte[] buffer = new byte[16 * 1024];
+        int buffered = 0;
+
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                if (buffered == buffer.Length)
+                    Array.Resize(ref buffer, buffer.Length * 2);
+
+                int read = await _stream.ReadAsync(buffer.AsMemory(buffered), _cts.Token).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+
+                buffered += read;
+                int consumed = 0;
+                while (consumed < buffered)
+                {
+                    FixDecodeResult decoded = FixMessageCodec.Decode(buffer.AsSpan(consumed, buffered - consumed));
+                    if (decoded.Error == FixDecodeError.Incomplete)
+                        break;
+                    if (!decoded.Success || decoded.Message is null)
+                    {
+                        _logger.LogWarning("Disconnecting FIX session {SessionId}: invalid inbound frame ({Error})", Id, decoded.Error);
+                        Close();
+                        return;
+                    }
+
+                    bool activated = false;
+                    FixSessionUpdate update;
+                    lock (_sessionGate)
+                    {
+                        FixSessionState previous = _session.State;
+                        update = _session.Receive(decoded.Message);
+                        activated = previous != FixSessionState.Active && _session.State == FixSessionState.Active;
+                    }
+
+                    if (!ProcessUpdate(update))
+                        return;
+
+                    if (activated)
+                        SendInitialMessages();
+
+                    consumed += decoded.BytesConsumed;
+                }
+
+                if (consumed == 0)
+                    continue;
+
+                Buffer.BlockCopy(buffer, consumed, buffer, 0, buffered - consumed);
+                buffered -= consumed;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (IOException ex)
+        {
+            _logger.LogDebug(ex, "FIX session {SessionId} read loop ended with I/O error", Id);
+        }
+        catch (SocketException ex)
+        {
+            _logger.LogDebug(ex, "FIX session {SessionId} read loop ended with socket error", Id);
+        }
+        finally
+        {
+            Close();
+        }
+    }
+
+    private async Task WriteLoopAsync()
+    {
+        try
+        {
+            while (await _outbound.Reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            {
+                while (_outbound.Reader.TryRead(out byte[]? payload))
+                {
+                    await _stream.WriteAsync(payload, _cts.Token).ConfigureAwait(false);
+                    FixConflatedMetrics.MessagesSent.Add(1);
+                    FixConflatedMetrics.BytesSent.Add(payload.Length);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (IOException ex)
+        {
+            _logger.LogDebug(ex, "FIX session {SessionId} write loop ended with I/O error", Id);
+        }
+        catch (SocketException ex)
+        {
+            _logger.LogDebug(ex, "FIX session {SessionId} write loop ended with socket error", Id);
+        }
+        finally
+        {
+            Close();
+        }
+    }
+
+    private async Task HeartbeatLoopAsync()
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_cts.Token).ConfigureAwait(false))
+            {
+                FixSessionUpdate update;
+                lock (_sessionGate)
+                    update = _session.Advance();
+
+                if (!ProcessUpdate(update))
+                    return;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            Close();
+        }
+    }
+
+    private bool ProcessUpdate(FixSessionUpdate update)
+    {
+        foreach (FixMessage outbound in update.OutboundMessages)
+        {
+            if (!_outbound.Writer.TryWrite(FixMessageCodec.Encode(outbound)))
+            {
+                _logger.LogWarning("Disconnecting FIX session {SessionId}: outbound queue full", Id);
+                Close();
+                return false;
+            }
+        }
+
+        if (update.DisconnectTransport)
+        {
+            Close();
+            return false;
+        }
+
+        return true;
+    }
+
+    private void SendInitialMessages()
+    {
+        if (_initialMessagesProvider is null)
+            return;
+
+        foreach (FixMessage message in _initialMessagesProvider())
+        {
+            if (!TrySendApplication(message))
+                return;
+        }
+    }
+
+    private void Close()
+    {
+        if (Interlocked.Exchange(ref _closed, 1) != 0)
+            return;
+
+        _cts.Cancel();
+        _outbound.Writer.TryComplete();
+        try { _client.Client.Shutdown(SocketShutdown.Both); }
+        catch (SocketException) { }
+        catch (ObjectDisposedException) { }
+        _onClosed(Id);
+    }
+}

--- a/src/B3.Umdf.Server/AppSettings.cs
+++ b/src/B3.Umdf.Server/AppSettings.cs
@@ -14,6 +14,12 @@ public sealed partial class AppSettings
     /// <summary>WebSocket server port. CLI: --ws-port</summary>
     public int? WsPort { get; set; }
 
+    /// <summary>Enable the opt-in FIX conflated TCP listener. Env: UMDF_FIX_CONFLATED_ENABLED.</summary>
+    public bool FixConflatedEnabled { get; set; }
+
+    /// <summary>FIX conflated TCP listener port. Env: UMDF_FIX_CONFLATED_PORT.</summary>
+    public int? FixConflatedPort { get; set; }
+
     /// <summary>Replay speed multiplier. 0=max, 1=real-time. CLI: --speed</summary>
     public double Speed { get; set; }
 
@@ -104,6 +110,34 @@ public sealed partial class AppSettings
     /// UMDF_CLIENT_COALESCE_WINDOW_MS.
     /// </summary>
     public int ClientCoalesceWindowMs { get; set; } = 10;
+
+    /// <summary>
+    /// FIX conflated book-delta conflation window (milliseconds). Mirrors the
+    /// sandbox spec default (~380 ms) but remains configurable for experiments.
+    /// Env: UMDF_FIX_CONFLATED_CONFLATION_MS.
+    /// </summary>
+    public int FixConflatedConflationWindowMs { get; set; } = 380;
+
+    /// <summary>
+    /// Per-connection FIX session resend-buffer capacity (application messages kept
+    /// in memory for ResendRequest replay inside the current process/session only).
+    /// Env: UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY.
+    /// </summary>
+    public int FixConflatedResendBufferCapacity { get; set; } = 10_000;
+
+    /// <summary>
+    /// Per-connection outbound queue capacity for the FIX TCP transport. Slow
+    /// sessions are disconnected when this bounded queue fills. Env:
+    /// UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY.
+    /// </summary>
+    public int FixConflatedOutboundQueueCapacity { get; set; } = 4096;
+
+    /// <summary>
+    /// Hot-path event queue capacity per group for the FIX conflated publisher.
+    /// When full, new events are dropped instead of blocking the shared group
+    /// thread. Env: UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY.
+    /// </summary>
+    public int FixConflatedEventQueueCapacity { get; set; } = 65_536;
 
     /// <summary>
     /// Server-side semantic conflation window (milliseconds) applied inside
@@ -293,6 +327,10 @@ public sealed partial class AppSettings
     {
         if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_WS_PORT"), out var port))
             WsPort = port;
+        if (TryParseBoolean(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_ENABLED"), out var fixConflatedEnabled))
+            FixConflatedEnabled = fixConflatedEnabled;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_PORT"), out var fixPort))
+            FixConflatedPort = fixPort;
         if (double.TryParse(Environment.GetEnvironmentVariable("UMDF_SPEED"), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var sp))
             Speed = sp;
         if (TryParseBoolean(Environment.GetEnvironmentVariable("UMDF_REPLAY_TO_MULTICAST"), out var replayToMulticast))
@@ -317,6 +355,14 @@ public sealed partial class AppSettings
             ClientOutlierIntervalMs = outlierMs;
         if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_CLIENT_COALESCE_WINDOW_MS"), out var coalesceMs))
             ClientCoalesceWindowMs = coalesceMs;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_CONFLATION_MS"), out var fixConflationMs) && fixConflationMs > 0)
+            FixConflatedConflationWindowMs = fixConflationMs;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY"), out var fixResendCapacity) && fixResendCapacity >= 0)
+            FixConflatedResendBufferCapacity = fixResendCapacity;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY"), out var fixOutboundQueueCapacity) && fixOutboundQueueCapacity > 0)
+            FixConflatedOutboundQueueCapacity = fixOutboundQueueCapacity;
+        if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY"), out var fixEventQueueCapacity) && fixEventQueueCapacity > 0)
+            FixConflatedEventQueueCapacity = fixEventQueueCapacity;
         if (int.TryParse(Environment.GetEnvironmentVariable("UMDF_SERVER_FLUSH_WINDOW_MS"), out var serverFlushMs) && serverFlushMs >= 0)
             ServerFlushWindowMs = serverFlushMs;
         var conflatedCadences = Environment.GetEnvironmentVariable("UMDF_CONFLATED_CADENCES_MS");

--- a/tests/B3.Umdf.ConsoleApp.Tests/FixConflatedFeatureGateTests.cs
+++ b/tests/B3.Umdf.ConsoleApp.Tests/FixConflatedFeatureGateTests.cs
@@ -1,0 +1,32 @@
+using B3.Umdf.ConsoleApp;
+using B3.Umdf.Server;
+
+namespace B3.Umdf.ConsoleApp.Tests;
+
+public sealed class FixConflatedFeatureGateTests
+{
+    [Fact]
+    public void TryResolvePort_Disabled_ReturnsFalseWithoutError()
+    {
+        var settings = new AppSettings();
+
+        bool enabled = FixConflatedFeatureGate.TryResolvePort(settings, out int port, out string? error);
+
+        Assert.False(enabled);
+        Assert.Equal(0, port);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void TryResolvePort_EnabledWithoutPort_ReturnsValidationError()
+    {
+        var settings = new AppSettings { FixConflatedEnabled = true };
+
+        bool enabled = FixConflatedFeatureGate.TryResolvePort(settings, out int port, out string? error);
+
+        Assert.False(enabled);
+        Assert.Equal(0, port);
+        Assert.NotNull(error);
+        Assert.Contains("UMDF_FIX_CONFLATED_PORT", error, StringComparison.Ordinal);
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/AllocationSensitiveCollection.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/AllocationSensitiveCollection.cs
@@ -1,0 +1,6 @@
+namespace B3.Umdf.FixConflated.Tests;
+
+[CollectionDefinition(nameof(AllocationSensitiveCollection), DisableParallelization = true)]
+public sealed class AllocationSensitiveCollection
+{
+}

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataHotPathTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataHotPathTests.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+[Collection(nameof(AllocationSensitiveCollection))]
+public sealed class FixConflatedMarketDataHotPathTests
+{
+    [Fact]
+    public void HotPath_Callbacks_Allocate_Below_Threshold()
+    {
+        var clock = new FakeFixClock();
+        var sink = new CapturingSink();
+        using var publisher = CreatePublisher(clock, sink, startBackgroundWorker: false);
+        OrderBook book = new(1234);
+        OrderBookEntry entry = CreateEntry(book.SecurityId, 7001, BookSideType.Bid, 281000, 100);
+
+        publisher.OnOrderAdded(book, in entry);
+        publisher.OnTrade(book.SecurityId, 281050, 10, 9001, 0);
+        publisher.FlushNow();
+
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true);
+
+        long beforeBytes = GC.GetAllocatedBytesForCurrentThread();
+        publisher.OnOrderAdded(book, in entry);
+        publisher.OnTrade(book.SecurityId, 281050, 10, 9002, 0);
+        long afterBytes = GC.GetAllocatedBytesForCurrentThread();
+
+        long deltaBytes = afterBytes - beforeBytes;
+        Assert.True(deltaBytes < 512,
+            $"Fix hot-path callbacks allocated {deltaBytes} bytes for one order delta + one trade; threshold is 512 bytes total.");
+    }
+
+    [Fact]
+    public void BlockedSink_DoesNot_Stall_HotPath_Enqueue()
+    {
+        var clock = new FakeFixClock();
+        using var sink = new BlockingSink();
+        using var publisher = CreatePublisher(clock, sink, startBackgroundWorker: true, pendingEventCapacity: 4096);
+        OrderBook book = new(1234);
+        OrderBookEntry entry = CreateEntry(book.SecurityId, 7001, BookSideType.Bid, 281000, 100);
+
+        publisher.OnTrade(book.SecurityId, 281050, 10, 9001, 0);
+        Assert.True(sink.FirstMessageStarted.Wait(TimeSpan.FromSeconds(1)));
+
+        Stopwatch sw = Stopwatch.StartNew();
+        for (int i = 0; i < 512; i++)
+            publisher.OnOrderAdded(book, in entry);
+        sw.Stop();
+
+        Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(100),
+            $"Hot-path enqueue took {sw.Elapsed.TotalMilliseconds:F1} ms while the FIX sink was blocked.");
+        sink.ReleaseWriter.Set();
+        publisher.FlushNow();
+    }
+
+    private static FixConflatedMarketDataPublisher CreatePublisher(
+        FakeFixClock clock,
+        IFixApplicationMessageSink sink,
+        bool startBackgroundWorker,
+        int pendingEventCapacity = 1024)
+    {
+        return new FixConflatedMarketDataPublisher(
+            sink,
+            new SequentialHeaderProvider(),
+            new StaticInstrumentResolver(new FixMarketDataInstrument("PETR4", 1234, 4)),
+            new FixConflatedMarketDataOptions
+            {
+                ConflationInterval = TimeSpan.FromMilliseconds(380),
+                PendingEventCapacity = pendingEventCapacity,
+                StartBackgroundWorker = startBackgroundWorker,
+            },
+            clock);
+    }
+
+    private static OrderBookEntry CreateEntry(ulong securityId, ulong orderId, BookSideType side, long price, long quantity)
+    {
+        return new OrderBookEntry
+        {
+            SecurityId = securityId,
+            OrderId = orderId,
+            Side = side,
+            Price = price,
+            Quantity = quantity,
+        };
+    }
+
+    private sealed class FakeFixClock : IFixClock
+    {
+        private DateTimeOffset _utcNow = new(2026, 8, 12, 19, 0, 0, TimeSpan.Zero);
+
+        public DateTimeOffset UtcNow => _utcNow;
+        public long MonotonicTicks => 0;
+    }
+
+    private sealed class SequentialHeaderProvider : IFixApplicationHeaderProvider
+    {
+        private int _nextSequenceNumber = 1;
+
+        public FixApplicationSessionHeader NextHeader(DateTimeOffset sendingTime)
+            => new("SERVER", "CLIENT", _nextSequenceNumber++, sendingTime);
+    }
+
+    private sealed class StaticInstrumentResolver : IFixMarketDataInstrumentResolver
+    {
+        private readonly FixMarketDataInstrument _instrument;
+
+        public StaticInstrumentResolver(FixMarketDataInstrument instrument)
+        {
+            _instrument = instrument;
+        }
+
+        public bool TryResolve(ulong securityId, out FixMarketDataInstrument instrument)
+        {
+            if (_instrument.SecurityId == securityId)
+            {
+                instrument = _instrument;
+                return true;
+            }
+
+            instrument = default;
+            return false;
+        }
+    }
+
+    private sealed class CapturingSink : IFixApplicationMessageSink
+    {
+        public void OnMessage(ReadOnlyMemory<byte> message)
+        {
+        }
+    }
+
+    private sealed class BlockingSink : IFixApplicationMessageSink, IDisposable
+    {
+        public ManualResetEventSlim FirstMessageStarted { get; } = new(false);
+        public ManualResetEventSlim ReleaseWriter { get; } = new(false);
+
+        public void OnMessage(ReadOnlyMemory<byte> message)
+        {
+            FirstMessageStarted.Set();
+            ReleaseWriter.Wait(TimeSpan.FromSeconds(5));
+        }
+
+        public void Dispose()
+        {
+            FirstMessageStarted.Dispose();
+            ReleaseWriter.Dispose();
+        }
+    }
+}

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataPublisherTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedMarketDataPublisherTests.cs
@@ -83,6 +83,7 @@ public sealed class FixConflatedMarketDataPublisherTests
 
         var tradeTime = new DateTimeOffset(2026, 8, 12, 19, 20, 30, 555, TimeSpan.Zero);
         publisher.OnTrade(1234, 2812, 250, 771122, tradeTime.ToUnixTimeMilliseconds() * 1_000_000);
+        publisher.FlushIfDue();
 
         Assert.Single(sink.Messages);
         FixMessage tradeMessage = Decode(sink.Messages[0]);

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedTcpServerTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedTcpServerTests.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using B3.Umdf.FixConflated;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixConflatedTcpServerTests
+{
+    [Fact]
+    public async Task Logon_And_Broadcast_Are_Delivered_Over_Tcp()
+    {
+        var hub = new FixConflatedSessionHub();
+        int port = GetFreeTcpPort();
+        await using var server = new FixConflatedTcpServer(
+            hub,
+            new FixConflatedTcpServerOptions
+            {
+                OutboundQueueCapacity = 64,
+                SessionOptions = new FixSessionOptions { ApplicationResendBufferCapacity = 8 },
+            });
+        await server.StartAsync(port);
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        using NetworkStream stream = client.GetStream();
+
+        await stream.WriteAsync(FixMessageCodec.Encode(CreateLogon("CLIENT-A", "SANDBOX", 1)));
+
+        FixMessage logonAck = await ReadMessageAsync(stream);
+        Assert.Equal(FixMsgTypes.Logon, GetRequired(logonAck, FixTags.MsgType));
+        Assert.Equal("1", GetRequired(logonAck, FixTags.MsgSeqNum));
+        Assert.Equal("SANDBOX", GetRequired(logonAck, FixTags.SenderCompId));
+        Assert.Equal("CLIENT-A", GetRequired(logonAck, FixTags.TargetCompId));
+
+        hub.BroadcastApplication(CreateApplicationMessage("md-1"));
+
+        FixMessage incremental = await ReadMessageAsync(stream);
+        Assert.Equal(FixMsgTypes.MarketDataIncrementalRefresh, GetRequired(incremental, FixTags.MsgType));
+        Assert.Equal("2", GetRequired(incremental, FixTags.MsgSeqNum));
+        Assert.Equal("md-1", GetRequired(incremental, FixTags.MDReqId));
+    }
+
+    private static FixMessage CreateLogon(string senderCompId, string targetCompId, int seqNum)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, FixMsgTypes.Logon);
+        message.Add(FixTags.SenderCompId, senderCompId);
+        message.Add(FixTags.TargetCompId, targetCompId);
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260812-19:30:00.000");
+        message.Add(FixTags.EncryptMethod, 0);
+        message.Add(FixTags.HeartBtInt, 30);
+        return message;
+    }
+
+    private static FixMessage CreateApplicationMessage(string mdReqId)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.MsgType, FixMsgTypes.MarketDataIncrementalRefresh);
+        message.Add(FixTags.MDReqId, mdReqId);
+        message.Add(FixTags.NoMDEntries, 0);
+        return message;
+    }
+
+    private static async Task<FixMessage> ReadMessageAsync(NetworkStream stream)
+    {
+        byte[] buffer = new byte[4096];
+        int buffered = 0;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        while (true)
+        {
+            FixDecodeResult decoded = FixMessageCodec.Decode(buffer.AsSpan(0, buffered));
+            if (decoded.Success)
+                return decoded.Message!;
+            if (decoded.Error != FixDecodeError.Incomplete)
+                throw new Xunit.Sdk.XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
+
+            int read = await stream.ReadAsync(buffer.AsMemory(buffered), cts.Token);
+            Assert.True(read > 0, "Expected the server to send a FIX frame before closing the socket.");
+            buffered += read;
+        }
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static string GetRequired(FixMessage message, int tag)
+    {
+        Assert.True(message.TryGetString(tag, out string? value));
+        return value!;
+    }
+}

--- a/tests/B3.Umdf.Server.Tests/AppSettingsFixConflatedEnvTests.cs
+++ b/tests/B3.Umdf.Server.Tests/AppSettingsFixConflatedEnvTests.cs
@@ -1,0 +1,62 @@
+using B3.Umdf.Server;
+
+namespace B3.Umdf.Server.Tests;
+
+public sealed class AppSettingsFixConflatedEnvTests
+{
+    [Fact]
+    public void ApplyEnvironment_ParsesFixConflatedKnobs()
+    {
+        WithEnv(new Dictionary<string, string?>
+        {
+            ["UMDF_FIX_CONFLATED_ENABLED"] = "true",
+            ["UMDF_FIX_CONFLATED_PORT"] = "9501",
+            ["UMDF_FIX_CONFLATED_CONFLATION_MS"] = "500",
+            ["UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY"] = "2048",
+            ["UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY"] = "128",
+            ["UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY"] = "4096",
+        }, () =>
+        {
+            var settings = new AppSettings();
+            settings.ApplyEnvironment();
+
+            Assert.True(settings.FixConflatedEnabled);
+            Assert.Equal(9501, settings.FixConflatedPort);
+            Assert.Equal(500, settings.FixConflatedConflationWindowMs);
+            Assert.Equal(2048, settings.FixConflatedResendBufferCapacity);
+            Assert.Equal(128, settings.FixConflatedOutboundQueueCapacity);
+            Assert.Equal(4096, settings.FixConflatedEventQueueCapacity);
+        });
+    }
+
+    private static void WithEnv(Dictionary<string, string?> overrides, Action body)
+    {
+        var keys = new[]
+        {
+            "UMDF_FIX_CONFLATED_ENABLED",
+            "UMDF_FIX_CONFLATED_PORT",
+            "UMDF_FIX_CONFLATED_CONFLATION_MS",
+            "UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY",
+            "UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY",
+            "UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY",
+        };
+        var saved = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (string key in keys)
+        {
+            saved[key] = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, null);
+        }
+
+        try
+        {
+            foreach (KeyValuePair<string, string?> entry in overrides)
+                Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+            body();
+        }
+        finally
+        {
+            foreach (KeyValuePair<string, string?> entry in saved)
+                Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in FIX conflated TCP listener, per-connection FIX session host, targeted initial snapshot replay, and per-session resend buffering
- wire shared per-group FIX handlers into Program.cs only when UMDF_FIX_CONFLATED_ENABLED is on
- add FIX-channel metrics plus allocation-sensitive / slow-consumer / TCP integration coverage

## Design
- placed the TCP listener/session host in B3.Umdf.FixConflated so the transport can stay next to the existing FIX session/wire primitives and avoid new references from that project beyond BCL + B3.Umdf.Book
- kept one shared FixConflatedChannelHandler / FixConflatedMarketDataPublisher per group; its sink decodes the shared encoded application frame once, then replays the application message through each connection's own FixSessionConnection so every TCP session keeps its own sequence numbers / resend buffer
- initial full-book snapshots are sent per connection after logon via a targeted snapshot provider instead of broadcasting them to every client

## Metrics
- new meter: B3.Umdf.FixConflated
- active TCP connections
- messages + bytes sent
- per-group hot-path queue depth / dropped events

## Tests
- FIX transport TCP integration test covering logon + broadcast delivery
- allocation-sensitive hot-path regression test for order/trade callbacks
- blocked-sink test proving a stalled FIX consumer does not stall the hot path
- config/env and disabled-feature gate tests

Closes #93
