### PR TITLE
FIX Conflated sandbox: add perf-smoke benchmark coverage (closes #103 item 5)

### DIFF
--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: benchmarks/B3.Umdf.Book.Benchmarks
         run: |
           dotnet run -c Release --no-build -- \
-            --filter '*BookManagerOnPacketBenchmarks*|*BookSideBenchmarks*' \
+            --filter '*BookManagerOnPacketBenchmarks*' '*BookSideBenchmarks*' \
             --exporters json
 
       - name: Run Feed benchmarks (MpscPacketRing)
@@ -48,6 +48,13 @@ jobs:
         run: |
           dotnet run -c Release --no-build -- \
             --filter '*MpscPacketRingBenchmarks*' \
+            --exporters json
+
+      - name: Run FIX Conflated benchmarks (writer encode + conflate/flush)
+        working-directory: benchmarks/B3.Umdf.FixConflated.Benchmarks
+        run: |
+          dotnet run -c Release --no-build -- \
+            --filter '*FixApplicationMessageWriterBenchmarks*' '*FixConflatedMarketDataPublisherBenchmarks*' \
             --exporters json
 
       - name: Upload BDN artifacts
@@ -58,6 +65,7 @@ jobs:
           path: |
             benchmarks/B3.Umdf.Book.Benchmarks/BenchmarkDotNet.Artifacts/
             benchmarks/B3.Umdf.Feed.Benchmarks/BenchmarkDotNet.Artifacts/
+            benchmarks/B3.Umdf.FixConflated.Benchmarks/BenchmarkDotNet.Artifacts/
           if-no-files-found: warn
           retention-days: 14
 
@@ -65,12 +73,13 @@ jobs:
         run: |
           shopt -s nullglob
           reports=()
-          for f in benchmarks/B3.Umdf.Book.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full.json \
-                  benchmarks/B3.Umdf.Feed.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full.json; do
+          for f in benchmarks/B3.Umdf.Book.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json \
+                  benchmarks/B3.Umdf.Feed.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json \
+                  benchmarks/B3.Umdf.FixConflated.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json; do
             reports+=(--report "$f")
           done
           if [ ${#reports[@]} -eq 0 ]; then
-            echo "No BenchmarkDotNet -report-full.json files found." >&2
+            echo "No BenchmarkDotNet -report-full-compressed.json files found." >&2
             exit 1
           fi
           dotnet run -c Release --no-build --project tools/PerfBaselineCompare -- \

--- a/B3MarketDataPlatform.slnx
+++ b/B3MarketDataPlatform.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/B3.Umdf.Book.Benchmarks/B3.Umdf.Book.Benchmarks.csproj" />
     <Project Path="benchmarks/B3.Umdf.Feed.Benchmarks/B3.Umdf.Feed.Benchmarks.csproj" />
+    <Project Path="benchmarks/B3.Umdf.FixConflated.Benchmarks/B3.Umdf.FixConflated.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/B3.MarketData.WebSocketClient/B3.MarketData.WebSocketClient.csproj" />

--- a/benchmarks/B3.Umdf.FixConflated.Benchmarks/B3.Umdf.FixConflated.Benchmarks.csproj
+++ b/benchmarks/B3.Umdf.FixConflated.Benchmarks/B3.Umdf.FixConflated.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Umdf.Book\B3.Umdf.Book.csproj" />
+    <ProjectReference Include="..\..\src\B3.Umdf.FixConflated\B3.Umdf.FixConflated.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/B3.Umdf.FixConflated.Benchmarks/Program.cs
+++ b/benchmarks/B3.Umdf.FixConflated.Benchmarks/Program.cs
@@ -1,0 +1,172 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using B3.Umdf.Book;
+using B3.Umdf.FixConflated;
+
+BenchmarkSwitcher.FromAssemblies([typeof(FixApplicationMessageWriterBenchmarks).Assembly]).Run(args);
+
+// Direct encode hot path: FixApplicationMessageWriter builds the raw FIX
+// tag=value frame with no conflation/queueing involved. Mirrors how
+// FixConflatedMarketDataPublisher.EmitTrade / FlushBuffered call it once a
+// batch of entries has already been assembled.
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 2, iterationCount: 5)]
+public class FixApplicationMessageWriterBenchmarks
+{
+    private static readonly FixApplicationSessionHeader Header = new(
+        "B3UMDFC",
+        "CLIENT01",
+        1,
+        new DateTimeOffset(2026, 8, 25, 13, 30, 0, TimeSpan.Zero));
+
+    private static readonly FixMarketDataInstrument Instrument = new(
+        "PETR4",
+        1234,
+        priceScale: 2,
+        deliverToCompId: "LUX00");
+
+    private static readonly FixMarketDataSnapshotRequest SnapshotRequest = new("bench-snap", Instrument);
+
+    [Params(1, 10, 50)]
+    public int EntryCount;
+
+    private FixApplicationMessageWriter _writer = null!;
+    private FixMarketDataIncrementalEntry[] _incrementalEntries = null!;
+    private OrderBook _book = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _writer = new FixApplicationMessageWriter();
+
+        _incrementalEntries = new FixMarketDataIncrementalEntry[EntryCount];
+        for (int i = 0; i < EntryCount; i++)
+        {
+            _incrementalEntries[i] = new FixMarketDataIncrementalEntry(
+                (i & 1) == 0 ? FixMdUpdateAction.New : FixMdUpdateAction.Change,
+                FixMdEntryType.Bid,
+                Header.SendingTime,
+                FixMarketDataEntryFields.Price | FixMarketDataEntryFields.Size | FixMarketDataEntryFields.OrderId,
+                Price: 2800 + i,
+                Size: 100 + i,
+                OrderId: (ulong)(500 + i));
+        }
+
+        _book = new OrderBook(Instrument.SecurityId);
+        for (int i = 0; i < EntryCount; i++)
+        {
+            var entry = new OrderBookEntry
+            {
+                OrderId = (ulong)(500 + i),
+                Side = (i & 1) == 0 ? BookSideType.Bid : BookSideType.Ask,
+                SecurityId = _book.SecurityId,
+                Price = 2800 + i,
+                Quantity = 100 + i,
+            };
+            _book.GetSide(entry.Side).Add(in entry);
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _writer.Dispose();
+
+    [Benchmark(Description = "WriteIncrementalRefresh: N MD entries")]
+    public int WriteIncrementalRefresh()
+        => _writer.WriteIncrementalRefresh(Header, Instrument, _incrementalEntries).Length;
+
+    [Benchmark(Description = "WriteSnapshotFullRefresh: N book levels")]
+    public int WriteSnapshotFullRefresh()
+        => _writer.WriteSnapshotFullRefresh(Header, SnapshotRequest, _book).Length;
+}
+
+// Full conflation + encode hot path: book delta events flow through the
+// publisher's lock-free queues, get conflated per (SecurityId, Side) bucket,
+// and are flushed (encoded + handed to the sink) in one pass. Exercises the
+// same code path as production's periodic FlushIfDue() worker loop, but
+// with StartBackgroundWorker=false so the benchmark controls flush timing.
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 2, iterationCount: 5)]
+public class FixConflatedMarketDataPublisherBenchmarks
+{
+    private sealed class NullSink : IFixApplicationMessageSink
+    {
+        public static readonly NullSink Instance = new();
+        public void OnMessage(ReadOnlyMemory<byte> message) { }
+    }
+
+    private sealed class SequentialHeaderProvider : IFixApplicationHeaderProvider
+    {
+        private int _seqNum;
+
+        public FixApplicationSessionHeader NextHeader(DateTimeOffset sendingTime)
+            => new("B3UMDFC", "CLIENT01", Interlocked.Increment(ref _seqNum), sendingTime);
+    }
+
+    private sealed class StaticInstrumentResolver : IFixMarketDataInstrumentResolver
+    {
+        private readonly Dictionary<ulong, FixMarketDataInstrument> _instruments;
+
+        public StaticInstrumentResolver(Dictionary<ulong, FixMarketDataInstrument> instruments)
+            => _instruments = instruments;
+
+        public bool TryResolve(ulong securityId, out FixMarketDataInstrument instrument)
+            => _instruments.TryGetValue(securityId, out instrument);
+    }
+
+    [Params(64, 512)]
+    public int SymbolCount;
+
+    [Params(4)]
+    public int UpdatesPerSymbol;
+
+    private FixConflatedMarketDataPublisher _publisher = null!;
+    private OrderBook[] _books = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var instruments = new Dictionary<ulong, FixMarketDataInstrument>();
+        _books = new OrderBook[SymbolCount];
+        for (int s = 0; s < SymbolCount; s++)
+        {
+            ulong securityId = (ulong)(1000 + s);
+            instruments[securityId] = new FixMarketDataInstrument($"SYM{s}", securityId, priceScale: 2);
+            _books[s] = new OrderBook(securityId);
+        }
+
+        _publisher = new FixConflatedMarketDataPublisher(
+            NullSink.Instance,
+            new SequentialHeaderProvider(),
+            new StaticInstrumentResolver(instruments),
+            new FixConflatedMarketDataOptions { StartBackgroundWorker = false });
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        // Re-populate the pending-delta queues before each measured
+        // invocation; FlushNow() drains them, so state doesn't roll over.
+        for (int s = 0; s < SymbolCount; s++)
+        {
+            OrderBook book = _books[s];
+            for (int u = 0; u < UpdatesPerSymbol; u++)
+            {
+                var entry = new OrderBookEntry
+                {
+                    OrderId = (ulong)(1 + u),
+                    Side = BookSideType.Bid,
+                    SecurityId = book.SecurityId,
+                    Price = 2800 + u,
+                    Quantity = 100 + u,
+                };
+                _publisher.OnOrderUpdated(book, in entry);
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _publisher.Dispose();
+
+    [Benchmark(Description = "Conflate + encode: SymbolCount x UpdatesPerSymbol book deltas")]
+    public void FlushNow() => _publisher.FlushNow();
+}

--- a/docs/FIX-CONFLATED-SANDBOX.md
+++ b/docs/FIX-CONFLATED-SANDBOX.md
@@ -252,8 +252,18 @@ the existing `WireV2` WebSocket path (tracked by issue #103). All listed tooling
   this repo's own code. See its README for setup and known gotchas. Scope
   note: this validates protocol/encoding correctness, not content-level
   fidelity against the real B3 product.
-- **Perf-smoke benchmark coverage** — not yet added (deliberately deferred,
-  best-effort/optional item in issue #103).
+- **Perf-smoke benchmark coverage** —
+  `benchmarks/B3.Umdf.FixConflated.Benchmarks/` (BenchmarkDotNet, wired into
+  the opt-in `.github/workflows/perf-smoke.yml` alongside the Book/Feed
+  suites) covers the encode hot path (`FixApplicationMessageWriter.
+  WriteIncrementalRefresh`/`WriteSnapshotFullRefresh`) and the conflation +
+  encode hot path (`FixConflatedMarketDataPublisher.FlushNow`, exercised via
+  `OnOrderUpdated` deltas fanned out across many symbols). Baselines under
+  `docs/perf/baselines/FixApplicationMessageWriterBenchmarks.*.json` and
+  `FixConflatedMarketDataPublisherBenchmarks.*.json` are currently
+  schema-only placeholders (no committed prose number to seed them from);
+  see `docs/perf/baselines/README.md` for how to populate real numbers once
+  captured on a stable runner. Closes issue #103 item 5 (best-effort/optional).
 
 ### Message-content validation against real B3 sample captures
 

--- a/docs/perf/baselines/FixApplicationMessageWriterBenchmarks.WriteIncrementalRefresh-Entries10.json
+++ b/docs/perf/baselines/FixApplicationMessageWriterBenchmarks.WriteIncrementalRefresh-Entries10.json
@@ -1,0 +1,11 @@
+{
+  "benchmark": "FixApplicationMessageWriterBenchmarks",
+  "method": "WriteIncrementalRefresh",
+  "params": { "EntryCount": 10 },
+  "captured_at": null,
+  "captured_on": "not yet captured on stable hardware",
+  "runtime": "net10.0 Release",
+  "metrics": {},
+  "tolerance": { "mean_pct": 20, "alloc_pct": 25 },
+  "notes": "Schema-only placeholder for the FIX Conflated sandbox encode hot path (issue #103 item 5, best-effort). No prose baseline number exists yet; metrics are omitted on purpose and will be populated once the perf-smoke workflow runs on a stable runner."
+}

--- a/docs/perf/baselines/FixApplicationMessageWriterBenchmarks.WriteSnapshotFullRefresh-Entries10.json
+++ b/docs/perf/baselines/FixApplicationMessageWriterBenchmarks.WriteSnapshotFullRefresh-Entries10.json
@@ -1,0 +1,11 @@
+{
+  "benchmark": "FixApplicationMessageWriterBenchmarks",
+  "method": "WriteSnapshotFullRefresh",
+  "params": { "EntryCount": 10 },
+  "captured_at": null,
+  "captured_on": "not yet captured on stable hardware",
+  "runtime": "net10.0 Release",
+  "metrics": {},
+  "tolerance": { "mean_pct": 20, "alloc_pct": 25 },
+  "notes": "Schema-only placeholder for the FIX Conflated sandbox encode hot path (issue #103 item 5, best-effort). No prose baseline number exists yet; metrics are omitted on purpose and will be populated once the perf-smoke workflow runs on a stable runner."
+}

--- a/docs/perf/baselines/FixConflatedMarketDataPublisherBenchmarks.FlushNow-Symbols64.json
+++ b/docs/perf/baselines/FixConflatedMarketDataPublisherBenchmarks.FlushNow-Symbols64.json
@@ -1,0 +1,11 @@
+{
+  "benchmark": "FixConflatedMarketDataPublisherBenchmarks",
+  "method": "FlushNow",
+  "params": { "SymbolCount": 64, "UpdatesPerSymbol": 4 },
+  "captured_at": null,
+  "captured_on": "not yet captured on stable hardware",
+  "runtime": "net10.0 Release",
+  "metrics": {},
+  "tolerance": { "mean_pct": 20, "alloc_pct": 25 },
+  "notes": "Schema-only placeholder for the FIX Conflated sandbox conflation hot path (issue #103 item 5, best-effort): drains queued per-symbol book deltas, conflates them per (SecurityId, Side) bucket, and encodes+flushes one MarketDataIncrementalRefresh per bucket. No prose baseline number exists yet; metrics are omitted on purpose and will be populated once the perf-smoke workflow runs on a stable runner."
+}

--- a/docs/perf/baselines/README.md
+++ b/docs/perf/baselines/README.md
@@ -85,10 +85,13 @@ required-checks list.
 
 ## Why some files are schema-only
 
-`BookSideBenchmarks.*.json` and `MpscPacketRingBenchmarks.*.json` ship
-without populated `metrics`. The committed prose docs don't include a
-single defensible number for those benchmarks in isolation, so we'd
-rather commit a no-metric placeholder (which the comparer treats as
-"matched but nothing to gate on") than fabricate numbers that quietly
-drift. Populating those numbers is a follow-up to issue #19 and should
-happen the first time the perf-smoke workflow runs on a stable runner.
+`BookSideBenchmarks.*.json`, `MpscPacketRingBenchmarks.*.json`, and the
+`FixApplicationMessageWriterBenchmarks.*.json` /
+`FixConflatedMarketDataPublisherBenchmarks.*.json` pair ship without
+populated `metrics`. The committed prose docs don't include a single
+defensible number for those benchmarks in isolation, so we'd rather
+commit a no-metric placeholder (which the comparer treats as "matched
+but nothing to gate on") than fabricate numbers that quietly drift.
+Populating those numbers is a follow-up to issue #19 (and, for the FIX
+Conflated pair, issue #103 item 5) and should happen the first time the
+perf-smoke workflow runs on a stable runner.

--- a/tools/PerfBaselineCompare.Tests/ComparerTests.cs
+++ b/tools/PerfBaselineCompare.Tests/ComparerTests.cs
@@ -138,4 +138,25 @@ public class ComparerTests
         Assert.False(Comparer.ParamsMatch("MessageCount=10000, SymbolCount=512", want));
         Assert.False(Comparer.ParamsMatch("MessageCount=10000", want));
     }
+
+    [Fact]
+    public void ParamsMatch_SupportsAmpersandSeparator()
+    {
+        // BenchmarkDotNet 0.15.x (the version pinned in this repo) emits
+        // "Key=Value&Key2=Value2" with no spaces for multi-parameter rows,
+        // unlike the older comma-separated format covered above. Both must
+        // parse identically or every multi-[Params] baseline silently stops
+        // matching against real BDN output.
+        var parsed = Comparer.ParseBdnParams("MessageCount=10000&SymbolCount=64");
+        Assert.Equal("10000", parsed["MessageCount"]);
+        Assert.Equal("64", parsed["SymbolCount"]);
+
+        var want = new Dictionary<string, JsonElement>
+        {
+            ["MessageCount"] = JsonDocument.Parse("10000").RootElement.Clone(),
+            ["SymbolCount"] = JsonDocument.Parse("64").RootElement.Clone(),
+        };
+        Assert.True(Comparer.ParamsMatch("MessageCount=10000&SymbolCount=64", want));
+        Assert.False(Comparer.ParamsMatch("MessageCount=10000&SymbolCount=512", want));
+    }
 }

--- a/tools/PerfBaselineCompare/Comparer.cs
+++ b/tools/PerfBaselineCompare/Comparer.cs
@@ -153,7 +153,12 @@ public static class Comparer
     {
         var result = new Dictionary<string, string>(StringComparer.Ordinal);
         if (string.IsNullOrWhiteSpace(parameters)) return result;
-        foreach (var part in parameters.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+
+        // BenchmarkDotNet has used both "Key=Value, Key2=Value2" (older
+        // versions) and "Key=Value&Key2=Value2" (0.15.x, no spaces) for the
+        // multi-parameter "Parameters" summary string. Split on either
+        // separator so baselines keep matching regardless of BDN version.
+        foreach (var part in parameters.Split([',', '&'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             var eq = part.IndexOf('=');
             if (eq <= 0) continue;


### PR DESCRIPTION
## Summary
Adds the last remaining (best-effort/optional) item from #103: perf-smoke
benchmark coverage for the FIX Conflated sandbox encode/conflation hot path.

## Changes
- New `benchmarks/B3.Umdf.FixConflated.Benchmarks` project (BenchmarkDotNet),
  mirroring the existing Book/Feed benchmark suites:
  - `FixApplicationMessageWriterBenchmarks`: direct encode hot path
    (`WriteIncrementalRefresh` / `WriteSnapshotFullRefresh`), parameterized
    over entry count.
  - `FixConflatedMarketDataPublisherBenchmarks`: full conflate+encode hot
    path via `FlushNow()`, driven by realistic `OnOrderUpdated` deltas
    fanned out across many symbols/updates.
- Wired into the opt-in `.github/workflows/perf-smoke.yml` alongside the
  Book/Feed steps; registered in `B3MarketDataPlatform.slnx`.
- Schema-only baseline JSON placeholders under `docs/perf/baselines/`
  (no committed prose number exists yet to seed real thresholds from —
  same pattern already used for `BookSideBenchmarks`/`MpscPacketRingBenchmarks`).
- Updated `docs/FIX-CONFLATED-SANDBOX.md` to mark item 5 as done.

## Bugs fixed along the way (uncovered while validating end-to-end)
While wiring this up and actually running the workflow steps locally, found
that the existing perf-smoke plumbing for Book/Feed was silently broken:
- `--filter '*A*|*B*'` is not valid BenchmarkDotNet syntax — `|` is not an
  OR operator inside one glob; each alternative needs to be a **separate**
  `--filter` argument. Fixed all three filter invocations.
- `--exporters json` produces `*-report-full-compressed.json`, not
  `*-report-full.json`. The "Compare against baselines" step's glob never
  matched anything, so it always hit the `No BenchmarkDotNet ... files
  found` early exit — meaning the comparison step has likely never
  actually run since it was introduced. Fixed the glob for all three
  benchmark projects.
- `PerfBaselineCompare`'s `ParseBdnParams` only split on `,` (older BDN
  format), but the pinned BenchmarkDotNet 0.15.8 emits multi-`[Params]`
  rows as `Key=Value&Key2=Value2` (no comma). This silently broke param
  matching for any multi-parameter baseline (e.g.
  `BookManagerOnPacketBenchmarks`). Fixed to accept both separators, with
  a new regression test (`ParamsMatch_SupportsAmpersandSeparator`).

## Validation
- `dotnet build B3MarketDataPlatform.slnx -c Release` — clean.
- `dotnet test` for `B3.Umdf.FixConflated.Tests` (32/32) and
  `PerfBaselineCompare.Tests` (7/7, including the new regression test).
- Ran all three perf-smoke steps locally end-to-end (Book/Feed/FixConflated
  benchmarks + `PerfBaselineCompare`) against the real generated
  `*-report-full-compressed.json` files — all baselines now resolve
  (`PASS`/schema-only-match) instead of silently missing, exit code 0.

Closes #103.