### PR TITLE
Fix #126: correct TickSizeDenominator FIX tag

### DIFF
--- a/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessages.cs
@@ -76,6 +76,7 @@ public sealed record FixSecurityListEntry
     public string? Asset { get; init; }
     public decimal? MinPriceIncrement { get; init; }
     public decimal? TickSizeDenominator { get; init; }
+    public decimal? MinOrderQty { get; init; }
 }
 
 public sealed record FixSecurityListDefinition
@@ -235,7 +236,8 @@ internal static class FixApplicationTags
     public const int SecurityUpdatesSince = 6935;
     public const int Language = 6936;
     public const int Asset = 6937;
-    public const int TickSizeDenominator = 9749;
+    public const int TickSizeDenominator = 5151;
+    public const int MinOrderQty = 9749;
     public const int NewsSource = 6940;
     public const int InstrumentId = 9219;
     public const int NoSecurityGroups = 37022;

--- a/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/SecurityListMessageBuilder.cs
@@ -47,6 +47,7 @@ public static class SecurityListMessageBuilder
                 FixApplicationMessageBuilderSupport.AddOptionalString(message, FixApplicationTags.Asset, security.Asset);
                 FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.MinPriceIncrement, security.MinPriceIncrement);
                 FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.TickSizeDenominator, security.TickSizeDenominator);
+                FixApplicationMessageBuilderSupport.AddOptionalDecimal(message, FixApplicationTags.MinOrderQty, security.MinOrderQty);
             }
         }
 

--- a/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/SecurityListMessageBuilderTests.cs
@@ -62,6 +62,7 @@ public sealed class SecurityListMessageBuilderTests
                     Asset = "PETR",
                     MinPriceIncrement = 0.01m,
                     TickSizeDenominator = 1m,
+                    MinOrderQty = 100m,
                     MarketDataFeeds =
                     [
                         new FixMarketDataFeed("BOOK", 10, 1),
@@ -89,6 +90,7 @@ public sealed class SecurityListMessageBuilderTests
                     Asset = "VALE",
                     MinPriceIncrement = 0.01m,
                     TickSizeDenominator = 1m,
+                    MinOrderQty = 200m,
                     MarketDataFeeds =
                     [
                         new FixMarketDataFeed("BOOK", 10, 1)
@@ -104,6 +106,8 @@ public sealed class SecurityListMessageBuilderTests
         Assert.Equal(["PETR4", "VALE3"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.Symbol));
         Assert.Equal(["2", "1"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.NoMdFeedTypes));
         Assert.Equal(["BOOK", "TRADES", "BOOK"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.MdFeedType));
+        Assert.Equal(["1", "1"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.TickSizeDenominator));
+        Assert.Equal(["100", "200"], FixApplicationMessageTestHelpers.GetAllValues(message, FixApplicationTags.MinOrderQty));
 
         FixMessage decoded = FixApplicationMessageTestHelpers.RoundTrip(message);
         Assert.Equal(["10", "1", "10"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.MarketDepth));
@@ -111,5 +115,7 @@ public sealed class SecurityListMessageBuilderTests
         Assert.Equal(["BRL", "BRL"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.Currency));
         Assert.Equal(["0", "0"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.SettlType));
         Assert.Equal(["BRL", "BRL"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.SettlCurrency));
+        Assert.Equal(["1", "1"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.TickSizeDenominator));
+        Assert.Equal(["100", "200"], FixApplicationMessageTestHelpers.GetAllValues(decoded, FixApplicationTags.MinOrderQty));
     }
 }


### PR DESCRIPTION
## Summary
- fix FIX tag mapping for TickSizeDenominator from 9749 to 5151
- preserve MinOrderQty as its own optional SecurityList field on tag 9749
- add SecurityList builder assertions covering both tags

Fixes #126

## Testing
- dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj --filter SecurityListMessageBuilderTests