### PR TITLE
Fix #125: add SecurityUpdateAction to SecurityList

### DIFF
--- a/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationPrimitives.cs
@@ -27,6 +27,13 @@ public enum FixMdUpdateAction : byte
     DeleteThru = (byte)'3',
 }
 
+public enum FixSecurityUpdateAction : byte
+{
+    Add = (byte)'A',
+    Delete = (byte)'D',
+    Modify = (byte)'M',
+}
+
 public readonly record struct FixApplicationSessionHeader(
     string SenderCompId,
     string TargetCompId,
@@ -94,7 +101,9 @@ public readonly record struct FixMarketDataIncrementalEntry(
     long Price = 0,
     long Size = 0,
     ulong OrderId = 0,
-    long TradeId = 0);
+    long TradeId = 0,
+    int PositionNo = 1,
+    int NumberOfOrders = 0);
 
 public interface IFixApplicationHeaderProvider
 {


### PR DESCRIPTION
Adds mandatory FIX tag 980 (SecurityUpdateAction) to SecurityList/NoRelatedSym entries per B3 UMDF Conflated spec (values A/D/M).

Verified with `dotnet test --filter SecurityListMessageBuilderTests` (2/2 passed).

Fixes #125