### PR TITLE
Closes #111: align FIX conflated content metadata

### DIFF
--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -276,13 +276,6 @@ Issue #108 added a manual/offline comparison pass against the local B3 sample
   model (`15`, `63`, `64`, `107`, `120`, `200`, `225`, `231`, `541`, `762`,
   `969`, `1151`, `320/322/393/560`, `6937`, `9749`), but many rarer fields
   remain unimplemented because no natural source exists in the current metadata.
-- **Incremental (`X`) messages use production-specific tags the sandbox never
-  writes.** Real captures consistently include message-level `75=TradeDate`,
-  sometimes `1021=MDBookType`, and entry-level `22`, `207`, frequent `276`,
-  `286`, `289`, `290`, `346`, `1500`, `9325`, and timestamp/order metadata
-  such as `37016`/`37017`. The sandbox currently writes only
-  `279`, `269`, `55`, `48`, optional `270/271`, `272`, `273`, optional `37`,
-  and optional `1003`.
 
 #### Secondary schema sanity check
 

--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -235,17 +235,47 @@ Issue #108 added a manual/offline comparison pass against the local B3 sample
 
 #### Observed discrepancies / gaps
 
-- **Snapshot (`W`) instrument identity differs materially.** Real captures use
+- **Snapshot (`W`) instrument identity is partially aligned now.** Real captures use
   an instrument-only header such as
   `35=W|...|128=LUX00|22=8|48=910000|207=BVMF|262=...|268=0|911=33943`,
   typically **without `55=Symbol`**, and include optional header `128` plus
-  `911=TotNumReports`. The sandbox currently emits `262`, `55`, `48`, `268`
-  and omits `22`, `207`, `128`, and `911`.
-- **Snapshot entry content is much thinner in the sandbox.** The derivatives
+  `911=TotNumReports`. The sandbox now emits `22`, `207`, optional `128`, and
+  `911`, but still keeps `55=Symbol` for compatibility and does not yet mirror
+  the full production header shape exactly.
+- **Snapshot entry content is still thinner than production, but less so.** The derivatives
   sample shows populated snapshot entries like
   `269=0|270=14|271=200|272=...|273=...|37017=...|37=...|288=88|290=1|1021=3`
-  and status-style entries like `269=c|...|336=1|625=21|342=...`. Our current
-  snapshot builder only writes `269/270/271/272/273/37`.
+  and status-style entries like `269=c|...|336=1|625=21|342=...`. The sandbox
+  now also emits `37016/37017` and `290`, but still does not cover the broader
+  production entry set.
+- **Incremental (`X`) messages are closer to production, but still simplified.** Real captures consistently include message-level `75=TradeDate`,
+  sometimes `1021=MDBookType`, and entry-level `22`, `207`, frequent `276`,
+  `286`, `289`, `290`, `346`, `1500`, `9325`, and timestamp/order metadata
+  such as `37016`/`37017`. The sandbox now writes `75`, `1021`, `22`, `207`,
+  `276`, `286`, `290`, `346`, `1500`, `9325`, `37016`, and `37017`, but some
+  values remain fixed placeholders where the current in-memory model has no
+  richer source of truth (for example constant position/order-count style
+  metadata).
+- **Incremental tag order differs.** Real captures lead each entry with
+  `279`, then usually instrument identity (`22/48/207`) before or around
+  `269`, whereas the sandbox now follows that pattern more closely but still
+  prioritizes parser stability over exact byte-for-byte ordering parity.
+- **SecurityStatus (`f`) coverage is now intentionally compact.** Real
+  samples are compact, typically
+  `35=f|...|60=...|75=...|336=1|625=18|1151=69`, with no broad instrument block
+  or descriptive text. The sandbox builder now centers on `60/75/336/625/1151`
+  plus routing identity, instead of the previous richer status payload.
+- **News (`B`) production tag `6940` is now modeled.** Real samples end
+  with `6940=17` (equities) or `6940=3` (derivatives); the sandbox builder now
+  exposes that field directly.
+- **SecurityList (`y`) coverage is expanded, but still partial.** The real capture repeatedly includes tags such as `15`,
+  `63`, `64`, `107`, `120`, `200`, `225`, `231`, `454/455/456`, `470`, `541`,
+  `667`, `762`, `870/871/872`, `969`, `980`, `1151`, `1231`, `1234`, `1300`,
+  `5151`, `6937`, `6938`, `7595`, `9748`, `9749`, and sometimes `320/322/393/560`.
+  The sandbox now emits a meaningful subset derived from the existing reference
+  model (`15`, `63`, `64`, `107`, `120`, `200`, `225`, `231`, `541`, `762`,
+  `969`, `1151`, `320/322/393/560`, `6937`, `9749`), but many rarer fields
+  remain unimplemented because no natural source exists in the current metadata.
 - **Incremental (`X`) messages use production-specific tags the sandbox never
   writes.** Real captures consistently include message-level `75=TradeDate`,
   sometimes `1021=MDBookType`, and entry-level `22`, `207`, frequent `276`,
