### PR TITLE
Finalize FIX Conflated docs and end-to-end validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,20 @@ straight from the B3 SBE XML schema.
 | `B3.Umdf.Book` | MBO book + per-symbol heal: `OrderBook`, `BookSide`, `BookManager`, `BookStore`, `SnapshotApplier`, `SymbolStateRegistry`, `StaleMboBuffer`, `MarketDataManager`, `SymbolRegistry`, `CandleAggregator` |
 | `B3.Umdf.PcapReplay` | PCAP reader, UDP extractor, timestamp-merged replayer |
 | `B3.Umdf.Server` | WebSocket subscription server: `WireProtocol`, `SubscriptionManager`, `SnapshotEmitter`, `OutlierSweeper`, `RankingsPublisher`, `RecoveryProgressPublisher`, `GroupConflationHandler`, `ClientSession`, `WebSocketHost`, `AppSettings` |
+| `B3.Umdf.FixConflated` | Experimental FIX 4.4 "UMDF Conflated" sandbox: minimal session engine, application writers/builders, initial snapshot provider, TCP listener, and hot-path market-data publisher |
 | `B3.Umdf.ConsoleApp` | CLI application — PCAP replay + optional WebSocket server + `AppMetrics` |
 
 ## Tests
 
 | Project | Tests | Description |
 |---------|-------|-------------|
