### PR TITLE
Add FIX validator tool and reconnect e2e test

### DIFF
--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedReconnectEndToEndTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedReconnectEndToEndTests.cs
@@ -1,0 +1,269 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Sdk;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixConflatedReconnectEndToEndTests
+{
+    [Fact]
+    public async Task Stale_Reconnect_Is_Dropped_And_Fresh_Session_Recovers_Via_New_Snapshot()
+    {
+        const ulong securityId = 1234;
+
+        var stateRegistry = new SymbolStateRegistry(NullLogger.Instance);
+        var staleBuffer = new StaleMboBuffer(NullLogger.Instance);
+        var bookManager = new BookManager(
+            logger: NullLogger<BookManager>.Instance,
+            stateRegistry: stateRegistry,
+            staleBuffer: staleBuffer);
+        var marketDataManager = new MarketDataManager(
+            logger: NullLogger<MarketDataManager>.Instance,
+            stateRegistry: stateRegistry);
+
+        InstrumentInfo info = marketDataManager.GetOrCreateInfo(securityId);
+        info.Symbol = "PETR4";
+        info.PriceDivisor = 100;
+
+        OrderBook book = bookManager.GetOrCreateBook(securityId);
+        book.Bids.Add(CreateEntry(securityId, 7001, BookSideType.Bid, 2810, 100));
+        book.Asks.Add(CreateEntry(securityId, 8001, BookSideType.Ask, 2815, 120));
+
+        var resolver = new FixLiveInstrumentResolver(new SymbolRegistry(), [marketDataManager]);
+        var hub = new FixConflatedSessionHub();
+        int port = GetFreeTcpPort();
+
+        await using var server = new FixConflatedTcpServer(
+            hub,
+            new FixConflatedTcpServerOptions
+            {
+                OutboundQueueCapacity = 64,
+                SessionOptions = new FixSessionOptions
+                {
+                    ApplicationResendBufferCapacity = 16,
+                },
+            },
+            initialMessagesProvider: new FixInitialSnapshotProvider([bookManager], resolver).CreateMessages);
+        await server.StartAsync(port);
+
+        await RunFirstSessionAsync(port);
+
+        using (var staleClient = new TcpClient { NoDelay = true })
+        {
+            await staleClient.ConnectAsync(IPAddress.Loopback, port);
+            using NetworkStream staleStream = staleClient.GetStream();
+            var staleFixClient = new TestFixClient(staleStream);
+
+            await staleFixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 3));
+            await staleFixClient.AssertClosedWithoutFrameAsync();
+        }
+
+        using (var freshClient = new TcpClient { NoDelay = true })
+        {
+            await freshClient.ConnectAsync(IPAddress.Loopback, port);
+            using NetworkStream freshStream = freshClient.GetStream();
+            var freshFixClient = new TestFixClient(freshStream);
+
+            await freshFixClient.SendAsync(CreateLogon("CLIENT-B", "SANDBOX", 1));
+
+            FixMessage freshLogonAck = await freshFixClient.ReadMessageAsync();
+            Assert.Equal(FixMsgTypes.Logon, FixApplicationMessageTestHelpers.GetRequired(freshLogonAck, FixTags.MsgType));
+            Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(freshLogonAck, FixTags.MsgSeqNum));
+
+            FixMessage freshSnapshot = await freshFixClient.ReadMessageAsync();
+            Assert.Equal(FixMsgTypes.MarketDataSnapshotFullRefresh, FixApplicationMessageTestHelpers.GetRequired(freshSnapshot, FixTags.MsgType));
+            Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(freshSnapshot, FixTags.MsgSeqNum));
+            Assert.Equal("SNAP-1234", FixApplicationMessageTestHelpers.GetRequired(freshSnapshot, FixTags.MDReqId));
+            Assert.Equal("PETR4", FixApplicationMessageTestHelpers.GetRequired(freshSnapshot, FixTags.Symbol));
+            Assert.Equal("1234", FixApplicationMessageTestHelpers.GetRequired(freshSnapshot, FixTags.SecurityId));
+        }
+    }
+
+    private static async Task RunFirstSessionAsync(int port)
+    {
+        using var client = new TcpClient { NoDelay = true };
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        client.Client.LingerState = new LingerOption(true, 0);
+
+        using NetworkStream stream = client.GetStream();
+        var fixClient = new TestFixClient(stream);
+
+        await fixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 1));
+
+        FixMessage logonAck = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.Logon, FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgType));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgSeqNum));
+
+        FixMessage snapshot = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.MarketDataSnapshotFullRefresh, FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgType));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgSeqNum));
+
+        await fixClient.SendAsync(CreateHeartbeat("CLIENT-A", "SANDBOX", 2));
+        await fixClient.SendAsync(CreateTestRequest("CLIENT-A", "SANDBOX", 3, "reconnect-probe"));
+
+        FixMessage heartbeat = await fixClient.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.Heartbeat, FixApplicationMessageTestHelpers.GetRequired(heartbeat, FixTags.MsgType));
+        Assert.Equal("3", FixApplicationMessageTestHelpers.GetRequired(heartbeat, FixTags.MsgSeqNum));
+        Assert.Equal("reconnect-probe", FixApplicationMessageTestHelpers.GetRequired(heartbeat, FixTags.TestReqId));
+    }
+
+    private static FixMessage CreateLogon(string senderCompId, string targetCompId, int seqNum)
+    {
+        var message = CreateSessionMessage(FixMsgTypes.Logon, senderCompId, targetCompId, seqNum);
+        message.Add(FixTags.EncryptMethod, 0);
+        message.Add(FixTags.HeartBtInt, 30);
+        return message;
+    }
+
+    private static FixMessage CreateHeartbeat(string senderCompId, string targetCompId, int seqNum)
+        => CreateSessionMessage(FixMsgTypes.Heartbeat, senderCompId, targetCompId, seqNum);
+
+    private static FixMessage CreateTestRequest(string senderCompId, string targetCompId, int seqNum, string testReqId)
+    {
+        var message = CreateSessionMessage(FixMsgTypes.TestRequest, senderCompId, targetCompId, seqNum);
+        message.Add(FixTags.TestReqId, testReqId);
+        return message;
+    }
+
+    private static FixMessage CreateSessionMessage(string msgType, string senderCompId, string targetCompId, int seqNum)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, msgType);
+        message.Add(FixTags.SenderCompId, senderCompId);
+        message.Add(FixTags.TargetCompId, targetCompId);
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260812-19:30:00.000");
+        return message;
+    }
+
+    private static OrderBookEntry CreateEntry(ulong securityId, ulong orderId, BookSideType side, long price, long quantity)
+    {
+        return new OrderBookEntry
+        {
+            SecurityId = securityId,
+            OrderId = orderId,
+            Side = side,
+            Price = price,
+            Quantity = quantity,
+        };
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private sealed class TestFixClient
+    {
+        private readonly NetworkStream _stream;
+        private byte[] _buffer = new byte[4096];
+        private int _buffered;
+
+        public TestFixClient(NetworkStream stream)
+        {
+            _stream = stream;
+        }
+
+        public Task SendAsync(FixMessage message)
+            => _stream.WriteAsync(FixMessageCodec.Encode(message)).AsTask();
+
+        public async Task<FixMessage> ReadMessageAsync(TimeSpan? timeout = null)
+        {
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
+
+            while (true)
+            {
+                FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
+                if (decoded.Success)
+                {
+                    FixMessage message = decoded.Message!;
+                    Consume(decoded.BytesConsumed);
+                    return message;
+                }
+
+                if (decoded.Error != FixDecodeError.Incomplete)
+                    throw new XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
+
+                EnsureCapacity();
+                int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
+                Assert.True(read > 0, "Expected the FIX server to send a frame before closing the socket.");
+                _buffered += read;
+            }
+        }
+
+        public async Task AssertClosedWithoutFrameAsync(TimeSpan? timeout = null)
+        {
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(2));
+
+            try
+            {
+                while (true)
+                {
+                    FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
+                    if (decoded.Success)
+                    {
+                        FixMessage unexpected = decoded.Message!;
+                        throw new XunitException(
+                            $"Expected stale reconnect to be dropped without Logout, but received MsgType={FixApplicationMessageTestHelpers.GetRequired(unexpected, FixTags.MsgType)}.");
+                    }
+
+                    if (decoded.Error != FixDecodeError.Incomplete)
+                        throw new XunitException($"Expected transport close without FIX frame, but decode failed with {decoded.Error}.");
+
+                    EnsureCapacity();
+                    int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
+                    if (read == 0)
+                    {
+                        Assert.Equal(0, _buffered);
+                        return;
+                    }
+
+                    _buffered += read;
+                }
+            }
+            catch (OperationCanceledException) when (!cts.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                throw new XunitException("Expected the FIX server to close the stale reconnect promptly, but it stayed open past the timeout.");
+            }
+            catch (IOException)
+            {
+                Assert.Equal(0, _buffered);
+            }
+            catch (SocketException)
+            {
+                Assert.Equal(0, _buffered);
+            }
+        }
+
+        private void Consume(int count)
+        {
+            Buffer.BlockCopy(_buffer, count, _buffer, 0, _buffered - count);
+            _buffered -= count;
+        }
+
+        private void EnsureCapacity()
+        {
+            if (_buffered < _buffer.Length)
+                return;
+
+            Array.Resize(ref _buffer, _buffer.Length * 2);
+        }
+    }
+}