@@ -253,27 +283,6 @@ Issue #108 added a manual/offline comparison pass against the local B3 sample
   such as `37016`/`37017`. The sandbox currently writes only
   `279`, `269`, `55`, `48`, optional `270/271`, `272`, `273`, optional `37`,
   and optional `1003`.
-- **Incremental tag order differs.** Real captures lead each entry with
-  `279`, then usually instrument identity (`22/48/207`) before or around
-  `269`, whereas the sandbox emits `279`, `269`, `55`, `48`, then price/size
-  fields. FIX allows this, but matching production ordering more closely may
-  help downstream interoperability testing.
-- **SecurityStatus (`f`) coverage is currently far from production.** Real
-  samples are compact, typically
-  `35=f|...|60=...|75=...|336=1|625=18|1151=69`, with no broad instrument block
-  or descriptive text. The sandbox instead emits a much richer instrument-heavy
-  message (`55/48/22/207/...`) plus optional `58`, `1149`, `1020`, volumes and
-  prices. This is valid per schema, but does **not** match what the sampled B3
-  feed actually populated.
-- **News (`B`) has at least one unmapped production tag.** Real samples end
-  with `6940=17` (equities) or `6940=3` (derivatives); the sandbox `News`
-  builder does not currently expose that field.
-- **SecurityList (`y`) is missing several production-populated fields in the
-  sandbox builder.** The real capture repeatedly includes tags such as `15`,
-  `63`, `64`, `107`, `120`, `200`, `225`, `231`, `454/455/456`, `470`, `541`,
-  `667`, `762`, `870/871/872`, `969`, `980`, `1151`, `1231`, `1234`, `1300`,
-  `5151`, `6937`, `6938`, `7595`, `9748`, `9749`, and sometimes `320/322/393/560`.
-  Our builder covers only a subset of that shape today.
 
 #### Secondary schema sanity check
 
@@ -294,11 +303,13 @@ Issue #108 added a manual/offline comparison pass against the local B3 sample
   close field-for-field reproduction of observed B3 production payloads.
 - If stricter production mirroring becomes important, the highest-value follow-up
   items are:
-  1. enrich `W`/`X` instrument identity and report-count fields (`22`, `207`,
-     `911`, and selected entry-level metadata);
-  2. revisit `SecurityStatus (f)` to match the much smaller production shape;
-  3. expand `SecurityList (y)` coverage for the consistently populated
-     instrument/reference fields seen in the real capture.
+  1. replace fixed placeholder values in `X` (`276`, `286`, `290`, `346`,
+     `1500`, `9325`) with richer per-entry sources if the upstream book/trade
+     model is extended;
+  2. continue expanding `SecurityList (y)` for fields still absent from the
+     current in-memory reference model;
+  3. decide whether exact production ordering / optional omission of `55` in
+     snapshots is worth the compatibility trade-off.
 
 ## Explicit deviations from the real B3 product
 

--- a/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
@@ -109,14 +109,18 @@ public sealed class FixApplicationMessageWriter : IDisposable
         if (!string.IsNullOrEmpty(mdReqId))
             offset += WriteStringField(destination[offset..], FixTags.MDReqId, mdReqId);
 
+        offset += WriteUtcDateField(destination[offset..], FixTags.TradeDate, header.SendingTime);
+        offset += WriteIntField(destination[offset..], FixTags.MDBookType, 3);
         offset += WriteIntField(destination[offset..], FixTags.NoMDEntries, entries.Length);
 
         foreach (ref readonly var entry in entries)
         {
             offset += WriteCharField(destination[offset..], FixTags.MDUpdateAction, (char)entry.UpdateAction);
+            offset += WriteStringField(destination[offset..], FixTags.SecurityIdSource, instrument.SecurityIdSource);
+            offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, instrument.SecurityId);
+            offset += WriteStringField(destination[offset..], FixTags.SecurityExchange, instrument.SecurityExchange);
             offset += WriteCharField(destination[offset..], FixTags.MDEntryType, (char)entry.EntryType);
             offset += WriteStringField(destination[offset..], FixTags.Symbol, instrument.Symbol);
-            offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, instrument.SecurityId);
 
             if ((entry.Fields & FixMarketDataEntryFields.Price) != 0)
                 offset += WriteScaledInt64Field(destination[offset..], FixTags.MDEntryPx, entry.Price, instrument.PriceScale);
@@ -125,11 +129,21 @@ public sealed class FixApplicationMessageWriter : IDisposable
 
             offset += WriteUtcDateField(destination[offset..], FixTags.MDEntryDate, entry.EntryTime);
             offset += WriteUtcTimeField(destination[offset..], FixTags.MDEntryTime, entry.EntryTime);
