### PR TITLE
Wire real ZLIB compression into FIX Conflated transport

### DIFF
--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -15,7 +15,7 @@ An additional, **opt-in** output channel, alongside the existing
 `WireV2` WebSocket protocol (see
 [docs/WEBSOCKET-PROTOCOL.md](WEBSOCKET-PROTOCOL.md)), through which this
 platform emits live book, trade, instrument-status, and news data
-encoded as **FIX 4.4 Tag=Value** messages, batching book deltas over a
+encoded as **FIX 4.4 Tag=Value** messages inside a **single continuous per-session RFC 1950 ZLIB stream**, batching book deltas over a
 configurable time window ("conflation"). The same project also models
 additional UMDF-specific message shapes such as `SecurityList*` and
 `MarketTotals*`. This platform acts as the **FIX session acceptor**
@@ -66,6 +66,8 @@ it needs the `schema-upgrade` label.
 
 ## Session behavior (summary)
 
+- Outbound bytes are wrapped once per TCP connection in a **single continuous ZLIB stream** (`System.IO.Compression.ZLibStream`). The sandbox does **not** compress each FIX frame independently; clients must inflate the whole socket stream and then parse tag=value FIX messages out of the resulting plaintext byte stream. This is always on, because that matches the real B3 product and keeps the sandbox wire contract faithful by default.
+- The write loop flushes the shared connection-lifetime compressor after each encoded FIX message so logon, heartbeats, trades, and conflated book updates become readable to the client promptly instead of waiting for additional deflater buffering.
 - `Logon` (A) / `Heartbeat` (0) / `TestRequest` (1) / `Logout` (5) are
   supported per standard FIX 4.4 session semantics, with no credential
   check.
@@ -160,7 +162,7 @@ matrix alongside the existing WebSocket and transport knobs.
 ## Validation & tooling
 
 The FIX Conflated channel has validation/observability tooling parity with
