### PR TITLE
Fix #127: correct snapshot TotNumReports

### DIFF
--- a/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
+++ b/src/B3.Umdf.FixConflated/FixApplicationMessageWriter.cs
@@ -165,7 +165,7 @@ public sealed class FixApplicationMessageWriter : IDisposable
         offset += WriteStringField(destination[offset..], FixTags.MDReqId, request.MdReqId);
         offset += WriteStringField(destination[offset..], FixTags.Symbol, request.Instrument.Symbol);
         offset += WriteUInt64Field(destination[offset..], FixTags.SecurityId, request.Instrument.SecurityId);
-        offset += WriteIntField(destination[offset..], FixTags.TotNumReports, entryCount);
+        offset += WriteIntField(destination[offset..], FixTags.TotNumReports, 1);
         offset += WriteIntField(destination[offset..], FixTags.NoMDEntries, entryCount);
 
         offset += WriteSnapshotSide(destination[offset..], book.Bids, FixMdEntryType.Bid, request.Instrument.PriceScale, header.SendingTime);
@@ -181,8 +181,10 @@ public sealed class FixApplicationMessageWriter : IDisposable
         DateTimeOffset entryTime)
     {
         int offset = 0;
+        int positionNo = 1;
         foreach (var (_, orders) in side.PriceLevels)
         {
+            int numberOfOrders = orders.Count;
             foreach (var order in orders)
             {
                 offset += WriteCharField(destination[offset..], FixTags.MDEntryType, (char)entryType);
@@ -192,9 +194,12 @@ public sealed class FixApplicationMessageWriter : IDisposable
                 offset += WriteUtcTimeField(destination[offset..], FixTags.MDEntryTime, entryTime);
                 offset += WriteUtcDateField(destination[offset..], FixTags.MDInsertDate, entryTime);
                 offset += WriteUtcTimeField(destination[offset..], FixTags.MDInsertTime, entryTime);
-                offset += WriteIntField(destination[offset..], FixTags.MDEntryPositionNo, 1);
+                offset += WriteIntField(destination[offset..], FixTags.MDEntryPositionNo, positionNo);
+                offset += WriteIntField(destination[offset..], FixTags.NumberOfOrders, numberOfOrders);
                 offset += WriteUInt64Field(destination[offset..], FixTags.OrderId, order.OrderId);
             }
+
+            positionNo++;
         }
 
         return offset;

--- a/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
+++ b/src/B3.Umdf.FixConflated/FixSnapshotMessageBuilder.cs
@@ -20,7 +20,7 @@ internal static class FixSnapshotMessageBuilder
         message.Add(FixTags.SecurityId, request.Instrument.SecurityId.ToString(CultureInfo.InvariantCulture));
 
         int entryCount = book.Bids.OrderCount + book.Asks.OrderCount;
-        message.Add(FixTags.TotNumReports, entryCount);
+        message.Add(FixTags.TotNumReports, 1);
         message.Add(FixTags.NoMDEntries, entryCount);
 
         string entryDate = entryTime.UtcDateTime.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
@@ -38,8 +38,10 @@ internal static class FixSnapshotMessageBuilder
         string entryDate,
         string entryTime)
     {
+        int positionNo = 1;
         foreach (KeyValuePair<long, List<OrderBookEntry>> level in side.PriceLevels)
         {
+            int numberOfOrders = level.Value.Count;
             foreach (OrderBookEntry order in level.Value)
             {
                 message.Add(FixTags.MDEntryType, ((char)entryType).ToString());
@@ -49,9 +51,12 @@ internal static class FixSnapshotMessageBuilder
                 message.Add(FixTags.MDEntryTime, entryTime);
                 message.Add(FixTags.MDInsertDate, entryDate);
                 message.Add(FixTags.MDInsertTime, entryTime);
-                message.Add(FixTags.MDEntryPositionNo, 1);
+                message.Add(FixTags.MDEntryPositionNo, positionNo);
+                message.Add(FixTags.NumberOfOrders, numberOfOrders);
                 message.Add(FixTags.OrderId, order.OrderId.ToString(CultureInfo.InvariantCulture));
             }
+
+            positionNo++;
         }
     }
 

--- a/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixApplicationMessageWriterTests.cs
@@ -95,7 +95,7 @@ public sealed class FixApplicationMessageWriterTests
         Assert.Equal("BVMF", GetRequired(decoded, FixTags.SecurityExchange));
         Assert.Equal("LUX00", GetRequired(decoded, FixTags.DeliverToCompID));
         Assert.Equal("4", GetRequired(decoded, FixTags.NoMDEntries));
-        Assert.Equal("4", GetRequired(decoded, FixTags.TotNumReports));
+        Assert.Equal("1", GetRequired(decoded, FixTags.TotNumReports));
 
         IReadOnlyList<IReadOnlyDictionary<int, string>> entries = ParseSnapshotEntries(decoded);
         Assert.Equal(4, entries.Count);
@@ -106,6 +106,33 @@ public sealed class FixApplicationMessageWriterTests
         Assert.Equal("1", entries[2][FixTags.MDEntryType]);
         Assert.Equal("28.12", entries[2][FixTags.MDEntryPx]);
         Assert.Equal("3", entries[2][FixTags.OrderId]);
+    }
+
+    [Fact]
+    public void SnapshotFullRefresh_Uses_Single_Report_Count_Even_When_Book_Has_Many_Entries()
+    {
+        using var writer = new FixApplicationMessageWriter();
+        var header = new FixApplicationSessionHeader(
+            "SERVER",
+            "CLIENT",
+            12,
+            new DateTimeOffset(2026, 8, 12, 19, 16, 00, TimeSpan.Zero));
+        var request = new FixMarketDataSnapshotRequest(
+            "snap-2",
+            new FixMarketDataInstrument("VALE3", 4321, priceScale: 2));
+        OrderBook book = CreateBook(
+            (1UL, BookSideType.Bid, 5000L, 100L),
+            (2UL, BookSideType.Bid, 4999L, 100L),
+            (3UL, BookSideType.Bid, 4998L, 100L),
+            (4UL, BookSideType.Ask, 5001L, 100L),
+            (5UL, BookSideType.Ask, 5002L, 100L),
+            (6UL, BookSideType.Ask, 5003L, 100L));
+
+        ReadOnlyMemory<byte> frame = writer.WriteSnapshotFullRefresh(header, request, book);
+
+        FixMessage decoded = Decode(frame);
+        Assert.Equal("6", GetRequired(decoded, FixTags.NoMDEntries));
+        Assert.Equal("1", GetRequired(decoded, FixTags.TotNumReports));
     }
 
     private static OrderBook CreateBook(params (ulong OrderId, BookSideType Side, long Price, long Quantity)[] orders)


### PR DESCRIPTION
SecurityStatus/MarketDataSnapshotFullRefresh (W) is emitted as exactly one physical FIX message per snapshot request — there is no fragmentation/893=LastFragment handling for snapshots. Therefore 911=TotNumReports must be 1, while 268=NoMDEntries continues to report the actual book entry count.

Verified with `dotnet test --filter FixApplicationMessageWriterTests` (3/3 passed).

Fixes #127