+            offset += WriteUtcDateField(destination[offset..], FixTags.MDInsertDate, entry.EntryTime);
+            offset += WriteUtcTimeField(destination[offset..], FixTags.MDInsertTime, entry.EntryTime);
+            offset += WriteStringField(destination[offset..], FixTags.MDStreamId, instrument.MdStreamId);
+            offset += WriteIntField(destination[offset..], FixTags.MDEntryPositionNo, 1);
+            offset += WriteIntField(destination[offset..], FixTags.NumberOfOrders, 1);
+            offset += WriteStringField(destination[offset..], FixTags.QuoteCondition, "A");
+            offset += WriteStringField(destination[offset..], FixTags.OpenCloseSettlFlag, "0");
 
             if ((entry.Fields & FixMarketDataEntryFields.OrderId) != 0)
                 offset += WriteUInt64Field(destination[offset..], FixTags.OrderId, entry.OrderId);
             if ((entry.Fields & FixMarketDataEntryFields.TradeId) != 0)
+            {
                 offset += WriteInt64Field(destination[offset..], FixTags.TradeId, entry.TradeId);
+                offset += WriteUtcDateField(destination[offset..], FixTags.LastTradeDate, entry.EntryTime);
+            }
         }
 
         return offset;
@@ -144,9 +158,14 @@ public sealed class FixApplicationMessageWriter : IDisposable
     {
         int offset = 0;
         offset += WriteSessionHeader(destination[offset..], header, FixMsgTypes.MarketDataSnapshotFullRefresh);
+        if (!string.IsNullOrEmpty(request.Instrument.DeliverToCompId))
+            offset += WriteStringField(destination[offset..], FixTags.DeliverToCompID, request.Instrument.DeliverToCompId!);
+        offset += WriteStringField(destination[offset..], FixTags.SecurityIdSource, request.Instrument.SecurityIdSource);
+        offset += WriteStringField(destination[offset..], FixTags.SecurityExchange, request.Instrument.SecurityExchange);
         offset += WriteStringField(destination[offset..], FixTags.MDReqId, request.MdReqId);
         offset += WriteStringField(destination[offset..], FixTags.Symbol, request.Instrument.Symbol);
         offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, request.Instrument.SecurityId);
+        offset += WriteIntField(destination[offset..], FixTags.TotNumReports, entryCount);
         offset += WriteIntField(destination[offset..], FixTags.NoMDEntries, entryCount);
 
         offset += WriteSnapshotSide(destination[offset..], book.Bids, FixMdEntryType.Bid, request.Instrument.PriceScale, header.SendingTime);
@@ -171,6 +190,9 @@ public sealed class FixApplicationMessageWriter : IDisposable
                 offset += WriteInt64Field(destination[offset..], FixTags.MDEntrySize, order.Quantity);
                 offset += WriteUtcDateField(destination[offset..], FixTags.MDEntryDate, entryTime);
                 offset += WriteUtcTimeField(destination[offset..], FixTags.MDEntryTime, entryTime);
+                offset += WriteUtcDateField(destination[offset..], FixTags.MDInsertDate, entryTime);
+                offset += WriteUtcTimeField(destination[offset..], FixTags.MDInsertTime, entryTime);
+                offset += WriteIntField(destination[offset..], FixTags.MDEntryPositionNo, 1);
                 offset += WriteUInt64Field(destination[offset..], FixTags.OrderId, order.OrderId);
             }
         }

--- a/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
@@ -43,13 +43,14 @@ public sealed record FixSecurityStatusDefinition
     public decimal? LastPrice { get; init; }
     public DateOnly? TradeDate { get; init; }
     public string? Text { get; init; }
+    public string? TradingSessionId { get; init; }
+    public string? TradingSessionSubId { get; init; }
 }
 
 public sealed record FixNewsDefinition
 {
     public required long OrigTimeNanoseconds { get; init; }
     public required string Headline { get; init; }
-    public required string NewsSource { get; init; }
     public string BodyText { get; init; } = string.Empty;
     public char? Urgency { get; init; }
     public string? NewsId { get; init; }
@@ -57,6 +58,7 @@ public sealed record FixNewsDefinition
     public string? Language { get; init; }
     public IReadOnlyList<FixInstrumentReference> RelatedInstruments { get; init; } = [];
     public string? UrlLink { get; init; }
+    public string NewsSourceCode { get; init; } = "17";
 }
 
 public readonly record struct FixMarketDataFeed(string MdFeedType, int MarketDepth, int MdBookType);
@@ -65,6 +67,15 @@ public sealed record FixSecurityListEntry
 {
     public required FixInstrumentReference Instrument { get; init; }
     public IReadOnlyList<FixMarketDataFeed> MarketDataFeeds { get; init; } = [];
+    public string? Currency { get; init; }
+    public string? SettlType { get; init; }
+    public DateOnly? SettlDate { get; init; }
+    public string? MaturityMonthYear { get; init; }
+    public DateOnly? IssueDate { get; init; }
+    public string? SettlCurrency { get; init; }
+    public string? Asset { get; init; }
+    public decimal? MinPriceIncrement { get; init; }
+    public decimal? TickSizeDenominator { get; init; }
 }
 
 public sealed record FixSecurityListDefinition