-the existing `WireV2` WebSocket path (tracked by issue #103):
+the existing `WireV2` WebSocket path (tracked by issue #103). All listed tooling now inflates the continuous ZLIB transport stream before FIX frame parsing:
 
 - **Standalone FIX validator** — `tools/fix/fix-validate.mjs` is a
   dependency-free Node.js TCP client mirroring `tools/ws/ws-validate.mjs`. It
@@ -220,7 +222,7 @@ the existing `WireV2` WebSocket path (tracked by issue #103):
 ## Enabling
 
 Disabled by default. Enable with `UMDF_FIX_CONFLATED_ENABLED=true` plus
-at least `UMDF_FIX_CONFLATED_PORT=<port>`. Optional transport tuning
+at least `UMDF_FIX_CONFLATED_PORT=<port>`. Once enabled, transport compression is always on and mirrors the real B3 conflated feed: downstream clients must wrap the TCP socket in a ZLIB inflater before parsing FIX tag=value frames. Optional transport tuning
 includes `UMDF_FIX_CONFLATED_CONFLATION_MS`,
 `UMDF_FIX_CONFLATED_RESEND_BUFFER_CAPACITY`,
 `UMDF_FIX_CONFLATED_OUTBOUND_QUEUE_CAPACITY`, and

--- a/src/B3.Umdf.FixConflated/FixTcpClientSession.cs
+++ b/src/B3.Umdf.FixConflated/FixTcpClientSession.cs
@@ -10,6 +10,7 @@ public sealed class FixTcpClientSession : IAsyncDisposable
 {
     private readonly TcpClient _client;
     private readonly NetworkStream _stream;
+    private readonly Stream _compressedWriteStream;
     private readonly FixSessionConnection _session;
     private readonly Func<IEnumerable<FixMessage>>? _initialMessagesProvider;
     private readonly Action<long> _onClosed;
@@ -35,6 +36,7 @@ public sealed class FixTcpClientSession : IAsyncDisposable
         Id = id;
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _stream = client.GetStream();
+        _compressedWriteStream = FixZlibCompression.CreateCompressionStream(_stream, leaveOpen: true);
         _session = session ?? throw new ArgumentNullException(nameof(session));
         _initialMessagesProvider = initialMessagesProvider;
         _onClosed = onClosed ?? throw new ArgumentNullException(nameof(onClosed));
@@ -91,6 +93,7 @@ public sealed class FixTcpClientSession : IAsyncDisposable
         }
         finally
         {
+            _compressedWriteStream.Dispose();
             _stream.Dispose();
             _client.Dispose();
             _cts.Dispose();
@@ -177,7 +180,8 @@ public sealed class FixTcpClientSession : IAsyncDisposable
             {
                 while (_outbound.Reader.TryRead(out byte[]? payload))
                 {
-                    await _stream.WriteAsync(payload, _cts.Token).ConfigureAwait(false);
+                    await _compressedWriteStream.WriteAsync(payload, _cts.Token).ConfigureAwait(false);
+                    await _compressedWriteStream.FlushAsync(_cts.Token).ConfigureAwait(false);
                     FixConflatedMetrics.MessagesSent.Add(1);
                     FixConflatedMetrics.BytesSent.Add(payload.Length);
                 }
@@ -264,6 +268,8 @@ public sealed class FixTcpClientSession : IAsyncDisposable
 
         _cts.Cancel();
         _outbound.Writer.TryComplete();
+        try { _compressedWriteStream.Dispose(); }
+        catch (ObjectDisposedException) { }
         try { _client.Client.Shutdown(SocketShutdown.Both); }
         catch (SocketException) { }
         catch (ObjectDisposedException) { }

--- a/src/B3.Umdf.FixConflated/FixZlibCompression.cs
+++ b/src/B3.Umdf.FixConflated/FixZlibCompression.cs
@@ -7,11 +7,23 @@ public static class FixZlibCompression
     public static byte[] Compress(ReadOnlySpan<byte> payload, CompressionLevel compressionLevel = CompressionLevel.Fastest)
     {
         using var output = new MemoryStream();
-        using (var zlib = new ZLibStream(output, compressionLevel, leaveOpen: true))
+        using (var zlib = CreateCompressionStream(output, leaveOpen: true, compressionLevel))
         {
             zlib.Write(payload);
         }
 
         return output.ToArray();
+    }
+
+    public static ZLibStream CreateCompressionStream(Stream destination, bool leaveOpen = false, CompressionLevel compressionLevel = CompressionLevel.Fastest)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+        return new ZLibStream(destination, compressionLevel, leaveOpen);
+    }
+
+    public static ZLibStream CreateDecompressionStream(Stream source, bool leaveOpen = false)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        return new ZLibStream(source, CompressionMode.Decompress, leaveOpen);
     }
 }

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedEndToEndTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedEndToEndTests.cs
@@ -62,7 +62,7 @@ public sealed class FixConflatedEndToEndTests
         using var client = new TcpClient { NoDelay = true };
         await client.ConnectAsync(IPAddress.Loopback, port);
         using NetworkStream stream = client.GetStream();
-        var fixClient = new TestFixClient(stream);
+        await using var fixClient = new FixSocketClientTestHelpers.InflatingFixClient(stream);
 
         await fixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 1));
 
