### PR TITLE
Fix flaky conflated MBP timing test

### DIFF
--- a/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
+++ b/tests/B3.Umdf.Server.Tests/GroupConflationHandlerMbpTests.cs
@@ -306,12 +306,10 @@ public class GroupConflationHandlerMbpTests
         try
         {
             var book = w.BookManager.GetOrCreateBook(SecurityId);
-            var liveRec = new RecordingWebSocket();
-            var conflatedRec = new RecordingWebSocket();
-            var live = new ClientSession(liveRec, channelCapacity: 64);
-            var conflated = new ClientSession(conflatedRec, channelCapacity: 64);
-            w.Manager.RegisterClient(live); _ = Task.Run(() => live.RunWriteLoopAsync());
-            w.Manager.RegisterClient(conflated); _ = Task.Run(() => conflated.RunWriteLoopAsync());
+            var live = new ClientSession(new FakeWebSocket(), channelCapacity: 64);
+            var conflated = new ClientSession(new FakeWebSocket(), channelCapacity: 64);
+            w.Manager.RegisterClient(live);
+            w.Manager.RegisterClient(conflated);
             w.Manager.HandleSubscribe(live.Id, Symbol, DataFlags.Mbp,
                 w.BookManager, w.Group, bookBatchCutoffSequence: 0);
             w.Manager.HandleSubscribe(
@@ -322,18 +320,24 @@ public class GroupConflationHandlerMbpTests
                 w.BookManager,
                 w.Group,
                 bookBatchCutoffSequence: 0);
-            await WaitUntil(
-                () => liveRec.HasMessageType(MessageType.LevelSnapshot) &&
-                      conflatedRec.HasMessageType(MessageType.LevelSnapshot),
-                TimeSpan.FromSeconds(2));
+
+            int liveBefore = live.QueueDepth;
+            int conflatedBefore = conflated.QueueDepth;
+
+            // Pin the cadence deadline to a full interval after the delta is buffered
+            // so the test observes immediate MBP enqueueing instead of racing the
+            // broadcaster timer's current phase.
+            typeof(CadenceConflationBuffer)
+                .GetField("_nextFlushTicks", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(GetCadenceBuffer(w.Group), Environment.TickCount64 + 500);
 
             book.Bids.Add(NewEntry(orderId: 1, price: 1000, qty: 7));
             w.Group.OnPriceLevelChanged(book, BookSideType.Bid, 1000);
             w.Group.OnBatchComplete();
 
-            await WaitUntil(() => liveRec.HasMessageType(MessageType.LevelUpdate), TimeSpan.FromSeconds(1));
-            Assert.Equal(0, conflatedRec.CountByType(MessageType.LevelUpdate));
-            await WaitUntil(() => conflatedRec.HasMessageType(MessageType.LevelUpdate), TimeSpan.FromSeconds(2));
+            await WaitUntil(() => live.QueueDepth > liveBefore, TimeSpan.FromSeconds(2));
+            Assert.Equal(conflatedBefore, conflated.QueueDepth);
+            await WaitUntil(() => conflated.QueueDepth > conflatedBefore, TimeSpan.FromSeconds(2));
         }
         finally
         {


### PR DESCRIPTION
Closes #101

## Summary
- make `ConflatedMbp_DoesNotDelayExistingMbpSubscribers` assert on per-session enqueue order instead of `RecordingWebSocket` delivery timing
- pin the cadence buffer deadline in the test so it does not race the broadcaster timer's current phase
- keep the behavioral check intact: immediate MBP subscribers still must observe the delta before the conflated cadence subscriber does

## Root cause
I could not reproduce the original failure locally in 50 isolated runs, but the test itself was timing-sensitive.

It mixed two independent async behaviors:
1. the broadcaster thread enqueuing the immediate MBP update, and
2. separate client write-loop tasks delivering frames into `RecordingWebSocket`.

Under CI scheduler jitter, the live subscriber's write loop could be delayed even though its update was already enqueued first. The test also depended on the cadence buffer's wall-clock phase, so a nearly-due cadence tick reduced the observation window further.

## Fix
The test now uses `FakeWebSocket` sessions without write loops and asserts on `ClientSession.QueueDepth`, which is the deterministic boundary where the broadcaster proves the immediate subscriber was serviced first. It also resets the cadence deadline to `now + 500ms` before publishing the delta so the test no longer races the cadence timer phase.

## Validation
- `dotnet build B3MarketDataPlatform.slnx`
- `dotnet test tests/B3.Umdf.Server.Tests/B3.Umdf.Server.Tests.csproj --filter "FullyQualifiedName~ConflatedMbp_DoesNotDelayExistingMbpSubscribers"` in a 50-iteration loop before the change: 0 failures (no local repro)
- `dotnet test tests/B3.Umdf.Server.Tests/B3.Umdf.Server.Tests.csproj --filter "FullyQualifiedName~GroupConflationHandlerMbpTests" --no-build` in a 40-iteration loop after the change: 0 failures
- `dotnet test B3MarketDataPlatform.slnx`