@@ -158,13 +169,20 @@ internal static class FixApplicationTags
     public const int Urgency = 61;
     public const int TradeDate = 75;
     public const int SecurityDescription = 107;
+    public const int Currency = 15;
+    public const int DeliverToCompId = 128;
     public const int Headline = 148;
     public const int UrlLink = 149;
     public const int NoRelatedSym = 146;
     public const int SecurityType = 167;
     public const int PutOrCall = 201;
     public const int SecurityExchange = 207;
+    public const int SettlCurrency = 120;
     public const int ContractMultiplier = 231;
+    public const int SettlType = 63;
+    public const int SettlDate = 64;
+    public const int MaturityMonthYear = 200;
+    public const int IssueDate = 225;
     public const int MDReqID = 262;
     public const int SubscriptionRequestType = 263;
     public const int MarketDepth = 264;
@@ -184,15 +202,20 @@ internal static class FixApplicationTags
     public const int HighPrice = 332;
     public const int LowPrice = 333;
     public const int TradSesOpenTime = 342;
+    public const int TradingSessionId = 336;
+    public const int TradingSessionSubId = 625;
     public const int GrossTradeAmt = 381;
     public const int TotalVolumeTraded = 387;
     public const int TotNoRelatedSym = 393;
     public const int LastPx = 31;
     public const int Product = 460;
     public const int CfiCode = 461;
+    public const int CountryOfIssue = 470;
     public const int MaturityDate = 541;
     public const int SecurityListRequestType = 559;
     public const int SecurityRequestResult = 560;
+    public const int MinPriceIncrement = 969;
+    public const int SecurityUpdateAction = 980;
     public const int SecuritySubType = 762;
     public const int LastFragment = 893;
     public const int MdBookType = 1021;
@@ -211,6 +234,8 @@ internal static class FixApplicationTags
     public const int TotalNumOfTrades = 6139;
     public const int SecurityUpdatesSince = 6935;
     public const int Language = 6936;
+    public const int Asset = 6937;
+    public const int TickSizeDenominator = 9749;
     public const int NewsSource = 6940;
     public const int InstrumentId = 9219;
     public const int NoSecurityGroups = 37022;

--- a/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
@@ -36,20 +36,38 @@ public readonly record struct FixApplicationSessionHeader(
 
 public readonly record struct FixMarketDataInstrument
 {
-    public FixMarketDataInstrument(string symbol, ulong securityId, int priceScale = 0)
+    public FixMarketDataInstrument(
+        string symbol,
+        ulong securityId,
+        int priceScale = 0,
+        string securityIdSource = "8",
+        string securityExchange = "BVMF",
+        string? deliverToCompId = null,
+        string mdStreamId = "3")
     {
         ArgumentNullException.ThrowIfNull(symbol);
+        ArgumentNullException.ThrowIfNull(securityIdSource);
+        ArgumentNullException.ThrowIfNull(securityExchange);
+        ArgumentNullException.ThrowIfNull(mdStreamId);
         if (priceScale is < 0 or > 18)
             throw new ArgumentOutOfRangeException(nameof(priceScale));
 
         Symbol = symbol;
         SecurityId = securityId;
         PriceScale = priceScale;
+        SecurityIdSource = securityIdSource;
+        SecurityExchange = securityExchange;
+        DeliverToCompId = deliverToCompId;
+        MdStreamId = mdStreamId;
     }
 
     public string Symbol { get; }
     public ulong SecurityId { get; }
     public int PriceScale { get; }
+    public string SecurityIdSource { get; }
+    public string SecurityExchange { get; }
+    public string? DeliverToCompId { get; }
+    public string MdStreamId { get; }
 
     public FixMdEntryType GetEntryType(BookSideType side)
         => side == BookSideType.Bid ? FixMdEntryType.Bid : FixMdEntryType.Offer;

--- a/src/B3.Umdf.FixConflated/FixConflatedChannelHandler.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedChannelHandler.cs
@@ -68,8 +68,8 @@ public sealed class FixConflatedChannelHandler : IBookEventHandler, IMarketDataE
             Instrument = instrument!,
             SecurityTradingStatus = tradingStatus,
             SourceTimestampNanoseconds = GetTimestampNanoseconds(info.LastUpdateTimestamp),
-            TradSesOpenTimeNanoseconds = info.TradSesOpenTime is ulong openTime ? checked((long)openTime) : null,
-            SecurityTradingEvent = info.TradingEvent,
+            TradingSessionId = "1",
+            TradingSessionSubId = tradingStatus.ToString(CultureInfo.InvariantCulture),
             TradeDate = info.LastUpdateTimestamp == 0
                 ? DateOnly.FromDateTime(_clock.UtcNow.UtcDateTime)
                 : DateOnly.FromDateTime(DateTimeOffset.FromUnixTimeMilliseconds((long)info.LastUpdateTimestamp / 1_000_000).UtcDateTime),
@@ -90,11 +90,11 @@ public sealed class FixConflatedChannelHandler : IBookEventHandler, IMarketDataE
         {
             OrigTimeNanoseconds = origTimeNanos > 0 ? origTimeNanos : GetTimestampNanoseconds(0),
             Headline = DecodeUtf8(headline),
-            NewsSource = source.ToString(CultureInfo.InvariantCulture),
             BodyText = DecodeUtf8(text),
             NewsId = newsId == 0 ? null : newsId.ToString(CultureInfo.InvariantCulture),
             LanguageCode = language == 0 ? null : language.ToString(CultureInfo.InvariantCulture),
             UrlLink = url.IsEmpty ? null : DecodeUtf8(url),
+            NewsSourceCode = source == 0 ? "17" : source.ToString(CultureInfo.InvariantCulture),
         }));
     }
 