@@ -221,59 +221,6 @@ public sealed class FixConflatedEndToEndTests
         finally
         {
             listener.Stop();
-        }
-    }
-
-    private sealed class TestFixClient
-    {
-        private readonly NetworkStream _stream;
-        private byte[] _buffer = new byte[4096];
-        private int _buffered;
-
-        public TestFixClient(NetworkStream stream)
-        {
-            _stream = stream;
-        }
-
-        public Task SendAsync(FixMessage message)
-            => _stream.WriteAsync(FixMessageCodec.Encode(message)).AsTask();
-
-        public async Task<FixMessage> ReadMessageAsync(TimeSpan? timeout = null)
-        {
-            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
-
-            while (true)
-            {
-                FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
-                if (decoded.Success)
-                {
-                    FixMessage message = decoded.Message!;
-                    Consume(decoded.BytesConsumed);
-                    return message;
-                }
-
-                if (decoded.Error != FixDecodeError.Incomplete)
-                    throw new Xunit.Sdk.XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
-
-                EnsureCapacity();
-                int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
-                Assert.True(read > 0, "Expected the FIX server to send a frame before closing the socket.");
-                _buffered += read;
-            }
-        }
-
-        private void Consume(int count)
-        {
-            Buffer.BlockCopy(_buffer, count, _buffer, 0, _buffered - count);
-            _buffered -= count;
-        }
-
-        private void EnsureCapacity()
-        {
-            if (_buffered < _buffer.Length)
-                return;
-
-            Array.Resize(ref _buffer, _buffer.Length * 2);
         }
     }
 }

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedReconnectEndToEndTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedReconnectEndToEndTests.cs
@@ -55,7 +55,7 @@ public sealed class FixConflatedReconnectEndToEndTests
         {
             await staleClient.ConnectAsync(IPAddress.Loopback, port);
             using NetworkStream staleStream = staleClient.GetStream();
-            var staleFixClient = new TestFixClient(staleStream);
+            await using var staleFixClient = new FixSocketClientTestHelpers.InflatingFixClient(staleStream);
 
             await staleFixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 3));
             await staleFixClient.AssertClosedWithoutFrameAsync();
@@ -65,7 +65,7 @@ public sealed class FixConflatedReconnectEndToEndTests
         {
             await freshClient.ConnectAsync(IPAddress.Loopback, port);
             using NetworkStream freshStream = freshClient.GetStream();
-            var freshFixClient = new TestFixClient(freshStream);
+            await using var freshFixClient = new FixSocketClientTestHelpers.InflatingFixClient(freshStream);
 
             await freshFixClient.SendAsync(CreateLogon("CLIENT-B", "SANDBOX", 1));
 
@@ -89,7 +89,7 @@ public sealed class FixConflatedReconnectEndToEndTests
         client.Client.LingerState = new LingerOption(true, 0);
 
         using NetworkStream stream = client.GetStream();
-        var fixClient = new TestFixClient(stream);
+        await using var fixClient = new FixSocketClientTestHelpers.InflatingFixClient(stream);
 
         await fixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 1));
 
