### PR TITLE
Add independent QuickFIX/n interop check for FIX Conflated sandbox

### DIFF
--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -242,6 +242,16 @@ the existing `WireV2` WebSocket path (tracked by issue #103). All listed tooling
   samples `FixConflatedMetrics` via the Prometheus `/metrics` endpoint into
   the same long-running RSS/GC/counter stability CSV used for the WireV2
   path.
+- **Independent third-party FIX engine interop check** —
+  `tools/fix/quickfixn-interop/` points the maintained
+  [QuickFIX/n](https://github.com/connamara/quickfixn) engine
+  (`QuickFIXn.Core` NuGet package) at the sandbox through a small
+  zlib-inflating TCP proxy, using the vendored data dictionary. This proves
+  session/encoding parseability against a real, independent, non-self-written
+  FIX engine — a check `fix-validate.mjs` alone cannot provide, since it is
+  this repo's own code. See its README for setup and known gotchas. Scope
+  note: this validates protocol/encoding correctness, not content-level
+  fidelity against the real B3 product.
 - **Perf-smoke benchmark coverage** — not yet added (deliberately deferred,
   best-effort/optional item in issue #103).
 

--- a/tools/fix/quickfixn-interop/QuickFixInteropCheck/Program.cs
+++ b/tools/fix/quickfixn-interop/QuickFixInteropCheck/Program.cs
@@ -1,0 +1,58 @@
+using System;
+using QuickFix;
+
+namespace QuickFixInteropCheck;
+
+/// <summary>
+/// Minimal QuickFIX/n application callback set. Its only job is to log every
+/// admin/application message it sends and receives so a human (or a script
+/// scanning its stdout) can confirm the sandbox's FIX 4.4 session and
+/// application messages are genuinely parseable by an independent,
+/// third-party FIX engine — not just by this repo's own
+/// tools/fix/fix-validate.mjs.
+/// </summary>
+public sealed class LoggingApplication : IApplication
+{
+    public void OnCreate(SessionID sessionID) => Console.WriteLine($"[app] OnCreate {sessionID}");
+
+    public void OnLogon(SessionID sessionID) => Console.WriteLine($"[app] OnLogon {sessionID}");
+
+    public void OnLogout(SessionID sessionID) => Console.WriteLine($"[app] OnLogout {sessionID}");
+
+    public void ToAdmin(Message message, SessionID sessionID)
+        => Console.WriteLine($"[app] ToAdmin: {Readable(message)}");
+
+    public void FromAdmin(Message message, SessionID sessionID)
+        => Console.WriteLine($"[app] FromAdmin: {Readable(message)}");
+
+    public void ToApp(Message message, SessionID sessionID)
+        => Console.WriteLine($"[app] ToApp: {Readable(message)}");
+
+    public void FromApp(Message message, SessionID sessionID)
+        => Console.WriteLine($"[app] FromApp (MsgType={message.Header.GetString(35)}): {Readable(message)}");
+
+    private static string Readable(Message message) => message.ToString().Replace('\u0001', '|');
+}
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        string cfgPath = args.Length > 0 ? args[0] : "quickfixn-session.cfg";
+        var settings = new SessionSettings(cfgPath);
+        var application = new LoggingApplication();
+
+        // In-memory store/log: this is a throwaway interop probe, not a
+        // persistent session — there is nothing worth keeping across runs.
+        var storeFactory = new QuickFix.Store.MemoryStoreFactory();
+        var logFactory = new QuickFix.Logger.ScreenLogFactory(settings);
+
+        using var initiator = new QuickFix.Transport.SocketInitiator(application, storeFactory, settings, logFactory);
+        initiator.Start();
+
+        Console.WriteLine("[main] initiator started, press Enter to stop...");
+        Console.ReadLine();
+
+        initiator.Stop();
+    }
+}

--- a/tools/fix/quickfixn-interop/QuickFixInteropCheck/QuickFixInteropCheck.csproj
+++ b/tools/fix/quickfixn-interop/QuickFixInteropCheck/QuickFixInteropCheck.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Standalone interop-check tool. Deliberately NOT referenced by, or a
+    dependency of, any project under src/ or tests/ — it exists purely as an
+    independent, third-party-engine validation harness for the FIX Conflated
+    sandbox (see ../README.md) and must never affect the main solution build.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Maintained QuickFIX/n fork (github.com/connamara/quickfixn), NOT the
+         stale 2016 `quickfixn` NuGet package, which is .NET Framework-only
+         and mis-parses messages under modern .NET compat shims. -->
+    <PackageReference Include="QuickFIXn.Core" Version="1.14.1" />
+  </ItemGroup>
+
+</Project>

--- a/tools/fix/quickfixn-interop/QuickFixInteropCheck/quickfixn-session.cfg
+++ b/tools/fix/quickfixn-interop/QuickFixInteropCheck/quickfixn-session.cfg
@@ -1,0 +1,15 @@
+[DEFAULT]
+ConnectionType=initiator
+ReconnectInterval=5
+StartTime=00:00:00
+EndTime=00:00:00
+UseDataDictionary=Y
+DataDictionary=../../../../schemas/fix-conflated/FIX44_UMDFConflated.xml
+HeartBtInt=30
+SocketConnectHost=127.0.0.1
+SocketConnectPort=19401
+
+[SESSION]
+BeginString=FIX.4.4
+SenderCompID=QUICKFIXN-INTEROP-CHECK
+TargetCompID=SANDBOX

--- a/tools/fix/quickfixn-interop/README.md
+++ b/tools/fix/quickfixn-interop/README.md
@@ -1,0 +1,115 @@
+# QuickFIX/n interop check
+
+This is a small, independent third-party-engine validation harness for the
+FIX Conflated sandbox channel (`docs/FIX-CONFLATED-SANDBOX.md`). It exists to
+answer a specific question that `tools/fix/fix-validate.mjs` alone cannot:
+**is the sandbox's FIX 4.4 session/encoding actually parseable by a real,
+independent, battle-tested FIX engine — not just by our own bespoke
+validator?** `fix-validate.mjs` is written by/for this repo, so a clean run
+of it proves internal self-consistency, not genuine interoperability.
+
+[QuickFIX/n](https://github.com/connamara/quickfixn) is a mature, widely used
+open-source FIX engine. Pointing it at this sandbox (using the vendored
+`schemas/fix-conflated/FIX44_UMDFConflated.xml` data dictionary) gives an
+outside, non-self-referential check that Logon/session semantics and
+application message shapes (`W`, `X`, `f`, `B`, …) are genuinely well-formed
+FIX 4.4, not just "well-formed enough for our own parser to agree with
+itself."
+
+**Important scope note:** this only validates session/encoding/parseability
+against a generic FIX engine — it does **not** validate content-level
+fidelity against the real B3 UMDF Conflated product (tag values, book
+semantics, conflation behavior). That level of validation is covered
+separately by the message-content comparison against real B3 sample captures
+documented in `docs/FIX-CONFLATED-SANDBOX.md`, and ultimately only B3's own
+(proprietary, non-public) certification script can fully validate production
+fidelity.
+
+## Why a proxy is needed
+
+The sandbox wraps its entire outbound (server→client) byte stream in a
+single continuous RFC 1950 ZLIB stream from the moment a client connects —
+see `src/B3.Umdf.FixConflated/FixZlibCompression.cs` and
+`FixTcpClientSession.cs`. This always-on transport compression matches the
+real B3 product, but no generic FIX engine (including QuickFIX/n) understands
+it out of the box; QuickFIX/n expects plain SOH-delimited FIX bytes directly
+on the socket.
+
+`zlib-proxy.mjs` is a small transparent TCP proxy that inflates only the
+server→client leg (the sandbox never compresses the client→server leg) before
+handing bytes to QuickFIX/n, and passes the client→server leg straight
+through unmodified. QuickFIX/n itself never needs to know the sandbox
+transport is compressed.
+
+## Prerequisites
+
+- A running FIX Conflated sandbox server: `UMDF_FIX_CONFLATED_ENABLED=true`
+  and `UMDF_FIX_CONFLATED_PORT=<port>` when starting `src/B3.Umdf.ConsoleApp`
+  (see `docs/FIX-CONFLATED-SANDBOX.md` → "Enabling").
+- Node.js (for `zlib-proxy.mjs`).
+- .NET 10 SDK (already required by this repo) to build/run
+  `QuickFixInteropCheck`, which restores the maintained
+  [`QuickFIXn.Core`](https://www.nuget.org/packages/QuickFIXn.Core) NuGet
+  package (not the stale 2016 `quickfixn` package — see "Gotcha" below).
+
+## Usage
+
+1. Start the sandbox server with the FIX listener enabled, for example:
+
+   ```bash
+   UMDF_FIX_CONFLATED_ENABLED=true UMDF_FIX_CONFLATED_PORT=19400 \
+     dotnet run --project src/B3.Umdf.ConsoleApp -- \
+     --pcap-prefix pcap/20250331_MBO_084_EQT --ws-port 18200 --speed 1
+   ```
+
+2. Start the zlib-inflating proxy in front of the real FIX port, on a
+   separate local port (`19401` here, matching the default
+   `quickfixn-session.cfg`):
+
+   ```bash
+   node tools/fix/quickfixn-interop/zlib-proxy.mjs 19401 127.0.0.1 19400
+   ```
+
+3. Run the QuickFIX/n interop check, pointed at the proxy port via
+   `quickfixn-session.cfg`:
+
+   ```bash
+   cd tools/fix/quickfixn-interop/QuickFixInteropCheck
+   dotnet run -- quickfixn-session.cfg
+   ```
+
+4. Watch the console output. A successful run logs `OnLogon`, followed by
+   `FromApp` lines for every `SecurityStatus (f)` / `MarketDataSnapshotFullRefresh (W)`
+   / `MarketDataIncrementalRefresh (X)` / `News (B)` message the server sends,
+   with no `MessageParseError` and no unexpected `OnLogout`. Press Enter (or
+   Ctrl+C) to stop.
+
+If you want to also exercise the per-session subscription model added by
+issue #116 (`MarketDataRequest` / `V`), that currently requires the
+tooling-side request to be sent explicitly — QuickFIX/n's `SocketInitiator`
+alone does not do this. `tools/fix/fix-validate.mjs` (with `FIX_SECURITY_ID`
+set) remains the right tool for that specific flow; this interop check is
+intentionally scoped to logon + legacy full-broadcast session validation
+against a real third-party engine.
+
+## Gotcha: use `QuickFIXn.Core`, not `quickfixn`
+
+The original `quickfixn` NuGet package (last published in 2016, targeting
+old .NET Framework versions only) fails with a `MessageParseError` /
+`FormatException` when run under the modern .NET compat shim used by this
+repo — it mis-parses the very first byte of the `BeginString` field. This is
+a bug in that stale package under a modern runtime, **not** a bug in the
+sandbox's FIX output (confirmed independently via a raw Python socket probe
+that showed the sandbox's bytes are well-formed FIX 4.4). Use the maintained
+fork's package, `QuickFIXn.Core` (already referenced by
+`QuickFixInteropCheck.csproj`), which targets `net8.0`/`net10.0` natively and
+has no such issue.
+
+## Isolation from the main solution
+
+`QuickFixInteropCheck.csproj` is a standalone project, not referenced by (or
+a dependency of) anything under `src/` or `tests/`, and this repo has no
+top-level `.sln` tying projects together implicitly. It will never be built
+or restored as part of the normal `dotnet build`/`dotnet test` flow for the
+main platform — you must `dotnet build`/`dotnet run` inside this directory
+explicitly.

--- a/tools/fix/quickfixn-interop/zlib-proxy.mjs
+++ b/tools/fix/quickfixn-interop/zlib-proxy.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Transparent TCP proxy that inflates the FIX Conflated sandbox's single
+// continuous RFC 1950 ZLIB server->client stream, so that a generic FIX
+// engine with no knowledge of this sandbox's transport compression (e.g.
+// QuickFIX/n) can connect to what looks like a plain, uncompressed FIX
+// session. See README.md in this directory for the full rationale and usage.
+//
+// Client -> server bytes are NOT touched: the sandbox only compresses
+// outbound/server->client bytes (see src/B3.Umdf.FixConflated/FixZlibCompression.cs
+// and FixTcpClientSession.cs), so this proxy only needs to inflate one leg.
+//
+// Usage: node zlib-proxy.mjs <listenPort> <upstreamHost> <upstreamPort>
+
+import net from 'node:net';
+import zlib from 'node:zlib';
+
+const [, , listenPortArg, upstreamHost, upstreamPortArg] = process.argv;
+if (!listenPortArg || !upstreamHost || !upstreamPortArg) {
+  console.error('Usage: node zlib-proxy.mjs <listenPort> <upstreamHost> <upstreamPort>');
+  process.exit(1);
+}
+
+const listenPort = Number(listenPortArg);
+const upstreamPort = Number(upstreamPortArg);
+
+const server = net.createServer((downstream) => {
+  console.log(`[proxy] downstream connected from ${downstream.remoteAddress}:${downstream.remotePort}`);
+
+  const upstream = net.connect(upstreamPort, upstreamHost, () => {
+    console.log(`[proxy] connected upstream ${upstreamHost}:${upstreamPort}`);
+  });
+
+  const inflate = zlib.createInflate();
+  inflate.on('error', (err) => {
+    console.error('[proxy] inflate error', err.message);
+    downstream.destroy();
+    upstream.destroy();
+  });
+
+  // upstream (server, compressed) -> inflate -> downstream (plain FIX client)
+  upstream.pipe(inflate).pipe(downstream);
+
+  // downstream (client, plain) -> upstream (server, plain) — no compression
+  // on this leg, matching the sandbox's actual transport behavior.
+  downstream.pipe(upstream);
+
+  const cleanup = (who) => (err) => {
+    if (err) console.error(`[proxy] ${who} error`, err.message);
+    downstream.destroy();
+    upstream.destroy();
+  };
+
+  downstream.on('error', cleanup('downstream'));
+  upstream.on('error', cleanup('upstream'));
+  downstream.on('close', () => { console.log('[proxy] downstream closed'); upstream.destroy(); });
+  upstream.on('close', () => { console.log('[proxy] upstream closed'); downstream.destroy(); });
+});
+
+server.listen(listenPort, () => {
+  console.log(`[proxy] listening on ${listenPort}, forwarding to ${upstreamHost}:${upstreamPort} (inflating server->client leg)`);
+});


### PR DESCRIPTION
## Summary
Adds `tools/fix/quickfixn-interop/`, a standalone third-party FIX engine interop check for the FIX Conflated sandbox. Answers "is our FIX 4.4 output genuinely parseable by a real, independent FIX engine, not just by our own `fix-validate.mjs`?"

## What's new
- `zlib-proxy.mjs`: transparent TCP proxy inflating the sandbox's continuous RFC 1950 ZLIB server→client stream (the sandbox's transport model is not natively understood by generic FIX engines).
- `QuickFixInteropCheck/`: minimal QuickFIX/n initiator (using the maintained `QuickFIXn.Core` package) pointed at the sandbox through the proxy, using the vendored `schemas/fix-conflated/FIX44_UMDFConflated.xml` data dictionary. Logs every admin/application message exchanged.
- `README.md`: rationale, setup steps, explicit scope note (validates session/encoding parseability, **not** content fidelity vs. the real B3 product — that remains covered by the existing sample-capture comparison in `docs/FIX-CONFLATED-SANDBOX.md`), and a documented gotcha (the stale 2016 `quickfixn` NuGet package mis-parses messages under modern .NET — use `QuickFIXn.Core` instead, confirmed via a raw socket probe that our own bytes are well-formed FIX 4.4).
- One new cross-reference bullet added to `docs/FIX-CONFLATED-SANDBOX.md`'s "Validation & tooling" section.

## Verification
Ran the full flow end-to-end against a real running sandbox server (replay-driven): Logon succeeded, `SecurityStatus (f)` and `MarketDataSnapshotFullRefresh (W)` messages were consumed by QuickFIX/n with **zero** `MessageParseError` and no unexpected `OnLogout`.

## Isolation
`QuickFixInteropCheck.csproj` is standalone — not referenced by any `src/`/`tests/` project. This repo has no top-level `.sln`, so this addition never affects the normal `dotnet build`/`dotnet test` flow. No CI changes.