--- a/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixSessionPrimitives.cs
@@ -106,6 +106,7 @@ internal static class FixTags
     public const int EncryptMethod = 98;
     public const int HeartBtInt = 108;
     public const int TestReqId = 112;
+    public const int DeliverToCompID = 128;
     public const int GapFillFlag = 123;
     public const int ResetSeqNumFlag = 141;
     public const int BeginSeqNo = 7;
@@ -119,10 +120,27 @@ internal static class FixTags
     public const int MDEntrySize = 271;
     public const int MDEntryDate = 272;
     public const int MDEntryTime = 273;
+    public const int QuoteCondition = 276;
     public const int TradeCondition = 277;
     public const int MDUpdateAction = 279;
+    public const int OpenCloseSettlFlag = 286;
+    public const int MDEntrySeller = 289;
+    public const int MDEntryPositionNo = 290;
+    public const int SecurityExchange = 207;
+    public const int SecurityIdSource = 22;
+    public const int TradeDate = 75;
+    public const int TradingSessionId = 336;
+    public const int NumberOfOrders = 346;
+    public const int TradingSessionSubId = 625;
+    public const int TotNumReports = 911;
+    public const int MDBookType = 1021;
+    public const int SecurityGroup = 1151;
+    public const int MDStreamId = 1500;
     public const int CheckSum = 10;
     public const int TradeId = 1003;
+    public const int LastTradeDate = 9325;
+    public const int MDInsertDate = 37016;
+    public const int MDInsertTime = 37017;
 }
 
 internal static class FixMsgTypes

--- a/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
@@ -11,11 +11,16 @@ internal static class FixSnapshotMessageBuilder
 
         var message = new FixMessage();
         message.Add(FixTags.MsgType, FixMsgTypes.MarketDataSnapshotFullRefresh);
+        if (!string.IsNullOrEmpty(request.Instrument.DeliverToCompId))
+            message.Add(FixTags.DeliverToCompID, request.Instrument.DeliverToCompId!);
+        message.Add(FixTags.SecurityIdSource, request.Instrument.SecurityIdSource);
+        message.Add(FixTags.SecurityExchange, request.Instrument.SecurityExchange);
         message.Add(FixTags.MDReqId, request.MdReqId);
         message.Add(FixTags.Symbol, request.Instrument.Symbol);
         message.Add(FixTags.SecurityId, request.Instrument.SecurityId.ToString(CultureInfo.InvariantCulture));
 
         int entryCount = book.Bids.OrderCount + book.Asks.OrderCount;
+        message.Add(FixTags.TotNumReports, entryCount);
         message.Add(FixTags.NoMDEntries, entryCount);
 
         string entryDate = entryTime.UtcDateTime.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
@@ -42,6 +47,9 @@ internal static class FixSnapshotMessageBuilder
                 message.Add(FixTags.MDEntrySize, order.Quantity.ToString(CultureInfo.InvariantCulture));
                 message.Add(FixTags.MDEntryDate, entryDate);
                 message.Add(FixTags.MDEntryTime, entryTime);
+                message.Add(FixTags.MDInsertDate, entryDate);
+                message.Add(FixTags.MDInsertTime, entryTime);
+                message.Add(FixTags.MDEntryPositionNo, 1);
                 message.Add(FixTags.OrderId, order.OrderId.ToString(CultureInfo.InvariantCulture));
             }
         }

--- a/src/B3.Umdf.FixConflated/NewsMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/NewsMessageBuilder.cs
@@ -9,7 +9,7 @@ public static class NewsMessageBuilder
     {
         ArgumentNullException.ThrowIfNull(definition);
         ArgumentException.ThrowIfNullOrEmpty(definition.Headline);
-        ArgumentException.ThrowIfNullOrEmpty(definition.NewsSource);
+        ArgumentException.ThrowIfNullOrEmpty(definition.NewsSourceCode);
 
         var message = new FixMessage();
         message.Add(FixTags.MsgType, FixApplicationMsgTypes.News);
@@ -19,7 +19,7 @@ public static class NewsMessageBuilder
                 FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.OrigTimeNanoseconds)));
         FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.Urgency, definition.Urgency);
         message.Add(FixApplicationTags.Headline, definition.Headline);
