### PR TITLE
Closes #117: add late-join snapshot coverage

### DIFF
--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -195,6 +195,17 @@ the existing `WireV2` WebSocket path (tracked by issue #103). All listed tooling
   `fix-validate.mjs` for the replay window, and reports the final fresh-WS
   `BookSnapshot` comparison as the pass/fail verdict. Mirrors the conventions
   of `tools/loss-resilience-test.sh`.
+- **Staged late-join replay harness** — `tools/fix-conflated-late-join-validate.sh`
+  keeps one replay running, then launches multiple fresh FIX validator clients
+  at staggered offsets (default `10,50,90%` of the run) so each connection gets
+  its own late-join `MarketDataSnapshotFullRefresh` cross-checked against a
+  simultaneous fresh WS subscribe snapshot. Example:
+  `WS_PORT=18080 FIX_PORT=19200 SPEED=1 FRESH_WS_COMPARE=0 tools/fix-conflated-late-join-validate.sh pcap/20250331_MBO_084_EQT 60 CPLE3 45`.
+  The optional fourth argument adds an initial delay before the staged joins,
+  useful when a replay needs time to leave instrument-definition bootstrap and
+  build a non-trivial book before the first "late join" probe. Set
+  `FRESH_WS_COMPARE=1` to require the extra fresh-WS cross-check when the
+  replay/window being used is known to answer WS subscribe snapshots promptly.
 - **Soak test coverage** — `tools/soak-test.sh` optionally starts the FIX
   listener alongside the WebSocket host (`ENABLE_FIX_CONFLATED=true`) and
   samples `FixConflatedMetrics` via the Prometheus `/metrics` endpoint into

--- a/tests/B3.Umdf.FixConflated.Tests/FixConflatedLateJoinSnapshotEndToEndTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixConflatedLateJoinSnapshotEndToEndTests.cs
@@ -1,0 +1,342 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Umdf.FixConflated.Tests;
+
+public sealed class FixConflatedLateJoinSnapshotEndToEndTests
+{
+    [Fact]
+    public async Task Late_Joining_Clients_Receive_Current_Full_Snapshot_And_Clean_Follow_On_Incrementals()
+    {
+        const ulong securityId = 1234;
+
+        var stateRegistry = new SymbolStateRegistry(NullLogger.Instance);
+        var staleBuffer = new StaleMboBuffer(NullLogger.Instance);
+        var bookManager = new BookManager(
+            logger: NullLogger<BookManager>.Instance,
+            stateRegistry: stateRegistry,
+            staleBuffer: staleBuffer);
+        var marketDataManager = new MarketDataManager(
+            logger: NullLogger<MarketDataManager>.Instance,
+            stateRegistry: stateRegistry);
+
+        InstrumentInfo info = marketDataManager.GetOrCreateInfo(securityId);
+        info.Symbol = "CPLE3";
+        info.PriceDivisor = 100;
+
+        OrderBook book = bookManager.GetOrCreateBook(securityId);
+        SeedInitialBook(book, securityId);
+
+        var resolver = new FixLiveInstrumentResolver(new SymbolRegistry(), [marketDataManager]);
+        var hub = new FixConflatedSessionHub();
+        using var channelHandler = new FixConflatedChannelHandler(
+            0,
+            hub,
+            resolver,
+            new FixConflatedMarketDataOptions
+            {
+                ConflationInterval = TimeSpan.FromMilliseconds(25),
+                PendingEventCapacity = 512,
+            });
+
+        int port = GetFreeTcpPort();
+        await using var server = new FixConflatedTcpServer(
+            hub,
+            new FixConflatedTcpServerOptions
+            {
+                OutboundQueueCapacity = 64,
+                SessionOptions = new FixSessionOptions
+                {
+                    ApplicationResendBufferCapacity = 32,
+                },
+            },
+            initialMessagesProvider: new FixInitialSnapshotProvider([bookManager], resolver).CreateMessages);
+        await server.StartAsync(port);
+
+        using var firstClient = new TcpClient { NoDelay = true };
+        await firstClient.ConnectAsync(IPAddress.Loopback, port);
+        using NetworkStream firstStream = firstClient.GetStream();
+        await using var firstFixClient = new FixSocketClientTestHelpers.InflatingFixClient(firstStream);
+
+        await firstFixClient.SendAsync(CreateLogon("CLIENT-LATE-1", "SANDBOX", 1));
+        await ReadAndAssertLogonAckAsync(firstFixClient, expectedSeqNum: "1");
+
+        FixMessage firstSnapshot = await firstFixClient.ReadMessageAsync();
+        AssertSnapshotMatchesBook(firstSnapshot, book, securityId, "2");
+
+        OrderBookEntry firstDeltaAdd = CreateEntry(securityId, 51001, BookSideType.Bid, 10025, 450);
+        book.Bids.AddOrUpdate(firstDeltaAdd);
+        channelHandler.OnOrderAdded(book, in firstDeltaAdd);
+
+        OrderBookEntry firstDeltaUpdate = CreateEntry(securityId, 11005, BookSideType.Bid, 10020, 990);
+        book.Bids.AddOrUpdate(firstDeltaUpdate);
+        channelHandler.OnOrderUpdated(book, in firstDeltaUpdate);
+
+        book.Asks.Remove(21004);
+        channelHandler.OnOrderDeleted(book, 21004, BookSideType.Ask);
+
+        FixMessage firstIncremental = await firstFixClient.ReadMessageAsync();
+        Assert.Equal("3", FixApplicationMessageTestHelpers.GetRequired(firstIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            firstIncremental,
+            CreateExpectedIncremental("0", firstDeltaAdd),
+            CreateExpectedIncremental("1", firstDeltaUpdate));
+
+        using var secondClient = new TcpClient { NoDelay = true };
+        await secondClient.ConnectAsync(IPAddress.Loopback, port);
+        using NetworkStream secondStream = secondClient.GetStream();
+        await using var secondFixClient = new FixSocketClientTestHelpers.InflatingFixClient(secondStream);
+
+        await secondFixClient.SendAsync(CreateLogon("CLIENT-LATE-2", "SANDBOX", 1));
+        await ReadAndAssertLogonAckAsync(secondFixClient, expectedSeqNum: "1");
+
+        FixMessage secondSnapshot = await secondFixClient.ReadMessageAsync();
+        AssertSnapshotMatchesBook(secondSnapshot, book, securityId, "2");
+
+        FixMessage firstDeleteIncremental = await firstFixClient.ReadMessageAsync();
+        Assert.Equal("4", FixApplicationMessageTestHelpers.GetRequired(firstDeleteIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            firstDeleteIncremental,
+            CreateExpectedIncremental("2", CreateEntry(securityId, 21004, BookSideType.Ask, 10050, 0)));
+
+        OrderBookEntry secondDeltaAdd = CreateEntry(securityId, 61001, BookSideType.Ask, 10065, 720);
+        book.Asks.AddOrUpdate(secondDeltaAdd);
+        channelHandler.OnOrderAdded(book, in secondDeltaAdd);
+
+        FixMessage firstSecondIncremental = await firstFixClient.ReadMessageAsync();
+        Assert.Equal("5", FixApplicationMessageTestHelpers.GetRequired(firstSecondIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            firstSecondIncremental,
+            CreateExpectedIncremental("0", secondDeltaAdd));
+
+        FixMessage secondIncremental = await secondFixClient.ReadMessageAsync();
+        Assert.Equal("3", FixApplicationMessageTestHelpers.GetRequired(secondIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            secondIncremental,
+            CreateExpectedIncremental("0", secondDeltaAdd));
+
+        OrderBookEntry secondDeltaUpdate = CreateEntry(securityId, 21003, BookSideType.Ask, 10055, 1230);
+        book.Asks.AddOrUpdate(secondDeltaUpdate);
+        channelHandler.OnOrderUpdated(book, in secondDeltaUpdate);
+
+        book.Bids.Remove(11001);
+        channelHandler.OnOrderDeleted(book, 11001, BookSideType.Bid);
+
+        FixMessage firstThirdIncremental = await firstFixClient.ReadMessageAsync();
+        Assert.Equal("6", FixApplicationMessageTestHelpers.GetRequired(firstThirdIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            firstThirdIncremental,
+            CreateExpectedIncremental("1", secondDeltaUpdate));
+
+        FixMessage secondThirdIncremental = await secondFixClient.ReadMessageAsync();
+        Assert.Equal("4", FixApplicationMessageTestHelpers.GetRequired(secondThirdIncremental, FixTags.MsgSeqNum));
+        AssertIncrementalContains(
+            secondThirdIncremental,
+            CreateExpectedIncremental("1", secondDeltaUpdate));
+    }
+
+    private static void SeedInitialBook(OrderBook book, ulong securityId)
+    {
+        foreach (OrderBookEntry bid in new[]
+                 {
+                     CreateEntry(securityId, 11001, BookSideType.Bid, 10000, 1000),
+                     CreateEntry(securityId, 11002, BookSideType.Bid, 10000, 700),
+                     CreateEntry(securityId, 11003, BookSideType.Bid, 10010, 800),
+                     CreateEntry(securityId, 11004, BookSideType.Bid, 10010, 650),
+                     CreateEntry(securityId, 11005, BookSideType.Bid, 10020, 900),
+                     CreateEntry(securityId, 11006, BookSideType.Bid, 10020, 600),
+                     CreateEntry(securityId, 11007, BookSideType.Bid, 10030, 500),
+                     CreateEntry(securityId, 11008, BookSideType.Bid, 10030, 400),
+                 })
+        {
+            book.Bids.Add(bid);
+        }
+
+        foreach (OrderBookEntry ask in new[]
+                 {
+                     CreateEntry(securityId, 21001, BookSideType.Ask, 10040, 750),
+                     CreateEntry(securityId, 21002, BookSideType.Ask, 10040, 500),
+                     CreateEntry(securityId, 21003, BookSideType.Ask, 10050, 1250),
+                     CreateEntry(securityId, 21004, BookSideType.Ask, 10050, 300),
+                     CreateEntry(securityId, 21005, BookSideType.Ask, 10060, 800),
+                     CreateEntry(securityId, 21006, BookSideType.Ask, 10060, 450),
+                     CreateEntry(securityId, 21007, BookSideType.Ask, 10070, 900),
+                     CreateEntry(securityId, 21008, BookSideType.Ask, 10070, 550),
+                 })
+        {
+            book.Asks.Add(ask);
+        }
+    }
+
+    private static async Task ReadAndAssertLogonAckAsync(FixSocketClientTestHelpers.InflatingFixClient client, string expectedSeqNum)
+    {
+        FixMessage logonAck = await client.ReadMessageAsync();
+        Assert.Equal(FixMsgTypes.Logon, FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgType));
+        Assert.Equal(expectedSeqNum, FixApplicationMessageTestHelpers.GetRequired(logonAck, FixTags.MsgSeqNum));
+    }
+
+    private static void AssertSnapshotMatchesBook(FixMessage snapshot, OrderBook book, ulong securityId, string expectedSeqNum)
+    {
+        Assert.Equal(FixMsgTypes.MarketDataSnapshotFullRefresh, FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgType));
+        Assert.Equal(expectedSeqNum, FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MsgSeqNum));
+        Assert.Equal($"SNAP-{securityId}", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.MDReqId));
+        Assert.Equal("CPLE3", FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.Symbol));
+        Assert.Equal(securityId.ToString(), FixApplicationMessageTestHelpers.GetRequired(snapshot, FixTags.SecurityId));
+
+        IReadOnlyList<IReadOnlyDictionary<int, string>> snapshotEntries = ParseSnapshotEntries(snapshot);
+        List<ExpectedSnapshotEntry> expected = BuildExpectedSnapshotEntries(book);
+        Assert.Equal(expected.Count, snapshotEntries.Count);
+
+        List<ExpectedSnapshotEntry> actual = snapshotEntries
+            .Select(static entry => new ExpectedSnapshotEntry(
+                Type: entry[FixTags.MDEntryType],
+                OrderId: entry[FixTags.OrderId],
+                Price: entry[FixTags.MDEntryPx],
+                Size: entry[FixTags.MDEntrySize]))
+            .ToList();
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static void AssertIncrementalContains(FixMessage message, params ExpectedIncrementalEntry[] expectedEntries)
+    {
+        IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseIncrementalEntries(message);
+        List<ExpectedIncrementalEntry> actual = entries
+            .Select(static entry => new ExpectedIncrementalEntry(
+                UpdateAction: entry[FixTags.MDUpdateAction],
+                Type: entry[FixTags.MDEntryType],
+                OrderId: entry[FixTags.OrderId],
+                Price: entry.TryGetValue(FixTags.MDEntryPx, out string? px) ? px : null,
+                Size: entry.TryGetValue(FixTags.MDEntrySize, out string? size) ? size : null))
+            .ToList();
+
+        Assert.Equal(expectedEntries.Length, actual.Count);
+        Assert.Equal(expectedEntries, actual);
+    }
+
+    private static List<ExpectedSnapshotEntry> BuildExpectedSnapshotEntries(OrderBook book)
+    {
+        return book.Bids.PriceLevels
+            .SelectMany(static level => level.Value.Select(order => new ExpectedSnapshotEntry("0", order.OrderId.ToString(), FormatPrice(order.Price), order.Quantity.ToString())))
+            .Concat(book.Asks.PriceLevels
+                .SelectMany(static level => level.Value.Select(order => new ExpectedSnapshotEntry("1", order.OrderId.ToString(), FormatPrice(order.Price), order.Quantity.ToString()))))
+            .ToList();
+    }
+
+    private static ExpectedIncrementalEntry CreateExpectedIncremental(string updateAction, OrderBookEntry entry)
+        => new(
+            UpdateAction: updateAction,
+            Type: entry.Side == BookSideType.Bid ? "0" : "1",
+            OrderId: entry.OrderId.ToString(),
+            Price: updateAction == "2" ? null : FormatPrice(entry.Price),
+            Size: updateAction == "2" ? null : entry.Quantity.ToString());
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseSnapshotEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDEntryType)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static IReadOnlyList<IReadOnlyDictionary<int, string>> ParseIncrementalEntries(FixMessage message)
+    {
+        List<IReadOnlyDictionary<int, string>> entries = [];
+        Dictionary<int, string>? current = null;
+        bool insideGroup = false;
+
+        foreach (FixField field in message.Fields)
+        {
+            if (field.Tag == FixTags.NoMDEntries)
+            {
+                insideGroup = true;
+                continue;
+            }
+
+            if (!insideGroup || field.Tag == FixTags.CheckSum)
+                continue;
+
+            if (field.Tag == FixTags.MDUpdateAction)
+            {
+                current = [];
+                entries.Add(current);
+            }
+
+            Assert.NotNull(current);
+            current[field.Tag] = field.Value;
+        }
+
+        return entries;
+    }
+
+    private static FixMessage CreateLogon(string senderCompId, string targetCompId, int seqNum)
+    {
+        var message = new FixMessage();
+        message.Add(FixTags.BeginString, FixMessageCodec.BeginString);
+        message.Add(FixTags.MsgType, FixMsgTypes.Logon);
+        message.Add(FixTags.SenderCompId, senderCompId);
+        message.Add(FixTags.TargetCompId, targetCompId);
+        message.Add(FixTags.MsgSeqNum, seqNum);
+        message.Add(FixTags.SendingTime, "20260814-15:00:00.000");
+        message.Add(FixTags.EncryptMethod, 0);
+        message.Add(FixTags.HeartBtInt, 30);
+        return message;
+    }
+
+    private static OrderBookEntry CreateEntry(ulong securityId, ulong orderId, BookSideType side, long price, long quantity)
+    {
+        return new OrderBookEntry
+        {
+            SecurityId = securityId,
+            OrderId = orderId,
+            Side = side,
+            Price = price,
+            Quantity = quantity,
+        };
+    }
+
+    private static string FormatPrice(long rawPrice) => (rawPrice / 100m).ToString("0.00");
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private sealed record ExpectedSnapshotEntry(string Type, string OrderId, string Price, string Size);
+
+    private sealed record ExpectedIncrementalEntry(string UpdateAction, string Type, string OrderId, string? Price, string? Size);
+}

--- a/tools/fix-conflated-late-join-validate.sh
+++ b/tools/fix-conflated-late-join-validate.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Replay-driven staged late-join FIX vs fresh WS snapshot validation harness.
+#
+# Starts one long-lived ConsoleApp replay, then launches multiple sequential
+# FIX validator connections at staggered offsets to prove late joiners receive
+# a correct current MarketDataSnapshotFullRefresh and continue cleanly from
+# that state.
+#
+# Usage:
+#   tools/fix-conflated-late-join-validate.sh <pcap-prefix> [duration-seconds] [symbol] [start-delay-seconds]
+#
+# Optional env:
+#   OUT=artifacts/fix-conflated-late-join-validate/<name>
+#   WS_PORT=18080
+#   FIX_PORT=19200
+#   SPEED=1
+#   CHECK_INTERVAL_MS=5000
+#   JOIN_PERCENTAGES=10,50,90
+#   PER_CLIENT_RUN_SECONDS=12
+#   FRESH_WS_COMPARE=0
+#   STARTUP_TIMEOUT_SECONDS=60
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PREFIX="${1:?usage: $0 <pcap-prefix> [duration-seconds] [symbol] [start-delay-seconds]}"
+DURATION_SECONDS="${2:-60}"
+REQUESTED_SYMBOL="${3:-${SYMBOL:-}}"
+START_DELAY_SECONDS="${4:-0}"
+OUT="${OUT:-artifacts/fix-conflated-late-join-validate/$(date +%Y%m%d-%H%M%S)}"
+HOST="${HOST:-127.0.0.1}"
+WS_PORT="${WS_PORT:-18080}"
+FIX_PORT="${FIX_PORT:-19200}"
+SPEED="${SPEED:-1}"
+CHECK_INTERVAL_MS="${CHECK_INTERVAL_MS:-5000}"
+JOIN_PERCENTAGES="${JOIN_PERCENTAGES:-10,50,90}"
+PER_CLIENT_RUN_SECONDS="${PER_CLIENT_RUN_SECONDS:-12}"
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-60}"
+FRESH_WS_COMPARE="${FRESH_WS_COMPARE:-0}"
+
+APP_DLL="src/B3.Umdf.ConsoleApp/bin/Release/net10.0/B3.Umdf.ConsoleApp.dll"
+BUILD_LOG="$OUT/build.log"
+CONSUMER_LOG="$OUT/consumer.log"
+SUMMARY_LOG="$OUT/summary.log"
+
+CONSUMER_PID=""
+
+mkdir -p "$OUT"
+
+cleanup() {
+  local rc=$?
+  trap - EXIT INT TERM
+  if [ -n "${CONSUMER_PID:-}" ] && kill -0 "$CONSUMER_PID" 2>/dev/null; then
+    kill -9 "$CONSUMER_PID" 2>/dev/null || true
+    wait "$CONSUMER_PID" 2>/dev/null || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+echo "## fix-conflated late-join validate prefix=$PREFIX duration=${DURATION_SECONDS}s out=$OUT" | tee "$SUMMARY_LOG"
+
+if [ ! -f "$APP_DLL" ]; then
+  echo "[build] $APP_DLL missing; building Release ConsoleApp" | tee -a "$SUMMARY_LOG"
+  dotnet build src/B3.Umdf.ConsoleApp/B3.Umdf.ConsoleApp.csproj -c Release >"$BUILD_LOG" 2>&1
+fi
+
+if ! node -e "require.resolve('ws', { paths: ['tools/ws'] })" >/dev/null 2>&1; then
+  echo "[error] missing Node dependency 'ws'; install with: npm install --prefix tools ws" | tee -a "$SUMMARY_LOG"
+  exit 1
+fi
+
+wait_for_http() {
+  local url="$1" timeout_s="$2" start_ts
+  start_ts="$(date +%s)"
+  while true; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [ $(( $(date +%s) - start_ts )) -ge "$timeout_s" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+wait_for_tcp() {
+  local host="$1" port="$2" timeout_s="$3"
+  python3 - "$host" "$port" "$timeout_s" <<'PY'
+import socket, sys, time
+host = sys.argv[1]
+port = int(sys.argv[2])
+timeout_s = int(sys.argv[3])
+deadline = time.time() + timeout_s
+while time.time() < deadline:
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            sys.exit(0)
+    except OSError:
+        time.sleep(1)
+sys.exit(1)
+PY
+}
+
+discover_symbol() {
+  local response discovered
+  response="$(curl -fsS "http://$HOST:$WS_PORT/symbols?limit=20")"
+  discovered="$(printf '%s' "$response" | python3 -c 'import json, sys; data=json.load(sys.stdin); syms=data.get("symbols") or []; want="CPLE3"; print(want if want in syms else (syms[0] if syms else ""))')"
+  printf '%s\n' "$discovered"
+}
+
+echo "[start] launching ConsoleApp (ws=$WS_PORT fix=$FIX_PORT speed=$SPEED)" | tee -a "$SUMMARY_LOG"
+UMDF_FIX_CONFLATED_ENABLED=true \
+UMDF_FIX_CONFLATED_PORT="$FIX_PORT" \
+dotnet "$APP_DLL" \
+  --pcap-prefix "$PREFIX" \
+  --ws-port "$WS_PORT" \
+  --speed "$SPEED" \
+  >"$CONSUMER_LOG" 2>&1 &
+CONSUMER_PID=$!
+
+wait_for_http "http://$HOST:$WS_PORT/ready" "$STARTUP_TIMEOUT_SECONDS" || { echo "[error] HTTP not ready" | tee -a "$SUMMARY_LOG"; exit 1; }
+wait_for_tcp "$HOST" "$FIX_PORT" "$STARTUP_TIMEOUT_SECONDS" || { echo "[error] FIX not ready" | tee -a "$SUMMARY_LOG"; exit 1; }
+
+SYMBOL_TO_USE="$REQUESTED_SYMBOL"
+if [ -z "$SYMBOL_TO_USE" ]; then
+  SYMBOL_TO_USE="$(discover_symbol)"
+fi
+if [ -z "$SYMBOL_TO_USE" ]; then
+  echo "[error] failed to discover symbol" | tee -a "$SUMMARY_LOG"
+  exit 1
+fi
+
+echo "[ready] symbol=$SYMBOL_TO_USE joinPercentages=$JOIN_PERCENTAGES startDelay=${START_DELAY_SECONDS}s" | tee -a "$SUMMARY_LOG"
+if [ "$FRESH_WS_COMPARE" = "1" ]; then
+  echo "[mode] fresh WS comparison enabled" | tee -a "$SUMMARY_LOG"
+else
+  echo "[mode] snapshot/incremental-only validation (fresh WS compare disabled)" | tee -a "$SUMMARY_LOG"
+fi
+
+if [ "$START_DELAY_SECONDS" -gt 0 ]; then
+  echo "[wait] initial start delay ${START_DELAY_SECONDS}s" | tee -a "$SUMMARY_LOG"
+  sleep "$START_DELAY_SECONDS"
+fi
+
+IFS=',' read -r -a percentages <<< "$JOIN_PERCENTAGES"
+last_offset=0
+overall_rc=0
+
+for pct in "${percentages[@]}"; do
+  pct="${pct// /}"
+  offset=$(( DURATION_SECONDS * pct / 100 ))
+  sleep_seconds=$(( offset - last_offset ))
+  if [ "$sleep_seconds" -gt 0 ]; then
+    echo "[wait] sleeping ${sleep_seconds}s until ${pct}% join point" | tee -a "$SUMMARY_LOG"
+    sleep "$sleep_seconds"
+  fi
+  last_offset="$offset"
+
+  client_log="$OUT/client-${pct}.log"
+  echo "[stage] join=${pct}% elapsed=${offset}s symbol=$SYMBOL_TO_USE" | tee -a "$SUMMARY_LOG"
+  set +e
+  RUN_SECONDS="$PER_CLIENT_RUN_SECONDS" \
+  CHECK_INTERVAL_MS="$CHECK_INTERVAL_MS" \
+  HTTP_BASE="http://$HOST:$WS_PORT" \
+  WS_SNAPSHOT_COMPARE_URL="${FRESH_WS_COMPARE:+ws://$HOST:$WS_PORT/ws}" \
+  WS_SNAPSHOT_TIMEOUT_MS=15000 \
+  node tools/fix/fix-validate.mjs "$HOST" "$FIX_PORT" "$SYMBOL_TO_USE" >"$client_log" 2>&1
+  rc=$?
+  set -e
+
+  result_line="$(grep -E '^(✅ MATCH|❌ MISMATCH) \| fresh-ws ' "$client_log" | tail -1 || true)"
+  snapshot_line="$(grep -E '^Snapshot loaded for ' "$client_log" | tail -1 || true)"
+  if [ "$FRESH_WS_COMPARE" = "1" ] && [ "$rc" -eq 0 ] && [ -n "$result_line" ]; then
+    echo "[pass] join=${pct}% $result_line" | tee -a "$SUMMARY_LOG"
+  elif [ "$FRESH_WS_COMPARE" != "1" ] && [ "$rc" -eq 0 ] && [ -n "$snapshot_line" ]; then
+    echo "[pass] join=${pct}% ${snapshot_line#Snapshot loaded for }" | tee -a "$SUMMARY_LOG"
+  else
+    overall_rc=2
+    echo "[fail] join=${pct}% rc=$rc ${result_line:-${snapshot_line:-'(no verdict)'}}" | tee -a "$SUMMARY_LOG"
+  fi
+done
+
+if kill -0 "$CONSUMER_PID" 2>/dev/null; then
+  kill -9 "$CONSUMER_PID" 2>/dev/null || true
+  wait "$CONSUMER_PID" 2>/dev/null || true
+fi
+
+echo "Logs:" | tee -a "$SUMMARY_LOG"
+echo "  consumer $CONSUMER_LOG" | tee -a "$SUMMARY_LOG"
+echo "  summary  $SUMMARY_LOG" | tee -a "$SUMMARY_LOG"
+
+exit "$overall_rc"


### PR DESCRIPTION
## Summary
- add an end-to-end FIX Conflated late-join integration test that seeds a non-trivial book before client logon, verifies the late joiner's `MarketDataSnapshotFullRefresh` exactly matches current book state, then proves subsequent incrementals apply cleanly
- add a companion staged replay script `tools/fix-conflated-late-join-validate.sh` for sequential late-join probes during one replay run
- document the new validator in `docs/FIX-CONFLATED-SANDBOX.md`

Closes #117.

## Automated test coverage added
Added `tests/B3.Umdf.FixConflated.Tests/FixConflatedLateJoinSnapshotEndToEndTests.cs` covering:
- first late client connects after the book is already populated and receives the full current snapshot
- incremental updates after that late snapshot apply cleanly for the already-connected client
- a second client connects even later and receives a fully up-to-date snapshot reflecting the newer generation of book state
- subsequent incrementals after the second late join still apply cleanly to both clients

The test constructs book state directly in-process rather than relying on PCAP timing, so it is deterministic and CI-friendly.

## Test evidence
Executed:
- `dotnet test tests/B3.Umdf.FixConflated.Tests/`

Result:
- Passed: 28
- Failed: 0
- Skipped: 0

## Replay/manual validation note
I also added and ran `tools/fix-conflated-late-join-validate.sh` against the existing `pcap/20250331_MBO_084_EQT*` fixtures.

What happened:
- initial attempts at speed 1 hit environment/timing instability during replay bootstrap and fresh-WS comparison
- retrying with unique ports, higher replay speed (`--speed 3`), and a 40s warm-up still did **not** produce a clean conclusive pass
- one staged join produced an empty FIX snapshot for `CPLE3`; another produced a FIX-vs-fresh-WS mismatch late in replay

Important scope note:
- this PR does **not** claim positive real-replay validation for late joins
- the replay harness result is currently inconclusive/noisy in this environment and should be treated as harness/timing instability evidence, not as a proven server bug from this PR alone
- the authoritative proof added by this PR is the new automated end-to-end test coverage

## Manual replay command used
Example retry command run during this PR work:
- `WS_PORT=18103 FIX_PORT=19303 SPEED=3 JOIN_PERCENTAGES=50,90 PER_CLIENT_RUN_SECONDS=15 FRESH_WS_COMPARE=1 tools/fix-conflated-late-join-validate.sh pcap/20250331_MBO_084_EQT 20 CPLE3 40`
