### PR TITLE
Fix #134 stabilize flaky SecurityId rejection test

### DIFF
--- a/src/B3.Umdf.FixConflated/FixConflatedTcpServer.cs
+++ b/src/B3.Umdf.FixConflated/FixConflatedTcpServer.cs
@@ -43,7 +43,7 @@ public sealed class FixConflatedTcpServer : IAsyncDisposable
 
     public Task StartAsync(int port, CancellationToken cancellationToken = default)
     {
-        if (port is < 1 or > 65535)
+        if (port is < 0 or > 65535)
             throw new ArgumentOutOfRangeException(nameof(port));
         if (_listener is not null)
             throw new InvalidOperationException("FIX conflated TCP server already started.");

--- a/tests/B3.Umdf.FixConflated.Tests/FixSubscriptionTests.cs
+++ b/tests/B3.Umdf.FixConflated.Tests/FixSubscriptionTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Umdf.FixConflated.Tests;
 
+[Collection(nameof(AllocationSensitiveCollection))]
 public sealed class FixSubscriptionTests
 {
     [Fact]
@@ -165,9 +166,9 @@ public sealed class FixSubscriptionTests
             var snapshotProvider = new FixInitialSnapshotProvider([bookManager], resolver);
             var requestHandler = new FixMarketDataRequestHandler(snapshotProvider, resolver);
             var hub = new FixConflatedSessionHub();
-            int port = GetFreeTcpPort();
             var server = new FixConflatedTcpServer(hub, new FixConflatedTcpServerOptions { OutboundQueueCapacity = 64 }, null, requestHandler);
-            await server.StartAsync(port);
+            await server.StartAsync(0);
+            int port = server.Port;
 
             var tcpClientA = new TcpClient { NoDelay = true };
             await tcpClientA.ConnectAsync(IPAddress.Loopback, port);
@@ -202,14 +203,6 @@ public sealed class FixSubscriptionTests
             TcpClientA.Dispose();
             TcpClientB.Dispose();
             await Server.DisposeAsync();
-        }
-
-        private static int GetFreeTcpPort()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
-            finally { listener.Stop(); }
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the test harness TOCTOU race by letting the FIX TCP server bind to an OS-assigned ephemeral port
- run `FixSubscriptionTests` in the non-parallel allocation-sensitive collection to avoid socket contention with other network-heavy FIX tests
- keep the unknown SecurityID rejection assertion unchanged while making the harness deterministic

## Root cause
`SubscriptionHarness` preselected a "free" TCP port by briefly binding a `TcpListener`, closing it, and then starting `FixConflatedTcpServer` on that same port. Under CI load and test parallelism, another socket/test could claim the port in the gap between those two steps, making the network harness flaky even though the rejection logic itself was correct.

## Validation
- `dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj --filter FullyQualifiedName~Unknown_SecurityId_Is_Rejected --no-restore` x30
- `dotnet test tests/B3.Umdf.FixConflated.Tests/B3.Umdf.FixConflated.Tests.csproj --no-restore -v minimal`

Fixes #134
