### PR TITLE
Fix #124: emit SecurityStatus required spec fields

### DIFF
--- a/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityStatusMessageBuilder.cs
@@ -11,21 +11,34 @@ public static class SecurityStatusMessageBuilder
         ArgumentNullException.ThrowIfNull(definition);
         ArgumentNullException.ThrowIfNull(definition.Instrument);
 
+        DateTimeOffset sourceTimestamp =
+            FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds);
+
         var message = new FixMessage();
         message.Add(FixTags.MsgType, FixApplicationMsgTypes.SecurityStatus);
 
         FixApplicationMessageBuilderSupport.AppendInstrumentPrefix(message, definition.Instrument);
-
-        DateOnly tradeDate = definition.TradeDate
-            ?? DateOnly.FromDateTime(FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds).UtcDateTime);
-        message.Add(
-            FixApplicationTags.TransactTime,
-            FixValueFormatting.FormatUtcTimestamp(
-                FixApplicationMessageBuilderSupport.FromUnixNanoseconds(definition.SourceTimestampNanoseconds)));
-        message.Add(FixApplicationTags.TradeDate, FixApplicationMessageBuilderSupport.FormatLocalDate(tradeDate));
+        FixApplicationMessageBuilderSupport.AppendInstrumentSuffix(message, definition.Instrument);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityStatusReqId, definition.SecurityStatusReqId);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.TradingSessionId, definition.TradingSessionId);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.TradingSessionSubId, definition.TradingSessionSubId);
+        FixApplicationMessageBuilderSupport.AddOptionalBoolean(message, FixApplicationTags.UnsolicitedIndicator, definition.UnsolicitedIndicator);
+        FixApplicationMessageBuilderSupport.AddOptionalUnixNanosTimestamp(message, FixApplicationTags.TradSesOpenTime, definition.TradSesOpenTimeNanoseconds);
         FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.SecurityGroup, definition.Instrument.SecurityGroup);
+        message.Add(FixApplicationTags.SecurityTradingStatus, definition.SecurityTradingStatus);
+
+        DateOnly tradeDate = definition.TradeDate
+            ?? DateOnly.FromDateTime(sourceTimestamp.UtcDateTime);
+        message.Add(FixApplicationTags.TradeDate, FixApplicationMessageBuilderSupport.FormatLocalDate(tradeDate));
+        message.Add(FixApplicationTags.TransactTime, FixValueFormatting.FormatUtcTimestamp(sourceTimestamp));
+        FixApplicationMessageBuilderSupport.AddOptionalChar(message, FixApplicationTags.HaltReason, definition.HaltReason);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.BuyVolume, definition.BuyVolume);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.SellVolume, definition.SellVolume);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.HighPrice, definition.HighPrice);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LowPrice, definition.LowPrice);
+        FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.LastPx, definition.LastPrice);
+        FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Text, definition.Text);
+        FixApplicationMessageBuilderSupport.AddOptionalInt(message, FixApplicationTags.SecurityTradingEvent, definition.SecurityTradingEvent);
 
         return message;
     }

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityStatusMessageBuilderTests.cs
@@ -26,6 +26,17 @@ public sealed class SecurityStatusMessageBuilderTests
             },
             SecurityTradingStatus = 2,
             SourceTimestampNanoseconds = 1_786_544_116_789_000_000,
+            SecurityStatusReqId = "req-1",
+            UnsolicitedIndicator = true,
+            TradSesOpenTimeNanoseconds = 1_786_543_200_000_000_000,
+            SecurityTradingEvent = 4,
+            HaltReason = 'X',
+            BuyVolume = 1000.5m,
+            SellVolume = 2000.25m,
+            HighPrice = 32.15m,
+            LowPrice = 30.05m,
+            LastPrice = 31.55m,
+            Text = "Trading resumed",
             TradingSessionId = "1",
             TradingSessionSubId = "18"
         });
@@ -33,14 +44,29 @@ public sealed class SecurityStatusMessageBuilderTests
         Assert.Equal(FixApplicationMsgTypes.SecurityStatus, FixApplicationMessageTestHelpers.GetRequired(message, FixTags.MsgType));
         Assert.Equal("PETR4", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Symbol));
         Assert.Equal("12345", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityId));
+        Assert.Equal("99", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.InstrumentId));
+        Assert.Equal("4", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Product));
+        Assert.Equal("ESVUFR", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.CfiCode));
         Assert.Equal("20260812", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradeDate));
         Assert.Equal("20260812-14:15:16.789", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TransactTime));
+        Assert.Equal("req-1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityStatusReqId));
         Assert.Equal("1", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradingSessionId));
         Assert.Equal("18", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradingSessionSubId));
+        Assert.Equal("Y", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.UnsolicitedIndicator));
+        Assert.Equal("20260812-14:00:00.000", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.TradSesOpenTime));
         Assert.Equal("EQUITY", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityGroup));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingStatus));
+        Assert.Equal("X", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.HaltReason));
+        Assert.Equal("1000.5", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.BuyVolume));
+        Assert.Equal("2000.25", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SellVolume));
+        Assert.Equal("32.15", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.HighPrice));
+        Assert.Equal("30.05", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.LowPrice));
+        Assert.Equal("31.55", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.LastPx));
+        Assert.Equal("Trading resumed", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.Text));
+        Assert.Equal("4", FixApplicationMessageTestHelpers.GetRequired(message, FixApplicationTags.SecurityTradingEvent));
 
         FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
-        Assert.False(decoded.TryGetString(FixApplicationTags.SecurityTradingStatus, out _));
-        Assert.False(decoded.TryGetString(FixApplicationTags.Text, out _));
+        Assert.Equal("2", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.SecurityTradingStatus));
+        Assert.Equal("Trading resumed", FixApplicationMessageTestHelpers.GetRequired(decoded, FixApplicationTags.Text));
     }
 }


### PR DESCRIPTION
## Summary
- emit all populated SecurityStatus fields supported by the current DTO and FIX44 UMDF Conflated spec, including SecurityTradingStatus (326)
- preserve optional-field behavior by only writing optional tags when values are present
- update SecurityStatus builder tests to validate the newly emitted tags

## Testing
- dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj --filter SecurityStatusMessageBuilderTests

Fixes #124