@@ -163,107 +163,6 @@ public sealed class FixConflatedReconnectEndToEndTests
         finally
         {
             listener.Stop();
-        }
-    }
-
-    private sealed class TestFixClient
-    {
-        private readonly NetworkStream _stream;
-        private byte[] _buffer = new byte[4096];
-        private int _buffered;
-
-        public TestFixClient(NetworkStream stream)
-        {
-            _stream = stream;
-        }
-
-        public Task SendAsync(FixMessage message)
-            => _stream.WriteAsync(FixMessageCodec.Encode(message)).AsTask();
-
-        public async Task<FixMessage> ReadMessageAsync(TimeSpan? timeout = null)
-        {
-            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
-
-            while (true)
-            {
-                FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
-                if (decoded.Success)
-                {
-                    FixMessage message = decoded.Message!;
-                    Consume(decoded.BytesConsumed);
-                    return message;
-                }
-
-                if (decoded.Error != FixDecodeError.Incomplete)
-                    throw new XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
-
-                EnsureCapacity();
-                int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
-                Assert.True(read > 0, "Expected the FIX server to send a frame before closing the socket.");
-                _buffered += read;
-            }
-        }
-
-        public async Task AssertClosedWithoutFrameAsync(TimeSpan? timeout = null)
-        {
-            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(2));
-
-            try
-            {
-                while (true)
-                {
-                    FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
-                    if (decoded.Success)
-                    {
-                        FixMessage unexpected = decoded.Message!;
-                        throw new XunitException(
-                            $"Expected stale reconnect to be dropped without Logout, but received MsgType={FixApplicationMessageTestHelpers.GetRequired(unexpected, FixTags.MsgType)}.");
-                    }
-
-                    if (decoded.Error != FixDecodeError.Incomplete)
-                        throw new XunitException($"Expected transport close without FIX frame, but decode failed with {decoded.Error}.");
-
-                    EnsureCapacity();
-                    int read = await _stream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
-                    if (read == 0)
-                    {
-                        Assert.Equal(0, _buffered);
-                        return;
-                    }
-
-                    _buffered += read;
-                }
-            }
-            catch (OperationCanceledException) when (!cts.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (OperationCanceledException)
-            {
-                throw new XunitException("Expected the FIX server to close the stale reconnect promptly, but it stayed open past the timeout.");
-            }
-            catch (IOException)
-            {
-                Assert.Equal(0, _buffered);
-            }
-            catch (SocketException)
-            {
-                Assert.Equal(0, _buffered);
-            }
-        }
-
-        private void Consume(int count)
-        {
-            Buffer.BlockCopy(_buffer, count, _buffer, 0, _buffered - count);
-            _buffered -= count;
-        }
-
-        private void EnsureCapacity()
-        {
-            if (_buffered < _buffer.Length)
-                return;
-
-            Array.Resize(ref _buffer, _buffer.Length * 2);
         }
     }
 }

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedTcpServerTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedTcpServerTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using B3.Umdf.FixConflated;
 
 namespace B3.Umdf.FixConflated.Tests;
@@ -24,10 +25,11 @@ public sealed class FixConflatedTcpServerTests
         using var client = new TcpClient();
         await client.ConnectAsync(IPAddress.Loopback, port);
         using NetworkStream stream = client.GetStream();
+        await using var fixClient = new FixSocketClientTestHelpers.InflatingFixClient(stream);
 
-        await stream.WriteAsync(FixMessageCodec.Encode(CreateLogon("CLIENT-A", "SANDBOX", 1)));
+        await fixClient.SendAsync(CreateLogon("CLIENT-A", "SANDBOX", 1));
 
-        FixMessage logonAck = await ReadMessageAsync(stream);
+        FixMessage logonAck = await fixClient.ReadMessageAsync();
         Assert.Equal(FixMsgTypes.Logon, GetRequired(logonAck, FixTags.MsgType));
         Assert.Equal("1", GetRequired(logonAck, FixTags.MsgSeqNum));
         Assert.Equal("SANDBOX", GetRequired(logonAck, FixTags.SenderCompId));
@@ -35,10 +37,42 @@ public sealed class FixConflatedTcpServerTests
 
         hub.BroadcastApplication(CreateApplicationMessage("md-1"));
 
-        FixMessage incremental = await ReadMessageAsync(stream);
+        FixMessage incremental = await fixClient.ReadMessageAsync();
         Assert.Equal(FixMsgTypes.MarketDataIncrementalRefresh, GetRequired(incremental, FixTags.MsgType));
         Assert.Equal("2", GetRequired(incremental, FixTags.MsgSeqNum));
         Assert.Equal("md-1", GetRequired(incremental, FixTags.MDReqId));