-        message.Add(FixApplicationTags.NewsSource, definition.NewsSource);
+        message.Add(FixApplicationTags.NewsSource, definition.NewsSourceCode);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.NewsId, definition.NewsId);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.LanguageCode, definition.LanguageCode);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Language, definition.Language);

--- a/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
@@ -38,6 +38,15 @@ public static class SecurityListMessageBuilder
                 }
 
                 FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, security.Instrument);
+                FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Currency, security.Currency);
+                FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SettlType, security.SettlType);
+                FixApplicationMessageBuilderSupport.AddOptionalDate(message, FixApplicationTags.SettlDate, security.SettlDate);
+                FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.MaturityMonthYear, security.MaturityMonthYear);
+                FixApplicationMessageBuilderSupport.AddOptionalDate(message, FixApplicationTags.IssueDate, security.IssueDate);
+                FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SettlCurrency, security.SettlCurrency);
+                FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Asset, security.Asset);
+                FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.MinPriceIncrement, security.MinPriceIncrement);
+                FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.TickSizeDenominator, security.TickSizeDenominator);
             }
         }
 

--- a/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
@@ -14,29 +14,18 @@ public static class SecurityStatusMessageBuilder
         var message = new FixMessage();
         message.Add(FixTags.MsgType, FixApplicationMsgTypes.SecurityStatus);
 
-        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityStatusReqId, definition.SecurityStatusReqId);
         FixApplicationMessageBuilderSupport.AppendInstrumentPrefix(message, definition.Instrument);
-        FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, definition.Instrument);
-        FixApplicationMessageBuilderSupport.AddOptionalBoolean(message, FixApplicationTags.UnsolicitedIndicator, definition.UnsolicitedIndicator);
-        FixApplicationMessageBuilderSupport.AddOptionalUnixNanosTimestamp(message, FixApplicationTags.TradSesOpenTime, definition.TradSesOpenTimeNanoseconds);
-        message.Add(FixApplicationTags.SecurityTradingStatus, definition.SecurityTradingStatus);
 
         DateOnly tradeDate = definition.TradeDate
             ?? DateOnly.FromDateTime(FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds).UtcDateTime);
-        message.Add(FixApplicationTags.TradeDate, FixApplicationMessageBuilderSupport.FormatLocalDate(tradeDate));
-
-        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.HaltReason, definition.HaltReason);
-        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.BuyVolume, definition.BuyVolume);
-        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.SellVolume, definition.SellVolume);
-        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.HighPrice, definition.HighPrice);
-        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LowPrice, definition.LowPrice);
-        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LastPx, definition.LastPrice);
         message.Add(
             FixApplicationTags.TransactTime,
             FixValueFormatting.FormatUtcTimestamp(
                 FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds)));
-        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Text, definition.Text);
-        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityTradingEvent, definition.SecurityTradingEvent);
+        message.Add(FixApplicationTags.TradeDate, FixApplicationMessageBuilderSupport.FormatLocalDate(tradeDate));
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.TradingSessionId, definition.TradingSessionId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.TradingSessionSubId, definition.TradingSessionSubId);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityGroup, definition.Instrument.SecurityGroup);
 
         return message;
     }

--- a/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
@@ -14,7 +14,7 @@ public sealed class FixApplicationMessageWriterTests
             "CLIENT",
             7,
             new DateTimeOffset(2026, 8, 12, 19, 10, 11, 123, TimeSpan.Zero));