-| `B3.Umdf.Book.Tests` | 193 | Order book ops, snapshot apply, per-symbol registry, stale buffer (drop-oldest + protected floor), forced-heal escape, SecurityID reuse, candle aggregator, news reassembler, concurrency stress |
-| `B3.Umdf.Feed.Tests` | 51 | Feed handler, gap detection, A/B dedup, channel-handler reorder buffer (256 packets), MultiFeedManager dispatch |
-| `B3.Umdf.PcapReplay.Tests` | 18 | PCAP reader, UDP/VLAN/SLL extraction, timestamp-merge ordering |
-| `B3.Umdf.Transport.Tests` | 16 | Packet source, multicast config, batch receive (`recvmmsg`) |
-| `B3.Umdf.Server.Tests` | 103 | Subscription manager, snapshot emitter, outlier sweep, conflation, epoch reset, trade bust, news fan-out, wire protocol, client session, backpressure |
-| `B3.Umdf.ConsoleApp.Tests` | 30 | CLI option parsing, env-var precedence, multicast config validation |
+| `B3.Umdf.Book.Tests` | 269 | Order book ops, snapshot apply, per-symbol registry, stale buffer (drop-oldest + protected floor), forced-heal escape, SecurityID reuse, candle aggregator, news reassembler, concurrency stress |
+| `B3.Umdf.Feed.Tests` | 77 | Feed handler, gap detection, A/B dedup, channel-handler reorder buffer (256 packets), MultiFeedManager dispatch |
+| `B3.Umdf.PcapReplay.Tests` | 28 | PCAP reader, UDP/VLAN/SLL extraction, timestamp-merge ordering |
+| `B3.Umdf.Transport.Tests` | 39 | Packet source, multicast config, batch receive (`recvmmsg`) |
+| `B3.Umdf.Server.Tests` | 212 | Subscription manager, snapshot emitter, outlier sweep, conflation, epoch reset, trade bust, news fan-out, wire protocol, client session, backpressure |
+| `B3.Umdf.FixConflated.Tests` | 25 | FIX codec/session engine, builders, hot-path queueing, TCP transport, and end-to-end snapshot/conflation/trade delivery |
+| `B3.Umdf.ConsoleApp.Tests` | 44 | CLI option parsing, env-var precedence, multicast config validation |
 
 ```bash
 dotnet build

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,18 +27,18 @@ The full set of `UMDF_*` knobs surfaced by `AppSettings` and `Program.cs`:
 | Environment Variable | CLI | Default | Description |
 |---------------------|-----|---------|-------------|
 | `UMDF_WS_PORT` | `--ws-port` | *(off)* | WebSocket server port |
-| `UMDF_FIX_CONFLATED_ENABLED` | — | `false` | Enable the opt-in FIX conflated TCP listener |
-| `UMDF_FIX_CONFLATED_PORT` | — | *(off)* | FIX conflated TCP listener port (required when enabled) |
+| `UMDF_FIX_CONFLATED_ENABLED` | — | `false` | Enable the opt-in FIX conflated TCP listener. Requires `UMDF_FIX_CONFLATED_PORT` when set to `true` |
+| `UMDF_FIX_CONFLATED_PORT` | — | *(off)* | FIX conflated TCP listener port. Must be `1..65535`, is required when enabled, and must differ from `UMDF_WS_PORT` |
 | `UMDF_SPEED` | `--speed` | `0` | Replay speed multiplier |
 | `UMDF_REPLAY_TO_MULTICAST` | `--replay-to-multicast` | `false` | Publish replayed PCAP payloads to multicast instead of consuming them in-process |
 | `UMDF_MULTICAST_CONFIG` | `--multicast-config` | — | Multicast JSON config path |
 | `UMDF_LOG_LEVEL` | — | `Information` | Minimum log level |
 | `UMDF_SHUTDOWN_DRAIN_SECONDS` | — | `5` | Graceful shutdown drain timeout |
 | **FIX conflated TCP** | | | |
-| `UMDF_FIX_CONFLATED_CONFLATION_MS` | — | `380` | Book-delta conflation window used by the FIX sandbox publisher |
-| `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY` | — | `10000` | Per-connection in-memory application resend buffer size for `ResendRequest` handling |
-| `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY` | — | `4096` | Per-connection bounded outbound queue; slow FIX consumers are disconnected when it fills |
-| `UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY` | — | `65536` | Per-group bounded hot-path event queue feeding the background FIX encoder |
+| `UMDF_FIX_CONFLATED_CONFLATION_MS` | — | `380` | Book-delta conflation window used by the FIX sandbox publisher. Must be an integer `> 0`; the default matches B3's documented ~380 ms cadence but stays configurable for experiments |
+| `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY` | — | `10000` | Per-connection in-memory application resend buffer size for `ResendRequest` handling. Must be an integer `>= 0`; `0` disables in-session replay retention |
+| `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY` | — | `4096` | Per-connection bounded outbound queue. Must be an integer `> 0`; slow FIX consumers are disconnected when it fills |
+| `UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY` | — | `65536` | Per-group bounded hot-path event queue feeding the background FIX encoder. Must be an integer `> 0`; when full, new FIX events are dropped instead of blocking the shared UMDF group thread |
 | **WebSocket / clients** | | | |
 | `UMDF_MAX_CONNECTIONS` | — | `0` (unlimited) | Max concurrent WebSocket connections |
 | `UMDF_CLIENT_CHANNEL_CAPACITY` | — | `4096` | Per-client outbound queue size (msgs) |
@@ -72,6 +72,17 @@ The full set of `UMDF_*` knobs surfaced by `AppSettings` and `Program.cs`:
 | `UMDF_LOSS_SEED` | `--loss-seed` | `0` | RNG seed for reproducible loss patterns. `0` = nondeterministic. |
 | **Diagnostics** | | | |
 | `UMDF_SCHEDULER_JITTER_PROBE` | — | `1` | Enables the scheduler jitter probe (200 Hz wakeup, exposes `b3.umdf.scheduler.jitter_us` histogram + `jitter_max_us` gauge). Set `0`/`false` to disable. See [NOISY-NEIGHBOUR.md](./NOISY-NEIGHBOUR.md). |
+
+### FIX conflated TCP validation rules
+
+| Environment Variable | Accepted values | Additional rule |
+|---------------------|-----------------|-----------------|
+| `UMDF_FIX_CONFLATED_ENABLED` | `true` / `false` | When `false`, the FIX listener stays off |
+| `UMDF_FIX_CONFLATED_PORT` | integer `1..65535` | Required when `UMDF_FIX_CONFLATED_ENABLED=true`; must differ from `UMDF_WS_PORT` |
+| `UMDF_FIX_CONFLATED_CONFLATION_MS` | integer `> 0` | Validated only when the FIX listener is enabled |
+| `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY` | integer `>= 0` | `0` keeps the listener active but disables application resend retention |
+| `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY` | integer `> 0` | Slow clients are disconnected if this bounded queue fills |
+| `UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY` | integer `> 0` | Overflow drops new FIX events rather than blocking the shared UMDF hot path |
 
 Docker-specific helpers consumed by `docker-entrypoint.sh`:
 

--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -14,11 +14,13 @@
 An additional, **opt-in** output channel, alongside the existing
 `WireV2` WebSocket protocol (see
 [docs/WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md)), through which this
-platform emits book, trade, instrument-status, news, security-list, and
-market-totals data encoded as **FIX 4.4 Tag=Value** messages, batching
-book deltas over a configurable time window ("conflation"). This
-platform acts as the **FIX session acceptor** ("server" role) — the
-inverse of connecting out to a real B3 UMDF Conflated feed.
+platform emits live book, trade, instrument-status, and news data
+encoded as **FIX 4.4 Tag=Value** messages, batching book deltas over a
+configurable time window ("conflation"). The same project also models
+additional UMDF-specific message shapes such as `SecurityList*` and
+`MarketTotals*`. This platform acts as the **FIX session acceptor**
+("server" role) — the inverse of connecting out to a real B3 UMDF
+Conflated feed.
 
 ## What this is not
 
@@ -70,22 +72,52 @@ it needs the `schema-upgrade` label.
 - `ResendRequest` (2) is honored only for messages still available in
   the **current session's** bounded in-memory buffer — there is no
   cross-session/cross-day persisted message store.
-  `MsgSeqNum` is tracked per connection; a reconnect presenting a
+- `MsgSeqNum` is tracked per connection; a reconnect presenting a
   sequence number lower than expected is disconnected immediately (no
   `SequenceReset`-based gap-fill across reconnects), matching B3's
   documented behavior. Recovery after such a disconnect happens via a
   fresh `MarketDataSnapshotFullRefresh` on the new session.
 
-## Message scope
+## Message catalog
 
-| Message | MsgType | Source in this platform |
+MsgType codes below are verified against both the vendored dictionary
+(`schemas/fix-conflated/FIX44_UMDFConflated.xml`) and the in-repo
+constants in `FixMsgTypes` / `FixApplicationMsgTypes`.
+
+### Session/admin messages
+
+| Message | MsgType | Direction in this sandbox | Current behavior |
+|---|---|---|---|
+| `Logon` | `A` | inbound + outbound | First inbound message must be `Logon`; the sandbox always accepts it and replies with a `Logon` ack |
+| `Heartbeat` | `0` | inbound + outbound | Periodic server heartbeat; also the response to `TestRequest` |
+| `TestRequest` | `1` | inbound | Accepted; answered with a `Heartbeat` carrying the same `TestReqID` |
+| `ResendRequest` | `2` | inbound | Replays only application messages still retained in the current session's bounded in-memory resend buffer |
+| `SequenceReset` | `4` | outbound | Emitted only as in-session gap-fill during `ResendRequest` handling |
+| `Logout` | `5` | inbound + outbound | Used for orderly shutdown and validation/sequence failures after logon |
+
+### Application messages emitted by the current TCP listener wiring
+
+| Message | MsgType | Trigger / source |
 |---|---|---|
-| `MarketDataSnapshotFullRefresh` | W | Book state on subscribe / post-reconnect recovery |
-| `MarketDataIncrementalRefresh` | X | Book deltas, batched per configurable conflation window; trades sent unthrottled in the same message family |
-| `SecurityStatus` | f | `OnInstrumentStatusChanged` |
-| `News` | B | Existing `NewsReassembler` pipeline |
-| `SecurityList` / `SecurityListRequest` | y / x | `SymbolRegistry` |
-| `MarketTotals*` | UTOT/UTOTC/UTOTQ/UTOTP | Best-effort, from existing rankings/aggregates |
+| `MarketDataSnapshotFullRefresh` | `W` | `FixInitialSnapshotProvider` sends one full snapshot per known book immediately after logon / reconnect recovery |
+| `MarketDataIncrementalRefresh` | `X` | `FixConflatedMarketDataPublisher` batches book deltas per instrument/side over the configured conflation window; trade entries (`MDEntryType=2`) bypass that window and flush immediately |
+| `SecurityStatus` | `f` | `FixConflatedChannelHandler.OnSecurityStatusChanged` |
+| `News` | `B` | `FixConflatedChannelHandler.OnNews`, fed by the existing `NewsReassembler` pipeline |
+
+### Additional UMDF-specific message definitions modeled in code/schema
+
+These message shapes are implemented by builders in
+`src/B3.Umdf.FixConflated`, but the current listener wiring does **not**
+yet auto-publish them on its own:
+
+| Message | MsgType | Current status |
+|---|---|---|
+| `SecurityListRequest` | `x` | Request/builder shape implemented by `SecurityListMessageBuilder.BuildRequest`; no automatic request/response flow is wired today |
+| `SecurityList` | `y` | Builder implemented by `SecurityListMessageBuilder.Build`; not automatically broadcast by the current TCP server wiring |
+| `MarketTotalsBroadcast` | `UTOT` | Builder implemented; not automatically broadcast by the current TCP server wiring |
+| `MarketTotalsComposition` | `UTOTC` | Builder implemented; not automatically broadcast by the current TCP server wiring |
+| `MarketTotalsRequest` | `UTOTQ` | Request/builder shape implemented; no automatic request/response flow is wired today |
+| `MarketTotalsResponse` | `UTOTP` | Builder implemented; not automatically broadcast by the current TCP server wiring |
 
 ## Conflation model
 
@@ -107,6 +139,41 @@ callback only performs a cheap, allocation-free enqueue into its own
 ring buffer; FIX encoding, conflation-window flushing, and socket I/O all
 run on a dedicated background thread, never blocking or allocating on
 the shared per-group hot path.
+
+## Configuration reference
+
+All FIX sandbox knobs are environment-variable only; there are no
+dedicated CLI switches.
+
+| Environment Variable | Default | Valid values | Effect |
+|---|---|---|---|
+| `UMDF_FIX_CONFLATED_ENABLED` | `false` | `true` / `false` | Enables the opt-in FIX conflated TCP listener. When `false`, the other FIX knobs are ignored |
+| `UMDF_FIX_CONFLATED_PORT` | *(off)* | integer `1..65535`; required when enabled; must differ from `UMDF_WS_PORT` | TCP listen port for the FIX acceptor |
+| `UMDF_FIX_CONFLATED_CONFLATION_MS` | `380` | integer `> 0` | Book-delta conflation window in milliseconds. The sandbox default matches the real product's documented ~380 ms cadence, but remains configurable for experiments |
+| `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY` | `10000` | integer `>= 0` | Per-connection in-memory application resend buffer size. `0` disables in-session replay retention |
+| `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY` | `4096` | integer `> 0` | Per-connection bounded outbound queue. Slow clients are disconnected if it fills |
+| `UMDF_FIX_CONFLATED_EVENT_QUEUE_CAPACITY` | `65536` | integer `> 0` | Per-group hot-path queue feeding the background FIX encoder. When full, new FIX events are dropped instead of blocking the shared UMDF group thread |
+
+See [docs/CONFIGURATION.md](CONFIGURATION.md) for the full configuration
+matrix alongside the existing WebSocket and transport knobs.
+
+## Explicit deviations from the real B3 product
+
+- **Logon always succeeds.** There is no password, certificate, CompID
+  whitelist, or session-level authentication step.
+- **No B3 certification / onboarding process.** This repo is an
+  exploratory local sandbox, not an official access path.
+- **Reconnect recovery is snapshot-based.** `ResendRequest` only replays
+  application messages still buffered inside the current TCP session;
+  there is no persisted cross-session or cross-day gap-fill store.
+- **Conflation cadence is configurable.** Real B3 documentation cites an
+  approximately 380 ms cadence; this sandbox uses
+  `UMDF_FIX_CONFLATED_CONFLATION_MS` with a default of `380`.
+- **Role relationship is inverted.** This platform is the FIX session
+  **acceptor/server**; downstream clients connect *to it*, rather than
+  this repo acting as a FIX client connecting out to B3.
+- **This remains a non-official sandbox only.** It is not certified for,
+  or suitable for, production connectivity to B3.
 
 ## Enabling
 

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedEndToEndTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedEndToEndTests.cs
@@ -1,0 +1,279 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixConflatedEndToEndTests
+{
+    [Fact]
+    public async Task Tcp_Server_Delivers_Snapshot_Conflated_Book_Deltas_And_Prompt_Trade()
+    {
+        const ulong securityId = 1234;
+        TimeSpan conflationWindow = TimeSpan.FromMilliseconds(300);
+
+        var stateRegistry = new SymbolStateRegistry(NullLogger.Instance);
+        var staleBuffer = new StaleMboBuffer(NullLogger.Instance);
+        var bookManager = new BookManager(
+            logger: NullLogger<BookManager>.Instance,
+            stateRegistry: stateRegistry,
+            staleBuffer: staleBuffer);
+        var marketDataManager = new MarketDataManager(
+            logger: NullLogger<MarketDataManager>.Instance,
+            stateRegistry: stateRegistry);
+
+        InstrumentInfo info = marketDataManager.GetOrCreateInfo(securityId);
+        info.Symbol = "PETR4";
+        info.PriceDivisor = 100;
+
+        var resolver = new FixLiveInstrumentResolver(new SymbolRegistry(), [marketDataManager]);
+        var hub = new FixConflatedSessionHub();
+        using var channelHandler = new FixConflatedChannelHandler(
+            0,
+            hub,
+            resolver,
+            new FixConflatedMarketDataOptions
+            {
+                ConflationInterval = conflationWindow,
+                PendingEventCapacity = 512,
+            });
+
+        OrderBook book = bookManager.GetOrCreateBook(securityId);
+        book.Bids.Add(CreateEntry(securityId, 7001, BookSideType.Bid, 2810, 100));
+        book.Asks.Add(CreateEntry(securityId, 8001, BookSideType.Ask, 2815, 120));
+
+        int port = GetFreeTcpPort();
+        await using var server = new FixConflatedTcpServer(
+            hub,
+            new FixConflatedTcpServerOptions
+            {
+                OutboundQueueCapacity = 64,
+                SessionOptions = new FixSessionOptions
+                {
+                    ApplicationResendBufferCapacity = 16,
+                },
+            },
+            initialMessagesProvider: new FixInitialSnapshotProvider([bookManager], resolver).CreateMessages);
+        await server.StartAsync(port);
+
+        using var client = new TcpClient { NoDelay = true };
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        using NetworkStream stream = client.GetStream();
+        var fixClient = new TestFixClient(stream);
+
+        await fixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 1));
+
+        FixMessage logonAck = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.Logon, FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgType));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgSeqNum));
+        Assert.Equal("SANDBOX", FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.SenderCompId));
+        Assert.Equal("CLIENT-A", FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.TargetCompId));
+
+        FixMessage snapshot = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.MarketDataSnapshotFullRefresh, FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgType));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgSeqNum));
+        Assert.Equal("SNAP-1234", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MDReqId));
+        Assert.Equal("PETR4", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.Symbol));
+        Assert.Equal("1234", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.SecurityId));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> snapshotEntries = ParseSnapshotEntries(snapshot);
+        Assert.Equal(2, snapshotEntries.Count);
+        Assert.Equal(["0", "1"], snapshotEntries.Select(static entry => entry[FixTags.MDEntryType]).ToArray());
+        Assert.Equal(["28.10", "28.15"], snapshotEntries.Select(static entry => entry[FixTags.MDEntryPx]).ToArray());
+
+        OrderBookEntry add = CreateEntry(securityId, 9001, BookSideType.Bid, 2811, 40);
+        book.Bids.AddOrUpdate(add);
+        channelHandler.OnOrderAdded(book, in add);
+
+        OrderBookEntry update = CreateEntry(securityId, 9001, BookSideType.Bid, 2812, 35);
+        book.Bids.AddOrUpdate(update);
+        channelHandler.OnOrderUpdated(book, in update);
+
+        DateTimeOffset tradeTime = DateTimeOffset.UtcNow;
+        Stopwatch tradeStopwatch = Stopwatch.StartNew();
+        channelHandler.OnTrade(securityId, 2813, 12, 99001, tradeTime.ToUnixTimeMilliseconds() * 1_000_000);
+
+        FixMessage trade = await fixClient.ReadMessageAsync();
+        tradeStopwatch.Stop();
+
+        Assert.True(tradeStopwatch.Elapsed < conflationWindow,
+            $"Expected trade delivery before the {conflationWindow.TotalMilliseconds:F0} ms conflation window, but it took {tradeStopwatch.Elapsed.TotalMilliseconds:F1} ms.");
+        Assert.Equal(FixMsgTypes.MarketDataIncrementalRefresh, FixApplicationMessageTestHelpers.GetRequired(trade, FixTags.MsgType));
+        Assert.Equal("3", FixApplicationMessageTestHelpers.GetRequired(trade, FixTags.MsgSeqNum));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> tradeEntries = ParseIncrementalEntries(trade);
+        IReadOnlyDictionary<int, string> tradeEntry = Assert.Single(tradeEntries);
+        Assert.Equal("0", tradeEntry[FixTags.MDUpdateAction]);
+        Assert.Equal("2", tradeEntry[FixTags.MDEntryType]);
+        Assert.Equal("28.13", tradeEntry[FixTags.MDEntryPx]);
+        Assert.Equal("12", tradeEntry[FixTags.MDEntrySize]);
+        Assert.Equal("99001", tradeEntry[FixTags.TradeId]);
+
+        FixMessage conflatedBook = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.MarketDataIncrementalRefresh, FixApplicationMessageTestHelpers.GetRequired(conflatedBook, FixTags.MsgType));
+        Assert.Equal("4", FixApplicationMessageTestHelpers.GetRequired(conflatedBook, FixTags.MsgSeqNum));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> bookEntries = ParseIncrementalEntries(conflatedBook);
+        Assert.Equal(2, bookEntries.Count);
+        Assert.Equal(["0", "1"], bookEntries.Select(static entry => entry[FixTags.MDUpdateAction]).ToArray());
+        Assert.All(bookEntries, static entry => Assert.Equal("0", entry[FixTags.MDEntryType]));
+        Assert.Equal(["28.11", "28.12"], bookEntries.Select(static entry => entry[FixTags.MDEntryPx]).ToArray());
+        Assert.Equal(["9001", "9001"], bookEntries.Select(static entry => entry[FixTags.OrderId]).ToArray());
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseSnapshotEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDEntryType)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseIncrementalEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDUpdateAction)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static FixMessage CreateLogon(string senderCompId, string targetCompId, int seqNum)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, FixMsgTypes.Logon);
+        message.Add(FixTags.SenderCompId, senderCompId);
+        message.Add(FixTags.TargetCompId, targetCompId);
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260812-19:30:00.000");
+        message.Add(FixTags.EncryptMethod, 0);
+        message.Add(FixTags.HeartBtInt, 30);
+        return message;
+    }
+
+    private static OrderBookEntry CreateEntry(ulong securityId, ulong orderId, BookSideType side, long price, long quantity)
+    {
+        return new OrderBookEntry
+        {
+            SecurityId = securityId,
+            OrderId = orderId,
+            Side = side,
+            Price = price,
+            Quantity = quantity,
+        };
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private sealed class TestFixClient
+    {
+        private readonly NetworkStream _stream;
+        private byte[] _buffer = new byte[4096];
+        private int _buffered;
+
+        public TestFixClient(NetworkStream stream)
+        {
+            _stream = stream;
+        }
+
+        public Task SendAsync(FixMessage message)
+            => _stream.WriteAsync(FixMessageCodec.Encode(message)).AsTask();
+
+        public async Task<FixMessage> ReadMessageAsync(TimeSpan? timeout = null)
+        {
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
+
+            while (true)
+            {
+                FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
+                if (decoded.Success)
+                {
+                    FixMessage message = decoded.Message!;
+                    Consume(decoded.BytesConsumed);
+                    return message;
+                }
+
+                if (decoded.Error != FixDecodeError.Incomplete)
+                    throw new Xunit.Sdk.XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
+
+                EnsureCapacity();
+                int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
+                Assert.True(read > 0, "Expected the FIX server to send a frame before closing the socket.");
+                _buffered += read;
+            }
+        }
+
+        private void Consume(int count)
+        {
+            Buffer.BlockCopy(_buffer, count, _buffer, 0, _buffered - count);
+            _buffered -= count;
+        }
+
+        private void EnsureCapacity()
+        {
+            if (_buffered < _buffer.Length)
+                return;
+
+            Array.Resize(ref _buffer, _buffer.Length * 2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- finalize `docs/FIX-CONFLATED-SANDBOX.md` with a verified message catalog, FIX env-var reference, and explicit deviations from real B3 behavior
- expand `docs/CONFIGURATION.md` and `README.md` for the FIX Conflated project/config surface and refreshed test counts
- add a real TCP end-to-end FIX test covering logon, initial snapshot delivery, conflated book deltas, and prompt trade delivery over the wire

## Validation
- `dotnet build B3MarketDataPlatform.slnx`
- `dotnet test B3MarketDataPlatform.slnx`

Closes #94
Closes #89