+    }
+
+    [Fact]
+    public async Task Wire_Bytes_Are_ZlibCompressed_And_Inflate_To_Fix_Logon()
+    {
+        var hub = new FixConflatedSessionHub();
+        int port = GetFreeTcpPort();
+        await using var server = new FixConflatedTcpServer(
+            hub,
+            new FixConflatedTcpServerOptions
+            {
+                OutboundQueueCapacity = 64,
+                SessionOptions = new FixSessionOptions { ApplicationResendBufferCapacity = 8 },
+            });
+        await server.StartAsync(port);
+
+        using var client = new TcpClient { NoDelay = true };
+        await client.ConnectAsync(IPAddress.Loopback, port);
+        using NetworkStream stream = client.GetStream();
+
+        await stream.WriteAsync(FixMessageCodec.Encode(CreateLogon("CLIENT-A", "SANDBOX", 1)));
+
+        byte[] rawBytes = await FixSocketClientTestHelpers.ReadRawBytesAsync(stream, minimumBytes: 12);
+        string rawAscii = Encoding.ASCII.GetString(rawBytes);
+
+        Assert.Equal(0x78, rawBytes[0]);
+        Assert.DoesNotContain("8=FIX.4.4", rawAscii, StringComparison.Ordinal);
+
+        FixMessage logonAck = FixSocketClientTestHelpers.InflateSingleMessage(rawBytes, out string inflatedText);
+        Assert.StartsWith($"8=FIX.4.4{(char)FixMessageCodec.Soh}", inflatedText, StringComparison.Ordinal);
+        Assert.Equal(FixMsgTypes.Logon, GetRequired(logonAck, FixTags.MsgType));
+        Assert.Equal("1", GetRequired(logonAck, FixTags.MsgSeqNum));
     }
 
     private static FixMessage CreateLogon(string senderCompId, string targetCompId, int seqNum)
@@ -62,26 +96,6 @@ public sealed class FixConflatedTcpServerTests
         message.Add(FixTags.MDReqId, mdReqId);
         message.Add(FixTags.NoMDEntries, 0);
         return message;
-    }
-
-    private static async Task<FixMessage> ReadMessageAsync(NetworkStream stream)
-    {
-        byte[] buffer = new byte[4096];
-        int buffered = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-        while (true)
-        {
-            FixDecodeResult decoded = FixMessageCodec.Decode(buffer.AsSpan(0, buffered));
-            if (decoded.Success)
-                return decoded.Message!;
-            if (decoded.Error != FixDecodeError.Incomplete)
-                throw new Xunit.Sdk.XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
-
-            int read = await stream.ReadAsync(buffer.AsMemory(buffered), cts.Token);
-            Assert.True(read > 0, "Expected the server to send a FIX frame before closing the socket.");
-            buffered += read;
-        }
     }
 
     private static int GetFreeTcpPort()

--- a/tests/B3.Umdf.FixConflated.Tests/FixMessageCodecTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixMessageCodecTests.cs
@@ -63,17 +63,27 @@ public sealed class FixMessageCodecTests
     }
 
     [Fact]
-    public void Compress_UsesZlibWrapper()
+    public void StreamingCompression_RoundTrips_ConcatenatedMessages()
     {
-        byte[] raw = FixMessageCodec.Encode(CreateHeartbeat(seqNum: 7));
+        byte[] first = FixMessageCodec.Encode(CreateHeartbeat(seqNum: 7));
+        byte[] second = FixMessageCodec.Encode(CreateHeartbeat(seqNum: 8));
+        byte[] expected = [.. first, .. second];
 
-        byte[] compressed = FixZlibCompression.Compress(raw);
-        using var input = new MemoryStream(compressed);
-        using var zlib = new ZLibStream(input, CompressionMode.Decompress);
+        using var compressed = new MemoryStream();
+        using (var zlib = FixZlibCompression.CreateCompressionStream(compressed, leaveOpen: true, CompressionLevel.Fastest))
+        {
+            zlib.Write(first);
+            zlib.Flush();
+            zlib.Write(second);
+            zlib.Flush();
+        }
+
+        using var input = new MemoryStream(compressed.ToArray());
+        using var inflate = FixZlibCompression.CreateDecompressionStream(input);
         using var output = new MemoryStream();
-        zlib.CopyTo(output);
+        inflate.CopyTo(output);
 
-        Assert.Equal(raw, output.ToArray());
+        Assert.Equal(expected, output.ToArray());
     }
 
     private static FixMessage CreateHeartbeat(int seqNum)