-        var instrument = new FixMarketDataInstrument("PETR4", 1234, priceScale: 2);
+        var instrument = new FixMarketDataInstrument("PETR4", 1234, priceScale: 2, deliverToCompId: "LUX00");
         FixMarketDataIncrementalEntry[] entries =
         [
             new(
@@ -43,16 +43,22 @@ public sealed class FixApplicationMessageWriterTests
         Assert.Equal("CLIENT", GetRequired(decoded, FixTags.TargetCompId));
         Assert.Equal("7", GetRequired(decoded, FixTags.MsgSeqNum));
         Assert.Equal("2", GetRequired(decoded, FixTags.NoMDEntries));
+        Assert.Equal("20260812", GetRequired(decoded, FixTags.TradeDate));
+        Assert.Equal("3", GetRequired(decoded, FixTags.MDBookType));
 
         IReadOnlyList<IReadOnlyDictionary<int, string>> parsedEntries = ParseIncrementalEntries(decoded);
         Assert.Equal(2, parsedEntries.Count);
 
         Assert.Equal("0", parsedEntries[0][FixTags.MDUpdateAction]);
+        Assert.Equal("8", parsedEntries[0][FixTags.SecurityIdSource]);
+        Assert.Equal("BVMF", parsedEntries[0][FixTags.SecurityExchange]);
         Assert.Equal("0", parsedEntries[0][FixTags.MDEntryType]);
         Assert.Equal("PETR4", parsedEntries[0][FixTags.Symbol]);
         Assert.Equal("1234", parsedEntries[0][FixTags.SecurityId]);
         Assert.Equal("28.10", parsedEntries[0][FixTags.MDEntryPx]);
         Assert.Equal("100", parsedEntries[0][FixTags.MDEntrySize]);
+        Assert.Equal("3", parsedEntries[0][FixTags.MDStreamId]);
+        Assert.Equal("1", parsedEntries[0][FixTags.NumberOfOrders]);
         Assert.Equal("501", parsedEntries[0][FixTags.OrderId]);
 
         Assert.Equal("1", parsedEntries[1][FixTags.MDUpdateAction]);
@@ -71,7 +77,7 @@ public sealed class FixApplicationMessageWriterTests
             new DateTimeOffset(2026, 8, 12, 19, 15, 00, TimeSpan.Zero));
         var request = new FixMarketDataSnapshotRequest(
             "snap-1",
-            new FixMarketDataInstrument("PETR4", 1234, priceScale: 2));
+            new FixMarketDataInstrument("PETR4", 1234, priceScale: 2, deliverToCompId: "LUX00"));
         OrderBook book = CreateBook(
             (1UL, BookSideType.Bid, 2810L, 100L),
             (2UL, BookSideType.Bid, 2809L, 150L),
@@ -85,12 +91,17 @@ public sealed class FixApplicationMessageWriterTests
         Assert.Equal("snap-1", GetRequired(decoded, FixTags.MDReqId));
         Assert.Equal("PETR4", GetRequired(decoded, FixTags.Symbol));
         Assert.Equal("1234", GetRequired(decoded, FixTags.SecurityId));
+        Assert.Equal("8", GetRequired(decoded, FixTags.SecurityIdSource));
+        Assert.Equal("BVMF", GetRequired(decoded, FixTags.SecurityExchange));
+        Assert.Equal("LUX00", GetRequired(decoded, FixTags.DeliverToCompID));
         Assert.Equal("4", GetRequired(decoded, FixTags.NoMDEntries));
+        Assert.Equal("4", GetRequired(decoded, FixTags.TotNumReports));
 
         IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseSnapshotEntries(decoded);
         Assert.Equal(4, entries.Count);
         Assert.Equal("0", entries[0][FixTags.MDEntryType]);
         Assert.Equal("28.10", entries[0][FixTags.MDEntryPx]);
+        Assert.Equal("1", entries[0][FixTags.MDEntryPositionNo]);
         Assert.Equal("1", entries[0][FixTags.OrderId]);
         Assert.Equal("1", entries[2][FixTags.MDEntryType]);
         Assert.Equal("28.12", entries[2][FixTags.MDEntryPx]);

--- a/tests/B3.Umdf.FixConflated.Tests/NewsMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/NewsMessageBuilderTests.cs
@@ -12,7 +12,7 @@ public sealed class NewsMessageBuilderTests
             OrigTimeNanoseconds = 1_786_544_116_789_000_000,
             Headline = "PETR4 enters auction",
             BodyText = "Line one\nLine two",
-            NewsSource = "B3",
+            NewsSourceCode = "17",
             NewsId = "9001",
             LanguageCode = "pt",
             Language = "pt-BR",
@@ -33,7 +33,7 @@ public sealed class NewsMessageBuilderTests
         Assert.Equal(FixApplicationMsgTypes.News, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
         Assert.Equal("20260812-14:15:16.789", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.OrigTime));
         Assert.Equal("PETR4 enters auction", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Headline));
-        Assert.Equal("B3", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NewsSource));
+        Assert.Equal("17", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NewsSource));
         Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoRelatedSym));
         Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.NoLinesOfText));
         Assert.Equal(["Line one", "Line two"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.Text));

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
@@ -53,6 +53,15 @@ public sealed class SecurityListMessageBuilderTests
                         SecurityGroup = "EQUITY",
                         SecurityType = "CS"
                     },
+                    Currency = "BRL",
+                    SettlType = "0",
+                    SettlDate = new DateOnly(2026, 8, 13),
+                    MaturityMonthYear = "202608",
+                    IssueDate = new DateOnly(2020, 1, 2),
+                    SettlCurrency = "BRL",
+                    Asset = "PETR",
+                    MinPriceIncrement = 0.01m,
+                    TickSizeDenominator = 1m,
                     MarketDataFeeds =
                     [
                         new FixMarketDataFeed("BOOK", 10, 1),
@@ -73,6 +82,13 @@ public sealed class SecurityListMessageBuilderTests
                         SecurityGroup = "EQUITY",
                         SecurityType = "CS"
                     },
+                    Currency = "BRL",
+                    SettlType = "0",
+                    SettlDate = new DateOnly(2026, 8, 13),
+                    SettlCurrency = "BRL",
+                    Asset = "VALE",
+                    MinPriceIncrement = 0.01m,
+                    TickSizeDenominator = 1m,
                     MarketDataFeeds =
                     [
                         new FixMarketDataFeed("BOOK", 10, 1)
@@ -92,5 +108,8 @@ public sealed class SecurityListMessageBuilderTests
         FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
         Assert.Equal(["10", "1", "10"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.MarketDepth));
         Assert.Equal("list-1", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.SecurityListId));