--- a/tools/fix/README.md
+++ b/tools/fix/README.md
@@ -1,0 +1,53 @@
+# FIX validator tooling
+
+`tools/fix/fix-validate.mjs` is a standalone FIX 4.4 tag=value validator for the opt-in FIX Conflated sandbox channel. It opens a real TCP session, performs `Logon`, consumes the automatic `MarketDataSnapshotFullRefresh` plus later `MarketDataIncrementalRefresh` messages, rebuilds the book locally, and periodically compares that state with `GET /book/{symbol}` from the HTTP side that `tools/ws/ws-validate.mjs` already expects.
+
+## Prerequisites
+
+- Enable the FIX sandbox listener:
+  - `UMDF_FIX_CONFLATED_ENABLED=true`
+  - `UMDF_FIX_CONFLATED_PORT=<tcp-port>`
+- Start the console app with an HTTP/WebSocket port as well (for example `--ws-port 8080`) so the validator can query `HTTP_BASE/book/{symbol}`.
+- For replay-driven runs, fetch sample PCAPs with `./tools/pcap/download-pcaps.sh` and start `src/B3.Umdf.ConsoleApp` with one or more `--pcap-prefix` values.
+
+## Usage
+
+```bash
+HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs <host> <fix-port> [symbol] [http-base]
+```
+
+Examples:
+
+```bash
+HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs localhost 9200 PETR4
+node tools/fix/fix-validate.mjs localhost 9200 PETR4 http://localhost:8080
+node tools/fix/fix-validate.mjs localhost 9200
+```
+
+If you omit `symbol`, the validator adopts the first snapshot symbol it sees.
+That is useful for quick smoke runs when you do not yet know which symbols are
+present in the current replay.
+
+Useful environment overrides:
+
+- `FIX_SENDER_COMP_ID` / `FIX_TARGET_COMP_ID` — override the default CompIDs. The script defaults to a unique sender ID per run so repeated manual runs do not trip the sandbox reconnect rule for stale `MsgSeqNum` values.
+- `FIX_HEARTBEAT_SEC` — requested heartbeat interval (default `30`).
+- `CHECK_INTERVAL_MS` — `/book` comparison interval (default `5000`).
+- `RUN_SECONDS` — optional auto-stop timer for short validation runs.
+
+If `GET /book/{symbol}` is unavailable (for example it returns `404` in the
+current local host setup), the validator keeps running and logs the server-check
+as unavailable while still validating the FIX session, snapshot parsing, and
+incremental book reconstruction path.
+
+## Example local replay
+
+```bash
+./tools/pcap/download-pcaps.sh
+UMDF_FIX_CONFLATED_ENABLED=true UMDF_FIX_CONFLATED_PORT=9200 \
+  dotnet run --project src/B3.Umdf.ConsoleApp -- \
+  --pcap-prefix pcap/20250331_MBO_084_EQT --ws-port 8080 --speed 1
+HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs localhost 9200 PETR4
+```
+
+This is the standalone client piece for issue #103 item 1. A later follow-up can wrap it together with a live replay harness and the existing WebSocket validators.