--- a/tests/B3.Umdf.FixConflated.Tests/FixSocketClientTestHelpers.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixSocketClientTestHelpers.cs
@@ -1,0 +1,153 @@
+using System.IO.Compression;
+using System.Net.Sockets;
+using System.Text;
+using B3.Umdf.FixConflated;
+using Xunit.Sdk;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+internal static class FixSocketClientTestHelpers
+{
+    public static async Task<byte[]> ReadRawBytesAsync(NetworkStream stream, int minimumBytes, TimeSpan? timeout = null)
+    {
+        byte[] buffer = new byte[Math.Max(256, minimumBytes)];
+        int buffered = 0;
+        using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
+
+        while (buffered < minimumBytes)
+        {
+            if (buffered == buffer.Length)
+                Array.Resize(ref buffer, buffer.Length * 2);
+
+            int read = await stream.ReadAsync(buffer.AsMemory(buffered), cts.Token);
+            Assert.True(read > 0, "Expected the FIX server to send bytes before closing the socket.");
+            buffered += read;
+        }
+
+        return buffer[..buffered];
+    }
+
+    public static FixMessage InflateSingleMessage(byte[] compressedBytes, out string inflatedText)
+    {
+        using var input = new MemoryStream(compressedBytes);
+        using var zlib = FixZlibCompression.CreateDecompressionStream(input);
+        using var output = new MemoryStream();
+        zlib.CopyTo(output);
+        byte[] inflated = output.ToArray();
+        inflatedText = Encoding.ASCII.GetString(inflated);
+
+        FixDecodeResult decoded = FixMessageCodec.Decode(inflated);
+        Assert.True(decoded.Success, $"Expected inflated FIX frame to decode successfully, got {decoded.Error}.");
+        Assert.Equal(inflated.Length, decoded.BytesConsumed);
+        return decoded.Message!;
+    }
+
+    public sealed class InflatingFixClient : IAsyncDisposable
+    {
+        private readonly NetworkStream _stream;
+        private readonly Stream _inflateStream;
+        private byte[] _buffer = new byte[4096];
+        private int _buffered;
+
+        public InflatingFixClient(NetworkStream stream)
+        {
+            _stream = stream;
+            _inflateStream = FixZlibCompression.CreateDecompressionStream(stream, leaveOpen: true);
+        }
+
+        public Task SendAsync(FixMessage message)
+            => _stream.WriteAsync(FixMessageCodec.Encode(message)).AsTask();
+
+        public async Task<FixMessage> ReadMessageAsync(TimeSpan? timeout = null)
+        {
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(5));
+
+            while (true)
+            {
+                FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
+                if (decoded.Success)
+                {
+                    FixMessage message = decoded.Message!;
+                    Consume(decoded.BytesConsumed);
+                    return message;
+                }
+
+                if (decoded.Error != FixDecodeError.Incomplete)
+                    throw new XunitException($"Expected a full FIX frame but decode failed with {decoded.Error}.");
+
+                EnsureCapacity();
+                int read = await _inflateStream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
+                Assert.True(read > 0, "Expected the FIX server to send a FIX frame before closing the socket.");
+                _buffered += read;
+            }
+        }
+
+        public async Task AssertClosedWithoutFrameAsync(TimeSpan? timeout = null)
+        {
+            using var cts = new CancellationTokenSource(timeout ?? TimeSpan.FromSeconds(2));
+
+            try
+            {
+                while (true)
+                {
+                    FixDecodeResult decoded = FixMessageCodec.Decode(_buffer.AsSpan(0, _buffered));
+                    if (decoded.Success)
+                    {
+                        FixMessage unexpected = decoded.Message!;
+                        throw new XunitException(
+                            $"Expected stale reconnect to be dropped without Logout, but received MsgType={FixApplicationMessageTestHelpers.GetRequired(unexpected, FixTags.MsgType)}.");
+                    }
+
+                    if (decoded.Error != FixDecodeError.Incomplete)
+                        throw new XunitException($"Expected transport close without FIX frame, but decode failed with {decoded.Error}.");
+
+                    EnsureCapacity();
+                    int read = await _inflateStream.ReadAsync(_buffer.AsMemory(_buffered), cts.Token);
+                    if (read == 0)
+                    {
+                        Assert.Equal(0, _buffered);
+                        return;
+                    }
+
+                    _buffered += read;
+                }
+            }
+            catch (OperationCanceledException) when (!cts.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                throw new XunitException("Expected the FIX server to close the stale reconnect promptly, but it stayed open past the timeout.");
+            }
+            catch (IOException)
+            {
+                Assert.Equal(0, _buffered);
+            }
+            catch (SocketException)
+            {
+                Assert.Equal(0, _buffered);
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _inflateStream.Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        private void Consume(int count)
+        {
+            Buffer.BlockCopy(_buffer, count, _buffer, 0, _buffered - count);
+            _buffered -= count;
+        }
+
+        private void EnsureCapacity()
+        {
+            if (_buffered < _buffer.Length)
+                return;
+
+            Array.Resize(ref _buffer, _buffer.Length * 2);
+        }
+    }
+}

--- a/tools/fix/README.md
+++ b/tools/fix/README.md
@@ -1,6 +1,6 @@
 # FIX validator tooling
 
-`tools/fix/fix-validate.mjs` is a standalone FIX 4.4 tag=value validator for the opt-in FIX Conflated sandbox channel. It opens a real TCP session, performs `Logon`, consumes the automatic `MarketDataSnapshotFullRefresh` plus later `MarketDataIncrementalRefresh` messages, rebuilds the book locally, and periodically compares that state with `GET /book/{symbol}` from the HTTP side that `tools/ws/ws-validate.mjs` already expects.
+`tools/fix/fix-validate.mjs` is a standalone FIX 4.4 tag=value validator for the opt-in FIX Conflated sandbox channel. It opens a real TCP session, performs `Logon`, inflates the sandbox's continuous RFC 1950 ZLIB transport stream, consumes the automatic `MarketDataSnapshotFullRefresh` plus later `MarketDataIncrementalRefresh` messages, rebuilds the book locally, and periodically compares that state with `GET /book/{symbol}` from the HTTP side that `tools/ws/ws-validate.mjs` already expects.
 
 Today the server does **not** expose a production `/book/{symbol}` route, so
 that HTTP check is intentionally non-fatal and usually logs the cross-check as
@@ -65,3 +65,11 @@ HTTP_BASE=http://localhost:8080 node tools/fix/fix-validate.mjs localhost 9200 P
 
 This is the standalone client piece for issue #103 item 1. For the replay
 harness from issue #103 item 2, run `tools/fix-conflated-replay-validate.sh`.
+
+
+## Compression note
+
+The FIX sandbox now matches the real B3 UMDF Conflated wire contract: the TCP
+session carries one continuous ZLIB-compressed byte stream, not individually
+compressed messages. `fix-validate.mjs` handles that inflate step internally,
+so you still point it at the raw FIX TCP port.

--- a/tools/fix/fix-validate.mjs
+++ b/tools/fix/fix-validate.mjs
@@ -17,6 +17,7 @@
 // GET /book/{symbol} on the HTTP side used by the existing WS validator.
 
 import net from 'node:net';
+import zlib from 'node:zlib';
 
 const SOH = 0x01;
 const BEGIN_STRING = 'FIX.4.4';
@@ -71,6 +72,7 @@ const SENDER_COMP_ID = process.env.FIX_SENDER_COMP_ID || `FIX-VALIDATOR-${proces
 const TARGET_COMP_ID = process.env.FIX_TARGET_COMP_ID || 'SANDBOX';
 
 let inboundBuffer = Buffer.alloc(0);
+let inflatedBuffer = Buffer.alloc(0);
 let nextOutboundSeqNum = 1;
 let heartbeatIntervalSeconds = INITIAL_HEARTBEAT_SECONDS;
 let trackedSymbol = REQUESTED_SYMBOL;
@@ -107,6 +109,18 @@ console.log(`Connecting FIX validator to ${HOST}:${PORT} sender=${SENDER_COMP_ID
 
 const socket = net.createConnection({ host: HOST, port: PORT });
 socket.setNoDelay(true);
+const inflater = zlib.createInflate();
+
+inflater.on('data', chunk => {
+  lastReceivedAt = Date.now();
+  inflatedBuffer = Buffer.concat([inflatedBuffer, chunk]);
+  drainInbound(socket);
+});
+
+inflater.on('error', error => {
+  console.error(`Inbound zlib inflate failed: ${error.message}`);
+  socket.destroy(error);
+});
 
 socket.on('connect', () => {
   console.log('TCP connected; sending Logon');
@@ -141,9 +155,8 @@ socket.on('connect', () => {
 });
 
 socket.on('data', chunk => {
-  lastReceivedAt = Date.now();
   inboundBuffer = Buffer.concat([inboundBuffer, chunk]);
-  drainInbound(socket);
+  inflater.write(chunk);
 });
 
 socket.on('close', hadError => {
@@ -280,11 +293,12 @@ function requestShutdown(reason) {
   }
 
   socket.destroy();
+  inflater.destroy();
 }
 
 function drainInbound(currentSocket) {
-  while (inboundBuffer.length > 0) {
-    const decoded = decodeFrame(inboundBuffer);
+  while (inflatedBuffer.length > 0) {
+    const decoded = decodeFrame(inflatedBuffer);
     if (decoded.status === 'incomplete')
       return;
 
@@ -294,7 +308,7 @@ function drainInbound(currentSocket) {
       return;
     }
 
-    inboundBuffer = inboundBuffer.subarray(decoded.bytesConsumed);
+    inflatedBuffer = inflatedBuffer.subarray(decoded.bytesConsumed);
     handleMessage(decoded.message, currentSocket);
   }
 }


### PR DESCRIPTION
## Summary
- wrap each FIX Conflated TCP session's outbound socket in one continuous RFC 1950 ZLIB stream and flush after each encoded FIX message
- update FIX validator/tooling/tests to inflate the stream before parsing FIX frames
- document that compression is always-on for the sandbox when the listener is enabled because that matches the real B3 wire contract

## Decision
Compression is always on for the FIX Conflated sandbox transport once `UMDF_FIX_CONFLATED_ENABLED=true`. I did not add a toggle because the real B3 product uses a single continuous compressed stream per session, and making plaintext optional by default would weaken the sandbox's primary purpose: faithful wire compatibility.

## Flush behavior
The session write loop now holds one connection-lifetime `ZLibStream` and calls `FlushAsync()` after every encoded FIX frame. This was validated by the new real-socket test that reads raw wire bytes immediately after logon, confirms they are compressed (`0x78` header, not plaintext FIX), inflates them through a streaming inflater, and successfully decodes the logon ack.

## Validation
- `dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj`
  - Passed: 27, Failed: 0
- `dotnet test B3MarketDataPlatform.slnx`
  - All solution test projects passed with zero failures, including `B3.Umdf.FixConflated.Tests` (27), `B3.Umdf.Server.Tests` (212), and `B3.Umdf.Book.Tests` (269)
- Manual smoke attempt: `./tools/pcap/download-pcaps.sh` succeeded and replay harness started cleanly; raw socket probe confirmed zlib magic prefix `0x78 0x01`
- The updated validator successfully logged on over the compressed stream, but did not observe an initial `MarketDataSnapshotFullRefresh` during the short replay window, so the fresh-WS comparison step was skipped. This looks like a pre-existing behavior/timing gap worth reviewer follow-up, not a compression regression.

## Notes
- `gh issue view 107` could not be used locally because the available GitHub token is missing the `read:project` scope, so implementation followed the provided issue context.

Closes #107

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
