### PR TITLE
Document subscription model gaps in FIX Conflated docs

### DIFF
--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -79,6 +79,19 @@ it needs the `schema-upgrade` label.
   `SequenceReset`-based gap-fill across reconnects), matching B3's
   documented behavior. Recovery after such a disconnect happens via a
   fresh `MarketDataSnapshotFullRefresh` on the new session.
+- Instrument subscription is per-session: a client that sends an inbound
+  `MarketDataRequest` (`V`) is scoped to just the requested `SecurityID`(s)
+  for both the initial snapshot and subsequent incrementals, with
+  `MarketDataRequestReject` (`Y`) for malformed/unknown instruments. A
+  client that never sends `V` still gets the legacy full-broadcast
+  (every known instrument) automatically after `Logon`, for backward
+  compatibility with older tooling. See "Message catalog" and the
+  consolidated drift map below for details (issue #116).
+- A client may join at any point during an active session (mid-replay,
+  not just immediately after startup) and still receives a correct,
+  current full snapshot on `Logon`/subscribe, followed by clean
+  incrementals from that point forward — proven by an automated
+  multi-client, staggered-join end-to-end test (issue #117).
 
 ## Message catalog
 

--- a/tools/fix/README.md
+++ b/tools/fix/README.md
@@ -33,10 +33,26 @@ node tools/fix/fix-validate.mjs localhost 9200
 
 If you omit `symbol`, the validator adopts the first snapshot symbol it sees.
 That is useful for quick smoke runs when you do not yet know which symbols are
-present in the current replay.
+present in the current replay. In this legacy auto-discovery mode the
+validator does **not** send an explicit `MarketDataRequest`; it simply waits
+for the server's legacy full-broadcast snapshot (sent automatically after
+`Logon` to any session that never subscribes explicitly) and tracks whatever
+instrument shows up first.
+
+To exercise the real per-session subscription/filtering model instead (issue
+#116), set `FIX_SECURITY_ID` to a known numeric `SecurityID` — the validator
+then sends an explicit `MarketDataRequest` (`V`, `SubscriptionRequestType=1`)
+for that instrument right after `Logon`, and the server scopes the snapshot
+and all subsequent incrementals to just that `SecurityID`. An unknown
+`SecurityID` gets a `MarketDataRequestReject` (`Y`) instead of a snapshot.
 
 Useful environment overrides:
 
+- `FIX_SECURITY_ID` — numeric `SecurityID` to subscribe to explicitly via
+  `MarketDataRequest` (`V`). When unset (and no CLI `symbol` has produced a
+  tracked `SecurityID` yet), the validator skips sending `V` entirely and
+  relies on the legacy automatic full-broadcast snapshot instead — it never
+  crashes or blocks waiting for a value that was never provided.
 - `FIX_SENDER_COMP_ID` / `FIX_TARGET_COMP_ID` — override the default CompIDs. The script defaults to a unique sender ID per run so repeated manual runs do not trip the sandbox reconnect rule for stale `MsgSeqNum` values.
 - `FIX_HEARTBEAT_SEC` — requested heartbeat interval (default `30`).
 - `CHECK_INTERVAL_MS` — `/book` comparison interval (default `5000`).


### PR DESCRIPTION
Follow-up doc-only fixes found while reviewing the FIX Conflated docs for completeness after #116/#117/#118/#119/#120:

- `docs/FIX-CONFLATED-SANDBOX.md`: the 'Session behavior (summary)' section (the first thing a reader sees) never mentioned the per-session `MarketDataRequest` subscription model or late-join snapshot correctness — both were only described deep in the message catalog / drift map. Added 2 bullets there.
- `tools/fix/README.md`: PR #118 added the `FIX_SECURITY_ID` env var and the explicit-subscribe flow, but the tooling README was never updated — a user reading only this README would not know the flag exists. Documented it plus the legacy auto-discovery fallback behavior.

No code changes.