+        Assert.Equal(["BRL", "BRL"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.Currency));
+        Assert.Equal(["0", "0"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.SettlType));
+        Assert.Equal(["BRL", "BRL"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.SettlCurrency));
     }
 }

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
@@ -5,7 +5,7 @@ namespace B3.Umdf.FixConflated.Tests;
 public sealed class SecurityStatusMessageBuilderTests
 {
     [Fact]
-    public void Build_Produces_Parseable_SecurityStatus_WithRequiredAndMappedFields()
+    public void Build_Produces_Compact_ProductionLike_SecurityStatus()
     {
         var message = SecurityStatusMessageBuilder.Build(new FixSecurityStatusDefinition
         {
@@ -26,27 +26,21 @@ public sealed class SecurityStatusMessageBuilderTests
             },
             SecurityTradingStatus = 2,
             SourceTimestampNanoseconds = 1_786_544_116_789_000_000,
-            SecurityTradingEvent = 1,
-            UnsolicitedIndicator = true,
-            Text = "Trading halted",
-            BuyVolume = 1200m,
-            SellVolume = 800m,
-            HighPrice = 31.25m,
-            LowPrice = 29.80m,
-            LastPrice = 30.15m
+            TradingSessionId = "1",
+            TradingSessionSubId = "18"
         });
 
         Assert.Equal(FixApplicationMsgTypes.SecurityStatus, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
         Assert.Equal("PETR4", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Symbol));
         Assert.Equal("12345", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityId));
-        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingStatus));
         Assert.Equal("20260812", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradeDate));
         Assert.Equal("20260812-14:15:16.789", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TransactTime));
-        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingEvent));
-        Assert.Equal("Y", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.UnsolicitedIndicator));
+        Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradingSessionId));
+        Assert.Equal("18", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradingSessionSubId));
+        Assert.Equal("EQUITY", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityGroup));
 
         FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
-        Assert.Equal("Trading halted", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.Text));
-        Assert.Equal("30.15", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.LastPx));
+        Assert.False(decoded.TryGetString(FixApplicationTags.SecurityTradingStatus, out _));
+        Assert.False(decoded.TryGetString(FixApplicationTags.Text, out _));
     }
 }


### PR DESCRIPTION
## Summary
- align FIX snapshot/incremental message metadata more closely with observed B3 captures
- shrink `SecurityStatus (f)` toward the compact production shape while keeping routing identity
- expand `SecurityList (y)` and `News (B)` field coverage using existing in-repo metadata only

## Implemented
1. **`W` / `X` alignment**
   - added snapshot header tags `22`, `207`, optional `128`, and `911`
   - added snapshot entry tags `37016`, `37017`, and `290`
   - added incremental message-level `75` and `1021`
   - added incremental entry tags `22`, `207`, `276`, `286`, `290`, `346`, `1500`, `9325`, `37016`, `37017`
   - reordered incremental entry identity to lead with `279`, then instrument identity, then `269`
   - note: several `X` tags currently use fixed/derived placeholders (`276=A`, `286=0`, `290=1`, `346=1`, `1500=3`) because the current order-book model has no richer source of truth yet
2. **`SecurityStatus (f)`**
   - reduced emitted shape to compact routing identity plus `60`, `75`, `336`, `625`, `1151`
3. **`SecurityList (y)`**
   - added a meaningful subset derivable from current metadata: `15`, `63`, `64`, `107`, `120`, `200`, `225`, `231`, `541`, `762`, `969`, `1151`, `6937`, `9749`
4. **`News (B)`**
   - added tag `6940` support via explicit `NewsSourceCode`

## Deferred / partial
- did **not** add every missing `W` / `X` / `y` production tag from the doc; fields without a natural in-memory source remain deferred
- smoke replay against `tools/fix/fix-validate.mjs` could not be completed in this worktree because `pcap/20250331_MBO_084_EQT_Incremental_FeedA.pcap` was absent locally, so the console app exited before opening the FIX port

## Validation
- `dotnet test tests/B3.Umdf.FixConflated.Tests/`
  - Passed: 27, Failed: 0
- smoke attempt:
  - `UMDF_FIX_CONFLATED_ENABLED=true UMDF_FIX_CONFLATED_PORT=9321 dotnet run --project src/B3.Umdf.ConsoleApp -- --pcap-prefix pcap/20250331_MBO_084_EQT --ws-port 8181 --speed 1`
  - result: failed due to missing local PCAP input (`pcap/20250331_MBO_084_EQT_Incremental_FeedA.pcap`), so no end-to-end FIX session was established

## Proprietary sample handling
- No proprietary B3 sample capture files were added, vendored, or committed
- implementation was based only on the documented gap descriptions and small illustrative tag snippets already present in repo docs