--- a/tools/fix/fix-validate.mjs
+++ b/tools/fix/fix-validate.mjs
@@ -1,0 +1,846 @@
+#!/usr/bin/env node
+// Standalone FIX Conflated validator for the local sandbox.
+// Usage:
+//   HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs localhost 9200 PETR4
+//
+// Example with a replay-driven local run (future issue #103 item 2 can wrap this
+// together with the WS validator during a live PCAP replay):
+//   ./tools/pcap/download-pcaps.sh
+//   UMDF_FIX_CONFLATED_ENABLED=true UMDF_FIX_CONFLATED_PORT=9200 \
+//   dotnet run --project src/B3.Umdf.ConsoleApp -- \
+//     --pcap-prefix pcap/20250331_MBO_084_EQT --ws-port 8080 --speed 1
+//   HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs localhost 9200 PETR4
+//
+// The validator behaves like a real FIX 4.4 client: it opens a raw TCP socket,
+// performs Logon, rebuilds local book state from the automatic full snapshot plus
+// later incremental refreshes, and periodically compares the result with
+// GET /book/{symbol} on the HTTP side used by the existing WS validator.
+
+import net from 'node:net';
+
+const SOH = 0x01;
+const BEGIN_STRING = 'FIX.4.4';
+
+const TAG = {
+  BeginString: 8,
+  BodyLength: 9,
+  MsgType: 35,
+  OrderId: 37,
+  SecurityId: 48,
+  SenderCompId: 49,
+  Symbol: 55,
+  Text: 58,
+  TargetCompId: 56,
+  MsgSeqNum: 34,
+  SendingTime: 52,
+  EncryptMethod: 98,
+  HeartBtInt: 108,
+  TestReqId: 112,
+  CheckSum: 10,
+  MDReqId: 262,
+  NoMDEntries: 268,
+  MDEntryType: 269,
+  MDEntryPx: 270,
+  MDEntrySize: 271,
+  MDEntryDate: 272,
+  MDEntryTime: 273,
+  MDUpdateAction: 279,
+  TradeId: 1003,
+};
+
+const MSG = {
+  Heartbeat: '0',
+  TestRequest: '1',
+  Logout: '5',
+  Logon: 'A',
+  MarketDataSnapshotFullRefresh: 'W',
+  MarketDataIncrementalRefresh: 'X',
+};
+
+const HOST = process.argv[2] || '127.0.0.1';
+const PORT = parseRequiredPort(process.argv[3] || '9200');
+const REQUESTED_SYMBOL = normalizeSymbol(process.argv[4] || '') || null;
+const HTTP_BASE = process.argv[5] || process.env.HTTP_BASE || `http://${HOST}:8080`;
+const CHECK_INTERVAL = parsePositiveInt(process.env.CHECK_INTERVAL_MS || '5000', 5000);
+const HTTP_TIMEOUT_MS = parsePositiveInt(process.env.HTTP_TIMEOUT_MS || '3000', 3000);
+const INITIAL_HEARTBEAT_SECONDS = parsePositiveInt(process.env.FIX_HEARTBEAT_SEC || '30', 30);
+const RUN_SECONDS = parseNonNegativeInt(process.env.RUN_SECONDS || '0', 0);
+const SENDER_COMP_ID = process.env.FIX_SENDER_COMP_ID || `FIX-VALIDATOR-${process.pid}-${Date.now().toString(36)}`;
+const TARGET_COMP_ID = process.env.FIX_TARGET_COMP_ID || 'SANDBOX';
+
+let inboundBuffer = Buffer.alloc(0);
+let nextOutboundSeqNum = 1;
+let heartbeatIntervalSeconds = INITIAL_HEARTBEAT_SECONDS;
+let trackedSymbol = REQUESTED_SYMBOL;
+let trackedSecurityId = null;
+let lastSentAt = 0;
+let lastReceivedAt = 0;
+let sessionActive = false;
+let snapshotSeen = false;
+let shutdownRequested = false;
+let lastBookError = null;
+
+const orders = new Map();
+const counters = {
+  messagesIn: 0,
+  logons: 0,
+  snapshots: 0,
+  incrementals: 0,
+  bookEntries: 0,
+  tradeEntries: 0,
+  heartbeatsIn: 0,
+  heartbeatsOut: 0,
+  testRequestsIn: 0,
+  divergences: 0,
+  unknownMessages: 0,
+};
+
+let checkTimer = null;
+let heartbeatTimer = null;
+let runTimer = null;
+let shuttingDown = false;
+
+console.log(`Connecting FIX validator to ${HOST}:${PORT} sender=${SENDER_COMP_ID} target=${TARGET_COMP_ID} symbol=${trackedSymbol ?? '(first snapshot)'} http=${HTTP_BASE}`);
+
+const socket = net.createConnection({ host: HOST, port: PORT });
+socket.setNoDelay(true);
+
+socket.on('connect', () => {
+  console.log('TCP connected; sending Logon');
+  sendSessionMessage(socket, MSG.Logon, [
+    [TAG.EncryptMethod, '0'],
+    [TAG.HeartBtInt, String(heartbeatIntervalSeconds)],
+  ]);
+
+  heartbeatTimer = setInterval(() => {
+    if (!sessionActive || socket.destroyed)
+      return;
+
+    const now = Date.now();
+    if (now - lastSentAt < heartbeatIntervalSeconds * 1000)
+      return;
+
+    counters.heartbeatsOut++;
+    sendSessionMessage(socket, MSG.Heartbeat, []);
+  }, 1000);
+
+  checkTimer = setInterval(() => {
+    void checkServer();
+  }, CHECK_INTERVAL);
+
+  if (RUN_SECONDS > 0)
+  {
+    runTimer = setTimeout(() => {
+      console.log(`RUN_SECONDS=${RUN_SECONDS} reached; requesting graceful shutdown.`);
+      requestShutdown('timer');
+    }, RUN_SECONDS * 1000);
+  }
+});
+
+socket.on('data', chunk => {
+  lastReceivedAt = Date.now();
+  inboundBuffer = Buffer.concat([inboundBuffer, chunk]);
+  drainInbound(socket);
+});
+
+socket.on('close', hadError => {
+  clearTimers();
+  printSummary(hadError ? 'socket closed after error' : 'socket closed');
+  if (!shutdownRequested && lastBookError)
+    console.error(`Last server-check issue: ${lastBookError}`);
+  process.exit(counters.divergences > 0 ? 1 : 0);
+});
+
+socket.on('error', error => {
+  console.error(`Socket error: ${error.message}`);
+});
+
+process.on('SIGINT', () => requestShutdown('SIGINT'));
+process.on('SIGTERM', () => requestShutdown('SIGTERM'));
+
+async function checkServer() {
+  const local = computeBookState();
+  const prefix = `[check] ${trackedSymbol ?? '(waiting-symbol)'}`;
+
+  if (!snapshotSeen || !trackedSymbol) {
+    console.log(`${prefix} waiting for initial snapshot... msgs=${counters.messagesIn} orders=${orders.size}`);
+    return;
+  }
+
+  try {
+    const response = await fetch(`${HTTP_BASE}/book/${encodeURIComponent(trackedSymbol)}`, {
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      lastBookError = `GET /book/${trackedSymbol} -> HTTP ${response.status}`;
+      console.log(`${prefix} local=${formatLocalSummary(local)} | server-check unavailable (${response.status})`);
+      return;
+    }
+
+    const payload = await response.json();
+    const server = extractServerBook(payload);
+    if (!server.valid) {
+      lastBookError = `unexpected /book payload keys: ${Object.keys(payload).join(', ') || '(none)'}`;
+      console.log(`${prefix} local=${formatLocalSummary(local)} | server-check unexpected payload`);
+      console.log(`  payload keys: ${Object.keys(payload).join(', ') || '(none)'}`);
+      return;
+    }
+
+    lastBookError = null;
+    const comparison = compareBooks(local, server);
+    const tag = comparison.match ? '✅ MATCH' : '❌ MISMATCH';
+    console.log(`${tag} | ${trackedSymbol} | local: ${formatLocalSummary(local)} | server: ${formatServerSummary(server)}`);
+    console.log(`  msgs=${counters.messagesIn} snaps=${counters.snapshots} incr=${counters.incrementals} bookEntries=${counters.bookEntries} trades=${counters.tradeEntries} hbIn=${counters.heartbeatsIn} hbOut=${counters.heartbeatsOut} testReq=${counters.testRequestsIn}`);
+
+    if (!comparison.match) {
+      counters.divergences++;
+      comparison.lines.slice(0, 10).forEach(line => console.log(`  ${line}`));
+      console.log(`  local top bids: ${formatTopLevels(local.bids)}`);
+      console.log(`  local top asks: ${formatTopLevels(local.asks)}`);
+      if (server.bids.length > 0)
+        console.log(`  server top bids: ${formatTopLevels(server.bids)}`);
+      if (server.asks.length > 0)
+        console.log(`  server top asks: ${formatTopLevels(server.asks)}`);
+    }
+  } catch (error) {
+    lastBookError = error instanceof Error ? error.message : String(error);
+    console.log(`${prefix} local=${formatLocalSummary(local)} | server-check failed: ${lastBookError}`);
+  }
+}
+
+function requestShutdown(reason) {
+  if (shuttingDown)
+    return;
+
+  shuttingDown = true;
+  shutdownRequested = true;
+  clearTimers();
+  console.log(`Shutdown requested (${reason})`);
+  if (sessionActive && !socket.destroyed) {
+    sendSessionMessage(socket, MSG.Logout, [[TAG.Text, `fix-validate shutdown (${reason})`]]);
+    socket.end();
+    setTimeout(() => socket.destroy(), 1000).unref();
+    return;
+  }
+
+  socket.destroy();
+}
+
+function drainInbound(currentSocket) {
+  while (inboundBuffer.length > 0) {
+    const decoded = decodeFrame(inboundBuffer);
+    if (decoded.status === 'incomplete')
+      return;
+
+    if (decoded.status === 'error') {
+      console.error(`Inbound FIX decode failed: ${decoded.error}`);
+      currentSocket.destroy();
+      return;
+    }
+
+    inboundBuffer = inboundBuffer.subarray(decoded.bytesConsumed);
+    handleMessage(decoded.message, currentSocket);
+  }
+}
+
+function handleMessage(message, currentSocket) {
+  counters.messagesIn++;
+  const msgType = message.get(TAG.MsgType);
+  if (!msgType) {
+    console.error('Inbound FIX frame missing MsgType (35).');
+    currentSocket.destroy();
+    return;
+  }
+
+  switch (msgType) {
+    case MSG.Logon: {
+      counters.logons++;
+      sessionActive = true;
+      heartbeatIntervalSeconds = parseNonNegativeInt(message.get(TAG.HeartBtInt) || String(heartbeatIntervalSeconds), heartbeatIntervalSeconds);
+      console.log(`Logon ack seq=${message.get(TAG.MsgSeqNum) ?? '?'} heartbeat=${heartbeatIntervalSeconds}s sender=${message.get(TAG.SenderCompId) ?? '?'} target=${message.get(TAG.TargetCompId) ?? '?'}`);
+      break;
+    }
+    case MSG.Heartbeat:
+      counters.heartbeatsIn++;
+      if (message.get(TAG.TestReqId))
+        console.log(`Heartbeat(TestReqID=${message.get(TAG.TestReqId)})`);
+      break;
+    case MSG.TestRequest:
+      counters.testRequestsIn++;
+      console.log(`TestRequest received id=${message.get(TAG.TestReqId) ?? '(missing)'}`);
+      counters.heartbeatsOut++;
+      sendSessionMessage(currentSocket, MSG.Heartbeat, message.get(TAG.TestReqId)
+        ? [[TAG.TestReqId, message.get(TAG.TestReqId)]]
+        : []);
+      break;
+    case MSG.Logout:
+      console.log(`Logout received: ${message.get(TAG.Text) ?? '(no reason)'}`);
+      requestShutdown('server-logout');
+      break;
+    case MSG.MarketDataSnapshotFullRefresh:
+      applySnapshot(message);
+      break;
+    case MSG.MarketDataIncrementalRefresh:
+      applyIncremental(message);
+      break;
+    default:
+      counters.unknownMessages++;
+      if (counters.unknownMessages <= 5)
+        console.log(`Ignoring FIX MsgType=${msgType}`);
+      break;
+  }
+}
+
+function applySnapshot(message) {
+  const symbol = normalizeSymbol(message.get(TAG.Symbol) || '');
+  const securityId = message.get(TAG.SecurityId) || null;
+  if (!acceptInstrument(symbol, securityId))
+    return;
+
+  const entries = parseRepeatingGroup(message, TAG.NoMDEntries, TAG.MDEntryType);
+  orders.clear();
+
+  for (const entry of entries) {
+    const entryType = entry.get(TAG.MDEntryType);
+    if (entryType !== '0' && entryType !== '1')
+      continue;
+
+    const orderId = entry.get(TAG.OrderId);
+    if (!orderId)
+      continue;
+
+    const price = toFiniteNumber(entry.get(TAG.MDEntryPx));
+    const size = toFiniteNumber(entry.get(TAG.MDEntrySize));
+    if (price == null || size == null)
+      continue;
+
+    orders.set(orderId, { side: entryType, price, size });
+  }
+
+  snapshotSeen = true;
+  counters.snapshots++;
+  const local = computeBookState();
+  console.log(`Snapshot loaded for ${trackedSymbol} securityId=${trackedSecurityId ?? '?'} entries=${entries.length} local=${formatLocalSummary(local)}`);
+}
+
+function applyIncremental(message) {
+  const entries = parseRepeatingGroup(message, TAG.NoMDEntries, TAG.MDUpdateAction);
+  let appliedBookEntries = 0;
+  let tradeEntries = 0;
+
+  for (const entry of entries) {
+    const symbol = normalizeSymbol(entry.get(TAG.Symbol) || message.get(TAG.Symbol) || '');
+    const securityId = entry.get(TAG.SecurityId) || message.get(TAG.SecurityId) || null;
+    if (!acceptInstrument(symbol, securityId))
+      continue;
+
+    const entryType = entry.get(TAG.MDEntryType);
+    const action = entry.get(TAG.MDUpdateAction);
+    if (!entryType || !action)
+      continue;
+
+    if (entryType === '2') {
+      tradeEntries++;
+      counters.tradeEntries++;
+      if (tradeEntries <= 3) {
+        console.log(`Trade ${trackedSymbol} px=${entry.get(TAG.MDEntryPx) ?? '?'} qty=${entry.get(TAG.MDEntrySize) ?? '?'} tradeId=${entry.get(TAG.TradeId) ?? '?'}`);
+      }
+      continue;
+    }
+
+    if (entryType !== '0' && entryType !== '1')
+      continue;
+
+    applyBookDelta(entryType, action, entry);
+    appliedBookEntries++;
+    counters.bookEntries++;
+  }
+
+  if (appliedBookEntries > 0 || tradeEntries > 0)
+    counters.incrementals++;
+}
+
+function applyBookDelta(entryType, action, entry) {
+  const side = entryType;
+  const orderId = entry.get(TAG.OrderId) || null;
+
+  switch (action) {
+    case '0':
+    case '1': {
+      if (!orderId)
+        return;
+
+      const price = toFiniteNumber(entry.get(TAG.MDEntryPx));
+      const size = toFiniteNumber(entry.get(TAG.MDEntrySize));
+      if (price == null || size == null)
+        return;
+
+      orders.set(orderId, { side, price, size });
+      return;
+    }
+    case '2':
+      if (orderId)
+        orders.delete(orderId);
+      return;
+    case '3': {
+      const thresholdPrice = toFiniteNumber(entry.get(TAG.MDEntryPx));
+      for (const [existingOrderId, order] of orders) {
+        if (order.side !== side)
+          continue;
+
+        if (thresholdPrice == null || deleteThruMatches(side, order.price, thresholdPrice))
+          orders.delete(existingOrderId);
+      }
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+function deleteThruMatches(side, price, thresholdPrice) {
+  return side === '0'
+    ? price >= thresholdPrice
+    : price <= thresholdPrice;
+}
+
+function acceptInstrument(symbol, securityId) {
+  if (trackedSecurityId && securityId && trackedSecurityId !== securityId)
+    return false;
+  if (trackedSymbol && symbol && trackedSymbol !== symbol)
+    return false;
+
+  if (!trackedSymbol && symbol) {
+    trackedSymbol = symbol;
+    console.log(`Tracking symbol ${trackedSymbol}`);
+  }
+
+  if (!trackedSecurityId && securityId) {
+    trackedSecurityId = securityId;
+    console.log(`Tracking securityId ${trackedSecurityId}`);
+  }
+
+  if (REQUESTED_SYMBOL && trackedSymbol && trackedSymbol !== REQUESTED_SYMBOL)
+    return false;
+
+  return true;
+}
+
+function sendSessionMessage(currentSocket, msgType, extraFields) {
+  const fields = [
+    [TAG.MsgType, msgType],
+    [TAG.SenderCompId, SENDER_COMP_ID],
+    [TAG.TargetCompId, TARGET_COMP_ID],
+    [TAG.MsgSeqNum, String(nextOutboundSeqNum++)],
+    [TAG.SendingTime, formatUtcTimestamp(new Date())],
+    ...extraFields,
+  ];
+
+  const payload = encodeFixFrame(fields);
+  currentSocket.write(payload);
+  lastSentAt = Date.now();
+}
+
+function encodeFixFrame(fields) {
+  const body = Buffer.from(fields.map(([tag, value]) => `${tag}=${value}${String.fromCharCode(SOH)}`).join(''), 'ascii');
+  const prefix = Buffer.from(`8=${BEGIN_STRING}${String.fromCharCode(SOH)}9=${body.length}${String.fromCharCode(SOH)}`, 'ascii');
+  const checksumBase = Buffer.concat([prefix, body]);
+  const checksum = calculateChecksum(checksumBase);
+  const trailer = Buffer.from(`10=${checksum.toString().padStart(3, '0')}${String.fromCharCode(SOH)}`, 'ascii');
+  return Buffer.concat([checksumBase, trailer]);
+}
+
+function decodeFrame(buffer) {
+  const firstSoh = buffer.indexOf(SOH);
+  if (firstSoh < 0)
+    return { status: 'incomplete' };
+
+  const beginField = buffer.subarray(0, firstSoh).toString('ascii');
+  if (beginField !== `8=${BEGIN_STRING}`)
+    return { status: 'error', error: `invalid BeginString field (${beginField})` };
+
+  const secondStart = firstSoh + 1;
+  const secondSoh = buffer.indexOf(SOH, secondStart);
+  if (secondSoh < 0)
+    return { status: 'incomplete' };
+
+  const bodyLengthField = buffer.subarray(secondStart, secondSoh).toString('ascii');
+  if (!bodyLengthField.startsWith('9='))
+    return { status: 'error', error: `missing BodyLength field (${bodyLengthField})` };
+
+  const bodyLength = Number.parseInt(bodyLengthField.slice(2), 10);
+  if (!Number.isInteger(bodyLength) || bodyLength < 0)
+    return { status: 'error', error: `invalid BodyLength (${bodyLengthField})` };
+
+  const bodyStart = secondSoh + 1;
+  const checksumFieldStart = bodyStart + bodyLength;
+  if (checksumFieldStart + 7 > buffer.length)
+    return { status: 'incomplete' };
+
+  if (buffer[checksumFieldStart] !== 0x31 || buffer[checksumFieldStart + 1] !== 0x30 || buffer[checksumFieldStart + 2] !== 0x3d)
+    return { status: 'error', error: 'body length mismatch before CheckSum' };
+
+  const checksumFieldEnd = buffer.indexOf(SOH, checksumFieldStart);
+  if (checksumFieldEnd < 0)
+    return { status: 'incomplete' };
+
+  const expectedChecksumText = buffer.subarray(checksumFieldStart + 3, checksumFieldEnd).toString('ascii');
+  const expectedChecksum = Number.parseInt(expectedChecksumText, 10);
+  if (!Number.isInteger(expectedChecksum))
+    return { status: 'error', error: `invalid CheckSum (${expectedChecksumText})` };
+
+  const actualChecksum = calculateChecksum(buffer.subarray(0, checksumFieldStart));
+  if (actualChecksum !== expectedChecksum)
+    return { status: 'error', error: `checksum mismatch expected=${expectedChecksumText} actual=${actualChecksum.toString().padStart(3, '0')}` };
+
+  const totalLength = checksumFieldEnd + 1;
+  const message = parseFixMessage(buffer.subarray(0, totalLength));
+  return { status: 'complete', message, bytesConsumed: totalLength };
+}
+
+function parseFixMessage(frame) {
+  const fields = [];
+  const valuesByTag = new Map();
+  let cursor = 0;
+
+  while (cursor < frame.length) {
+    const fieldEnd = frame.indexOf(SOH, cursor);
+    if (fieldEnd < 0)
+      break;
+    if (fieldEnd === cursor) {
+      cursor = fieldEnd + 1;
+      continue;
+    }
+
+    const raw = frame.subarray(cursor, fieldEnd).toString('ascii');
+    const equals = raw.indexOf('=');
+    if (equals <= 0)
+      throw new Error(`Malformed FIX field: ${raw}`);
+
+    const tag = Number.parseInt(raw.slice(0, equals), 10);
+    if (!Number.isInteger(tag))
+      throw new Error(`Invalid FIX tag: ${raw}`);
+
+    const value = raw.slice(equals + 1);
+    fields.push({ tag, value });
+    const bucket = valuesByTag.get(tag);
+    if (bucket)
+      bucket.push(value);
+    else
+      valuesByTag.set(tag, [value]);
+
+    cursor = fieldEnd + 1;
+  }
+
+  return {
+    fields,
+    get(tag) {
+      return valuesByTag.get(tag)?.[0] ?? null;
+    },
+    getAll(tag) {
+      return valuesByTag.get(tag) ?? [];
+    },
+  };
+}
+
+function parseRepeatingGroup(message, countTag, entryStartTag) {
+  const entries = [];
+  let insideGroup = false;
+  let current = null;
+
+  for (const field of message.fields) {
+    if (field.tag === countTag) {
+      insideGroup = true;
+      continue;
+    }
+
+    if (!insideGroup || field.tag === TAG.CheckSum)
+      continue;
+
+    if (field.tag === entryStartTag) {
+      current = new Map();
+      entries.push(current);
+    }
+
+    if (!current)
+      continue;
+
+    current.set(field.tag, field.value);
+  }
+
+  return entries.map(values => ({
+    get(tag) {
+      return values.get(tag) ?? null;
+    },
+  }));
+}
+
+function computeBookState() {
+  const bids = aggregateLevels('0', (a, b) => b.price - a.price);
+  const asks = aggregateLevels('1', (a, b) => a.price - b.price);
+
+  return {
+    bids,
+    asks,
+    bidOrders: bids.reduce((sum, level) => sum + level.count, 0),
+    askOrders: asks.reduce((sum, level) => sum + level.count, 0),
+    bidLevels: bids.length,
+    askLevels: asks.length,
+    bestBid: bids[0]?.price ?? 0,
+    bestAsk: asks[0]?.price ?? 0,
+    crossed: bids.length > 0 && asks.length > 0 && bids[0].price >= asks[0].price,
+  };
+}
+
+function aggregateLevels(side, sorter) {
+  const aggregates = new Map();
+  for (const order of orders.values()) {
+    if (order.side !== side)
+      continue;
+
+    const key = String(order.price);
+    const existing = aggregates.get(key);
+    if (existing) {
+      existing.qty += order.size;
+      existing.count += 1;
+    } else {
+      aggregates.set(key, { price: order.price, qty: order.size, count: 1 });
+    }
+  }
+
+  return [...aggregates.values()].sort(sorter);
+}
+
+function extractServerBook(payload) {
+  const bidArray = firstNonEmptyLevelArray(payload.bids, payload.bidLevels);
+  const askArray = firstNonEmptyLevelArray(payload.asks, payload.askLevels);
+
+  const bidOrders = toFiniteNumber(payload.bidOrders) ?? sumKnownCounts(bidArray);
+  const askOrders = toFiniteNumber(payload.askOrders) ?? sumKnownCounts(askArray);
+  const bidLevels = Array.isArray(payload.bidLevels)
+    ? bidArray.length
+    : (toFiniteNumber(payload.bidLevels) ?? (bidArray.length > 0 ? bidArray.length : null));
+  const askLevels = Array.isArray(payload.askLevels)
+    ? askArray.length
+    : (toFiniteNumber(payload.askLevels) ?? (askArray.length > 0 ? askArray.length : null));
+  const bestBid = toFiniteNumber(payload.bestBid) ?? (bidArray[0]?.price ?? null);
+  const bestAsk = toFiniteNumber(payload.bestAsk) ?? (askArray[0]?.price ?? null);
+  const crossed = typeof payload.crossed === 'boolean'
+    ? payload.crossed
+    : (bestBid != null && bestAsk != null && bestBid > 0 && bestAsk > 0 && bestBid >= bestAsk);
+
+  const hasSummary = [bidOrders, askOrders, bidLevels, askLevels, bestBid, bestAsk].some(value => value != null);
+  return {
+    valid: hasSummary || bidArray.length > 0 || askArray.length > 0,
+    bids: bidArray,
+    asks: askArray,
+    bidOrders,
+    askOrders,
+    bidLevels,
+    askLevels,
+    bestBid,
+    bestAsk,
+    crossed,
+  };
+}
+
+function firstNonEmptyLevelArray(...sources) {
+  for (const source of sources) {
+    const levels = extractLevelArray(source);
+    if (levels.length > 0)
+      return levels;
+  }
+
+  return [];
+}
+
+function sumKnownCounts(levels) {
+  if (levels.length === 0 || levels.some(level => level.count == null))
+    return null;
+
+  return levels.reduce((sum, level) => sum + level.count, 0);
+}
+
+function extractLevelArray(source) {
+  if (!Array.isArray(source))
+    return [];
+
+  return source
+    .map(level => {
+      if (Array.isArray(level)) {
+        const price = toFiniteNumber(level[0]);
+        const qty = toFiniteNumber(level[1]);
+        const count = toFiniteNumber(level[2]);
+        return price == null || qty == null ? null : { price, qty, count };
+      }
+
+      if (!level || typeof level !== 'object')
+        return null;
+
+      const price = toFiniteNumber(level.price ?? level.px ?? level.mdEntryPx ?? level.bestPrice);
+      const qty = toFiniteNumber(level.qty ?? level.quantity ?? level.size ?? level.totalQuantity ?? level.mdEntrySize);
+      const count = toFiniteNumber(level.count ?? level.orderCount ?? level.orders ?? level.totalOrders ?? level.orderQty);
+      return price == null || qty == null ? null : { price, qty, count };
+    })
+    .filter(Boolean);
+}
+
+function compareBooks(local, server) {
+  const lines = [];
+
+  if (server.bidOrders != null && server.bidOrders !== local.bidOrders)
+    lines.push(`bidOrders local=${local.bidOrders} server=${server.bidOrders}`);
+  if (server.askOrders != null && server.askOrders !== local.askOrders)
+    lines.push(`askOrders local=${local.askOrders} server=${server.askOrders}`);
+  if (server.bidLevels != null && server.bidLevels !== local.bidLevels)
+    lines.push(`bidLevels local=${local.bidLevels} server=${server.bidLevels}`);
+  if (server.askLevels != null && server.askLevels !== local.askLevels)
+    lines.push(`askLevels local=${local.askLevels} server=${server.askLevels}`);
+  if (server.bestBid != null && server.bestBid !== local.bestBid)
+    lines.push(`bestBid local=${formatPrice(local.bestBid)} server=${formatPrice(server.bestBid)}`);
+  if (server.bestAsk != null && server.bestAsk !== local.bestAsk)
+    lines.push(`bestAsk local=${formatPrice(local.bestAsk)} server=${formatPrice(server.bestAsk)}`);
+  if (server.crossed != null && server.crossed !== local.crossed)
+    lines.push(`crossed local=${local.crossed} server=${server.crossed}`);
+
+  compareLevelSide(lines, 'bid', local.bids, server.bids);
+  compareLevelSide(lines, 'ask', local.asks, server.asks);
+
+  return {
+    match: lines.length === 0,
+    lines,
+  };
+}
+
+function compareLevelSide(lines, side, localLevels, serverLevels) {
+  if (serverLevels.length === 0)
+    return;
+
+  const max = Math.max(localLevels.length, serverLevels.length);
+  for (let index = 0; index < max; index++) {
+    const local = localLevels[index];
+    const server = serverLevels[index];
+    if (!local || !server) {
+      lines.push(`${side}[${index}] local=${formatLevel(local)} server=${formatLevel(server)}`);
+      continue;
+    }
+
+    if (local.price !== server.price || local.qty !== server.qty || (server.count != null && local.count !== server.count)) {
+      lines.push(`${side}[${index}] local=${formatLevel(local)} server=${formatLevel(server)}`);
+    }
+  }
+}
+
+function formatLocalSummary(state) {
+  return `${state.bidOrders}b/${state.askOrders}a ${state.bidLevels}lv/${state.askLevels}lv bid=${formatPrice(state.bestBid)} ask=${formatPrice(state.bestAsk)} crossed=${state.crossed}`;
+}
+
+function formatServerSummary(state) {
+  return `${formatMaybe(state.bidOrders)}b/${formatMaybe(state.askOrders)}a ${formatMaybe(state.bidLevels)}lv/${formatMaybe(state.askLevels)}lv bid=${formatPrice(state.bestBid)} ask=${formatPrice(state.bestAsk)} crossed=${formatMaybe(state.crossed)}`;
+}
+
+function formatTopLevels(levels) {
+  if (!levels || levels.length === 0)
+    return '(empty)';
+
+  return levels.slice(0, 5).map(formatLevel).join(' | ');
+}
+
+function formatLevel(level) {
+  if (!level)
+    return '(missing)';
+  return `${formatPrice(level.price)} x ${formatNumber(level.qty)} (${level.count})`;
+}
+
+function formatPrice(value) {
+  if (value == null)
+    return '?';
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(4).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function formatNumber(value) {
+  if (value == null)
+    return '?';
+  return Number.isInteger(value)
+    ? String(value)
+    : value.toFixed(4).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function formatMaybe(value) {
+  return value == null ? '?' : String(value);
+}
+
+function calculateChecksum(buffer) {
+  let checksum = 0;
+  for (const value of buffer)
+    checksum = (checksum + value) & 0xff;
+  return checksum;
+}
+
+function printSummary(reason) {
+  const local = computeBookState();
+  console.log(`[summary] ${reason} | symbol=${trackedSymbol ?? '(unknown)'} securityId=${trackedSecurityId ?? '?'} sessionActive=${sessionActive} lastRxMsAgo=${lastReceivedAt ? Date.now() - lastReceivedAt : 'n/a'} lastTxMsAgo=${lastSentAt ? Date.now() - lastSentAt : 'n/a'}`);
+  console.log(`[summary] local=${formatLocalSummary(local)} orders=${orders.size} msgs=${counters.messagesIn} logons=${counters.logons} snaps=${counters.snapshots} incr=${counters.incrementals} bookEntries=${counters.bookEntries} trades=${counters.tradeEntries} hbIn=${counters.heartbeatsIn} hbOut=${counters.heartbeatsOut} testReq=${counters.testRequestsIn} divergences=${counters.divergences}`);
+}
+
+function clearTimers() {
+  if (checkTimer) {
+    clearInterval(checkTimer);
+    checkTimer = null;
+  }
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  if (runTimer) {
+    clearTimeout(runTimer);
+    runTimer = null;
+  }
+}
+
+function formatUtcTimestamp(date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hour = String(date.getUTCHours()).padStart(2, '0');
+  const minute = String(date.getUTCMinutes()).padStart(2, '0');
+  const second = String(date.getUTCSeconds()).padStart(2, '0');
+  const millisecond = String(date.getUTCMilliseconds()).padStart(3, '0');
+  return `${year}${month}${day}-${hour}:${minute}:${second}.${millisecond}`;
+}
+
+function normalizeSymbol(value) {
+  const normalized = String(value).trim().toUpperCase();
+  return normalized.length === 0 ? null : normalized;
+}
+
+function toFiniteNumber(value) {
+  if (value == null)
+    return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseRequiredPort(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    console.error(`Invalid FIX port: ${value}`);
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}


### PR DESCRIPTION
Part of #103 (items 1 and 3).

## Summary
- add `tools/fix/fix-validate.mjs`, a standalone TCP FIX 4.4 validator that performs Logon, decodes tag=value frames with manual BodyLength/CheckSum handling, rebuilds book state from snapshot/incremental messages, handles Heartbeat/TestRequest, and periodically compares its local book against `HTTP_BASE/book/{symbol}` when that endpoint is available
- add `tools/fix/README.md` with prerequisites, replay usage, and environment overrides for local/manual FIX sandbox validation
- add `FixConflatedReconnectEndToEndTests` to prove the real `FixConflatedTcpServer` drops stale-sequence reconnects without Logout and that the supported recovery path is a fresh session + new full snapshot

## Validation
- `dotnet build B3MarketDataPlatform.slnx` ✅
- `dotnet test B3MarketDataPlatform.slnx` ✅
- reconnect test loop: 10/10 passes via `dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj --filter FullyQualifiedName~FixConflatedReconnectEndToEndTests --no-restore` ✅
- `node --check tools/fix/fix-validate.mjs` ✅

## Live run notes
- started `src/B3.Umdf.ConsoleApp` with `UMDF_FIX_CONFLATED_ENABLED=true`, `UMDF_FIX_CONFLATED_PORT=9200`, `--pcap-prefix pcap/20250331_MBO_084_EQT`, `--ws-port 8080`, `--speed 100`
- validator successfully connected, received Logon, and (with no symbol filter) received a live `MarketDataSnapshotFullRefresh` plus incrementals for symbol `J1BH34`
- explicit `PETR4` did not appear in that sample replay during the bounded smoke run (`/symbols?q=PETR4` returned no matches)
- `GET /book/{symbol}` returned HTTP 404 in the current local host setup, so the tool logged the server check as unavailable while still proving the FIX session/snapshot/incremental path itself
